### PR TITLE
.github/workflows: always run workflows

### DIFF
--- a/.github/workflows/aptos-contracts.yml
+++ b/.github/workflows/aptos-contracts.yml
@@ -8,21 +8,9 @@ on:
   pull_request:
 
 jobs:
-  detect-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      found: ${{ steps.c.outputs.found }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/changes
-        id: c
-        with:
-          folder: aptos
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
-    needs: [detect-changes]
-    if: needs.detect-changes.outputs.found == 'true'
     steps:
     - name: Check out code
       uses: actions/checkout@v4

--- a/.github/workflows/aptos-movefmt.yml
+++ b/.github/workflows/aptos-movefmt.yml
@@ -2,20 +2,8 @@ name: Aptos - Lint Move formatting
 # This workflow checks that all move packages are correctly formatting using movefmt
 on: [pull_request]
 jobs:
-  detect-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      found: ${{ steps.c.outputs.found }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/changes
-        id: c
-        with:
-          folder: aptos
   movefmt:
     runs-on: ubuntu-latest
-    needs: [detect-changes]
-    if: needs.detect-changes.outputs.found == 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Install Aptos CLI

--- a/.github/workflows/aptos-relayer.yml
+++ b/.github/workflows/aptos-relayer.yml
@@ -15,10 +15,16 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
 
-    - name: Install Nix
-      uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+    - name: Extract Go version
+      uses: ./.github/actions/check-go-version
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
       with:
-        nix_path: nixpkgs=channel:nixos-unstable
+        go-version: ${{ env.go_version }}
+
+    - name: Install Aptos CLI
+      uses: aptos-labs/actions/install-aptos-cli@ce57287eb852b9819c1d74fecc3be187677559fd # v0.1
 
     - name: Run tests
-      run: cd relayer && nix develop -c go test -v -count=1 -p=1 -tags=integration ./...
+      run: cd relayer && go test -v -count=1 -p=1 -tags=integration ./...

--- a/.github/workflows/aptos-relayer.yml
+++ b/.github/workflows/aptos-relayer.yml
@@ -8,22 +8,9 @@ on:
   pull_request:
 
 jobs:
-  detect-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      found: ${{ steps.c.outputs.found }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/changes
-        id: c
-        with:
-          folder: aptos
-
   test:
     name: Integration Tests
     runs-on: ubuntu-latest
-    needs: [detect-changes]
-    if: needs.detect-changes.outputs.found == 'true'
     steps:
     - name: Check out code
       uses: actions/checkout@v4

--- a/.github/workflows/aptos-run-smoke-tests.yml
+++ b/.github/workflows/aptos-run-smoke-tests.yml
@@ -13,20 +13,7 @@ env:
   CL_ECR: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink
 
 jobs:
-  detect-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      found: ${{ steps.c.outputs.found }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/changes
-        id: c
-        with:
-          folder: aptos
-
   run-tests:
-    needs: [detect-changes]
-    if: needs.detect-changes.outputs.found == 'true'
     environment: integration
     permissions:
       id-token: write


### PR DESCRIPTION
- fix running workflows, which were looking for changes in aptos/
- use go directly in relayer integration test instead of nix, 10 mins -> 7 mins