### PR TITLE
Add package-level interfaces for bindings

### DIFF
--- a/bindings/bind/common.go
+++ b/bindings/bind/common.go
@@ -33,35 +33,46 @@ type TransactOpts struct {
 	SequenceNumber    *uint64
 }
 
-type BoundContract struct {
-	address aptos.AccountAddress
-	module  string
-	client  aptos.AptosRpcClient
+type ModuleInformation struct {
+	PackageName string
+	ModuleName  string
+	Address     aptos.AccountAddress
 }
 
-func NewBoundContract(address aptos.AccountAddress, module string, client aptos.AptosRpcClient) *BoundContract {
+type BoundContract struct {
+	address                 aptos.AccountAddress
+	packageName, moduleName string
+	client                  aptos.AptosRpcClient
+}
+
+func NewBoundContract(address aptos.AccountAddress, packageName, moduleName string, client aptos.AptosRpcClient) *BoundContract {
 	return &BoundContract{
-		address: address,
-		module:  module,
-		client:  client,
+		address:     address,
+		packageName: packageName,
+		moduleName:  moduleName,
+		client:      client,
 	}
 }
 
-func (c *BoundContract) Encode(function string, typeArgs, paramTypes []string, paramValues []any) (module aptos.ModuleId, fun string, argTypes []aptos.TypeTag, args [][]byte, err error) {
+func (c *BoundContract) Encode(function string, typeArgs, paramTypes []string, paramValues []any) (moduleInfo ModuleInformation, fun string, argTypes []aptos.TypeTag, args [][]byte, err error) {
 	typeTags, args, err := serializeArgs(typeArgs, paramTypes, paramValues)
 	if err != nil {
-		return aptos.ModuleId{}, "", nil, nil, err
+		return ModuleInformation{}, "", nil, nil, err
 	}
 
-	return aptos.ModuleId{
-		Address: c.address,
-		Name:    c.module,
+	return ModuleInformation{
+		PackageName: c.moduleName,
+		ModuleName:  c.moduleName,
+		Address:     c.address,
 	}, function, typeTags, args, nil
 }
 
-func (c *BoundContract) Call(opts *CallOpts, module aptos.ModuleId, function string, argTypes []aptos.TypeTag, args [][]byte) ([]any, error) {
+func (c *BoundContract) Call(opts *CallOpts, module ModuleInformation, function string, argTypes []aptos.TypeTag, args [][]byte) ([]any, error) {
 	payload := aptos.ViewPayload{
-		Module:   module,
+		Module: aptos.ModuleId{
+			Address: module.Address,
+			Name:    module.ModuleName,
+		},
 		Function: function,
 		ArgTypes: argTypes,
 		Args:     args,
@@ -76,9 +87,12 @@ func (c *BoundContract) Call(opts *CallOpts, module aptos.ModuleId, function str
 	return c.client.View(&payload, ledgerVersion...)
 }
 
-func (c *BoundContract) Transact(opts *TransactOpts, module aptos.ModuleId, function string, argTypes []aptos.TypeTag, args [][]byte) (*api.PendingTransaction, error) {
+func (c *BoundContract) Transact(opts *TransactOpts, module ModuleInformation, function string, argTypes []aptos.TypeTag, args [][]byte) (*api.PendingTransaction, error) {
 	payload := aptos.TransactionPayload{Payload: &aptos.EntryFunction{
-		Module:   module,
+		Module: aptos.ModuleId{
+			Address: module.Address,
+			Name:    module.ModuleName,
+		},
 		Function: function,
 		ArgTypes: argTypes,
 		Args:     args,

--- a/bindings/bind/common.go
+++ b/bindings/bind/common.go
@@ -61,7 +61,7 @@ func (c *BoundContract) Encode(function string, typeArgs, paramTypes []string, p
 	}
 
 	return ModuleInformation{
-		PackageName: c.moduleName,
+		PackageName: c.packageName,
 		ModuleName:  c.moduleName,
 		Address:     c.address,
 	}, function, typeTags, args, nil

--- a/bindings/bind/large_packages.go
+++ b/bindings/bind/large_packages.go
@@ -43,7 +43,7 @@ func DeployOrBindLargePackages(
 		if err := predeployedAddress.ParseStringRelaxed(LargePackagesModuleAddress); err != nil {
 			return aptos.AccountAddress{}, nil, LargePackages{}, err
 		}
-		largePackagesContract := NewBoundContract(predeployedAddress, "large_packages", client)
+		largePackagesContract := NewBoundContract(predeployedAddress, "large_packages", "large_packages", client)
 		return predeployedAddress, nil, LargePackages{Address: predeployedAddress, LargePackagesTransactor: LargePackagesTransactor{BoundContract: largePackagesContract}}, nil
 	default:
 		return DeployLargePackages(auth, client)
@@ -70,7 +70,7 @@ func DeployLargePackages(
 		return aptos.AccountAddress{}, nil, LargePackages{}, err
 	}
 
-	largePackagesContract := NewBoundContract(address, "large_packages", client)
+	largePackagesContract := NewBoundContract(address, "large_packages", "large_packages", client)
 	return address, tx, LargePackages{Address: address, LargePackagesTransactor: LargePackagesTransactor{BoundContract: largePackagesContract}}, nil
 }
 

--- a/bindings/ccip/auth/auth.go
+++ b/bindings/ccip/auth/auth.go
@@ -28,9 +28,28 @@ type Auth interface {
 	AcceptOwnership(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 	ExecuteOwnershipTransfer(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
 	AssertIsRouter(opts *bind.TransactOpts, caller aptos.AccountAddress) (*api.PendingTransaction, error)
+
+	EncodeCall() AuthEncoder
+}
+
+type AuthEncoder interface {
+	Owner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ExecuteOwnershipTransfer(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AssertIsRouter(caller aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AssertOnlyOwner(caller aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
 const FunctionInfo = `[{"package":"ccip","module":"auth","name":"accept_ownership","parameters":null},{"package":"ccip","module":"auth","name":"assert_is_router","parameters":[{"name":"caller","type":"address"}]},{"package":"ccip","module":"auth","name":"assert_only_owner","parameters":[{"name":"caller","type":"address"}]},{"package":"ccip","module":"auth","name":"execute_ownership_transfer","parameters":[{"name":"to","type":"address"}]},{"package":"ccip","module":"auth","name":"transfer_ownership","parameters":[{"name":"to","type":"address"}]}]`
+
+func NewAuth(address aptos.AccountAddress, client aptos.AptosRpcClient) Auth {
+	contract := bind.NewBoundContract(address, "ccip", "auth", client)
+	return AuthContract{
+		BoundContract: contract,
+		authEncoder:   authEncoder{BoundContract: contract},
+	}
+}
 
 // Structs
 
@@ -42,22 +61,20 @@ type PendingRouterSignerCapability struct {
 }
 
 type AuthContract struct {
-	AuthCaller
-	AuthTransactor
+	*bind.BoundContract
+	authEncoder
+}
+
+var _ Auth = AuthContract{}
+
+func (c AuthContract) EncodeCall() AuthEncoder {
+	return c.authEncoder
 }
 
 // View Functions
 
-type AuthCaller struct {
-	*bind.BoundContract
-}
-
-func (c AuthCaller) EncodeOwner() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("owner", nil, []string{}, []any{})
-}
-
-func (c AuthCaller) Owner(opts *bind.CallOpts) (aptos.AccountAddress, error) {
-	module, function, typeTags, args, err := c.EncodeOwner()
+func (c AuthContract) Owner(opts *bind.CallOpts) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.authEncoder.Owner()
 	if err != nil {
 		return *new(aptos.AccountAddress), err
 	}
@@ -79,11 +96,52 @@ func (c AuthCaller) Owner(opts *bind.CallOpts) (aptos.AccountAddress, error) {
 
 // Entry Functions
 
-type AuthTransactor struct {
+func (c AuthContract) TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.authEncoder.TransferOwnership(to)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c AuthContract) AcceptOwnership(opts *bind.TransactOpts) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.authEncoder.AcceptOwnership()
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c AuthContract) ExecuteOwnershipTransfer(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.authEncoder.ExecuteOwnershipTransfer(to)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c AuthContract) AssertIsRouter(opts *bind.TransactOpts, caller aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.authEncoder.AssertIsRouter(caller)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+// Encoder
+type authEncoder struct {
 	*bind.BoundContract
 }
 
-func (c AuthTransactor) EncodeTransferOwnership(to aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c authEncoder) Owner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("owner", nil, []string{}, []any{})
+}
+
+func (c authEncoder) TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("transfer_ownership", nil, []string{
 		"address",
 	}, []any{
@@ -91,29 +149,11 @@ func (c AuthTransactor) EncodeTransferOwnership(to aptos.AccountAddress) (aptos.
 	})
 }
 
-func (c AuthTransactor) TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeTransferOwnership(to)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c AuthTransactor) EncodeAcceptOwnership() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c authEncoder) AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("accept_ownership", nil, []string{}, []any{})
 }
 
-func (c AuthTransactor) AcceptOwnership(opts *bind.TransactOpts) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeAcceptOwnership()
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c AuthTransactor) EncodeExecuteOwnershipTransfer(to aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c authEncoder) ExecuteOwnershipTransfer(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("execute_ownership_transfer", nil, []string{
 		"address",
 	}, []any{
@@ -121,16 +161,7 @@ func (c AuthTransactor) EncodeExecuteOwnershipTransfer(to aptos.AccountAddress) 
 	})
 }
 
-func (c AuthTransactor) ExecuteOwnershipTransfer(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeExecuteOwnershipTransfer(to)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c AuthTransactor) EncodeAssertIsRouter(caller aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c authEncoder) AssertIsRouter(caller aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("assert_is_router", nil, []string{
 		"address",
 	}, []any{
@@ -138,18 +169,7 @@ func (c AuthTransactor) EncodeAssertIsRouter(caller aptos.AccountAddress) (aptos
 	})
 }
 
-func (c AuthTransactor) AssertIsRouter(opts *bind.TransactOpts, caller aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeAssertIsRouter(caller)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-// Other Functions
-
-func (c AuthCaller) EncodeAssertOnlyOwner(caller aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c authEncoder) AssertOnlyOwner(caller aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("assert_only_owner", nil, []string{
 		"address",
 	}, []any{

--- a/bindings/ccip/auth/auth.go
+++ b/bindings/ccip/auth/auth.go
@@ -29,7 +29,7 @@ type Auth interface {
 	ExecuteOwnershipTransfer(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
 	AssertIsRouter(opts *bind.TransactOpts, caller aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	_Encode() AuthEncoder
+	Encode_() AuthEncoder
 }
 
 type AuthEncoder interface {
@@ -67,7 +67,7 @@ type AuthContract struct {
 
 var _ Auth = AuthContract{}
 
-func (c AuthContract) _Encode() AuthEncoder {
+func (c AuthContract) Encode_() AuthEncoder {
 	return c.authEncoder
 }
 

--- a/bindings/ccip/auth/auth.go
+++ b/bindings/ccip/auth/auth.go
@@ -29,7 +29,7 @@ type Auth interface {
 	ExecuteOwnershipTransfer(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
 	AssertIsRouter(opts *bind.TransactOpts, caller aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	EncodeCall() AuthEncoder
+	_Encode() AuthEncoder
 }
 
 type AuthEncoder interface {
@@ -67,7 +67,7 @@ type AuthContract struct {
 
 var _ Auth = AuthContract{}
 
-func (c AuthContract) EncodeCall() AuthEncoder {
+func (c AuthContract) _Encode() AuthEncoder {
 	return c.authEncoder
 }
 

--- a/bindings/ccip/auth/auth.go
+++ b/bindings/ccip/auth/auth.go
@@ -29,7 +29,8 @@ type Auth interface {
 	ExecuteOwnershipTransfer(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
 	AssertIsRouter(opts *bind.TransactOpts, caller aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	Encode_() AuthEncoder
+	// Encode returns the encoder implementation of this module.
+	Encoder() AuthEncoder
 }
 
 type AuthEncoder interface {
@@ -67,7 +68,7 @@ type AuthContract struct {
 
 var _ Auth = AuthContract{}
 
-func (c AuthContract) Encode_() AuthEncoder {
+func (c AuthContract) Encoder() AuthEncoder {
 	return c.authEncoder
 }
 

--- a/bindings/ccip/auth/auth.go
+++ b/bindings/ccip/auth/auth.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type AuthInterface interface {
+type Auth interface {
 	Owner(opts *bind.CallOpts) (aptos.AccountAddress, error)
 
 	TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
@@ -41,7 +41,7 @@ type AuthState struct {
 type PendingRouterSignerCapability struct {
 }
 
-type Auth struct {
+type AuthContract struct {
 	AuthCaller
 	AuthTransactor
 }

--- a/bindings/ccip/auth/auth.go
+++ b/bindings/ccip/auth/auth.go
@@ -29,7 +29,7 @@ type Auth interface {
 	ExecuteOwnershipTransfer(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
 	AssertIsRouter(opts *bind.TransactOpts, caller aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	// Encode returns the encoder implementation of this module.
+	// Encoder returns the encoder implementation of this module.
 	Encoder() AuthEncoder
 }
 

--- a/bindings/ccip/ccip.go
+++ b/bindings/ccip/ccip.go
@@ -15,16 +15,62 @@ import (
 	"github.com/smartcontractkit/chainlink-aptos/bindings/compile"
 )
 
-type CCIP struct {
-	Address aptos.AccountAddress
+type CCIP interface {
+	Address() aptos.AccountAddress
 
-	Auth               module_auth.Auth
-	FeeQuoter          module_fee_quoter.FeeQuoter
-	Offramp            module_offramp.Offramp
-	Onramp             module_onramp.Onramp
-	ReceiverRegistry   module_receiver_registry.ReceiverRegistry
-	RMNRemote          module_rmn_remote.RMNRemote
-	TokenAdminRegistry module_token_admin_registry.TokenAdminRegistry
+	Auth() module_auth.Auth
+	FeeQuoter() module_fee_quoter.FeeQuoter
+	Offramp() module_offramp.Offramp
+	Onramp() module_onramp.Onramp
+	ReceiverRegistry() module_receiver_registry.ReceiverRegistry
+	RMNRemote() module_rmn_remote.RMNRemote
+	TokenAdminRegistry() module_token_admin_registry.TokenAdminRegistry
+}
+
+var _ CCIP = CCIPContract{}
+
+type CCIPContract struct {
+	address aptos.AccountAddress
+
+	auth               module_auth.Auth
+	feeQuoter          module_fee_quoter.FeeQuoter
+	offramp            module_offramp.Offramp
+	onramp             module_onramp.Onramp
+	receiverRegistry   module_receiver_registry.ReceiverRegistry
+	rmnRemote          module_rmn_remote.RMNRemote
+	tokenAdminRegistry module_token_admin_registry.TokenAdminRegistry
+}
+
+func (C CCIPContract) Address() aptos.AccountAddress {
+	return C.address
+}
+
+func (C CCIPContract) Auth() module_auth.Auth {
+	return C.auth
+}
+
+func (C CCIPContract) FeeQuoter() module_fee_quoter.FeeQuoter {
+	return C.feeQuoter
+}
+
+func (C CCIPContract) Offramp() module_offramp.Offramp {
+	return C.offramp
+}
+
+func (C CCIPContract) Onramp() module_onramp.Onramp {
+	return C.onramp
+}
+
+func (C CCIPContract) ReceiverRegistry() module_receiver_registry.ReceiverRegistry {
+	return C.receiverRegistry
+}
+
+func (C CCIPContract) RMNRemote() module_rmn_remote.RMNRemote {
+	return C.rmnRemote
+}
+
+func (C CCIPContract) TokenAdminRegistry() module_token_admin_registry.TokenAdminRegistry {
+	return C.tokenAdminRegistry
 }
 
 const (
@@ -62,33 +108,33 @@ func Bind(address aptos.AccountAddress, client aptos.AptosRpcClient) CCIP {
 	receiverRegistryContract := bind.NewBoundContract(address, "receiver_registry", client)
 	rmnRemoteContract := bind.NewBoundContract(address, "rmn_remote", client)
 	tokenAdminRegistryContract := bind.NewBoundContract(address, "token_admin_registry", client)
-	return CCIP{
-		Address: address,
-		Auth: module_auth.Auth{
+	return CCIPContract{
+		address: address,
+		auth: module_auth.AuthContract{
 			AuthCaller:     module_auth.AuthCaller{BoundContract: authContract},
 			AuthTransactor: module_auth.AuthTransactor{BoundContract: authContract},
 		},
-		FeeQuoter: module_fee_quoter.FeeQuoter{
+		feeQuoter: module_fee_quoter.FeeQuoterContract{
 			FeeQuoterCaller:     module_fee_quoter.FeeQuoterCaller{BoundContract: feeQuoterContract},
 			FeeQuoterTransactor: module_fee_quoter.FeeQuoterTransactor{BoundContract: feeQuoterContract},
 		},
-		Offramp: module_offramp.Offramp{
+		offramp: module_offramp.OfframpContract{
 			OfframpCaller:     module_offramp.OfframpCaller{BoundContract: offrampContract},
 			OfframpTransactor: module_offramp.OfframpTransactor{BoundContract: offrampContract},
 		},
-		Onramp: module_onramp.Onramp{
+		onramp: module_onramp.OnrampContract{
 			OnrampCaller:     module_onramp.OnrampCaller{BoundContract: onrampContract},
 			OnrampTransactor: module_onramp.OnrampTransactor{BoundContract: onrampContract},
 		},
-		ReceiverRegistry: module_receiver_registry.ReceiverRegistry{
+		receiverRegistry: module_receiver_registry.ReceiverRegistryContract{
 			ReceiverRegistryCaller:     module_receiver_registry.ReceiverRegistryCaller{BoundContract: receiverRegistryContract},
 			ReceiverRegistryTransactor: module_receiver_registry.ReceiverRegistryTransactor{BoundContract: receiverRegistryContract},
 		},
-		RMNRemote: module_rmn_remote.RMNRemote{
+		rmnRemote: module_rmn_remote.RMNRemoteContract{
 			RMNRemoteCaller:     module_rmn_remote.RMNRemoteCaller{BoundContract: rmnRemoteContract},
 			RMNRemoteTransactor: module_rmn_remote.RMNRemoteTransactor{BoundContract: rmnRemoteContract},
 		},
-		TokenAdminRegistry: module_token_admin_registry.TokenAdminRegistry{
+		tokenAdminRegistry: module_token_admin_registry.TokenAdminRegistryContract{
 			TokenAdminRegistryCaller:     module_token_admin_registry.TokenAdminRegistryCaller{BoundContract: tokenAdminRegistryContract},
 			TokenAdminRegistryTransactor: module_token_admin_registry.TokenAdminRegistryTransactor{BoundContract: tokenAdminRegistryContract},
 		},
@@ -113,7 +159,7 @@ func DeployToObject(
 	}
 	address, tx, err := bind.DeployPackageToObject(auth, client, "ccip", namedAddresses)
 	if err != nil {
-		return aptos.AccountAddress{}, nil, CCIP{}, err
+		return aptos.AccountAddress{}, nil, CCIPContract{}, err
 	}
 	return address, tx, Bind(address, client), nil
 }

--- a/bindings/ccip/ccip.go
+++ b/bindings/ccip/ccip.go
@@ -101,43 +101,15 @@ func Compile(address aptos.AccountAddress, mcmsAddress aptos.AccountAddress, reg
 }
 
 func Bind(address aptos.AccountAddress, client aptos.AptosRpcClient) CCIP {
-	authContract := bind.NewBoundContract(address, "auth", client)
-	feeQuoterContract := bind.NewBoundContract(address, "fee_quoter", client)
-	offrampContract := bind.NewBoundContract(address, "offramp", client)
-	onrampContract := bind.NewBoundContract(address, "onramp", client)
-	receiverRegistryContract := bind.NewBoundContract(address, "receiver_registry", client)
-	rmnRemoteContract := bind.NewBoundContract(address, "rmn_remote", client)
-	tokenAdminRegistryContract := bind.NewBoundContract(address, "token_admin_registry", client)
 	return CCIPContract{
-		address: address,
-		auth: module_auth.AuthContract{
-			AuthCaller:     module_auth.AuthCaller{BoundContract: authContract},
-			AuthTransactor: module_auth.AuthTransactor{BoundContract: authContract},
-		},
-		feeQuoter: module_fee_quoter.FeeQuoterContract{
-			FeeQuoterCaller:     module_fee_quoter.FeeQuoterCaller{BoundContract: feeQuoterContract},
-			FeeQuoterTransactor: module_fee_quoter.FeeQuoterTransactor{BoundContract: feeQuoterContract},
-		},
-		offramp: module_offramp.OfframpContract{
-			OfframpCaller:     module_offramp.OfframpCaller{BoundContract: offrampContract},
-			OfframpTransactor: module_offramp.OfframpTransactor{BoundContract: offrampContract},
-		},
-		onramp: module_onramp.OnrampContract{
-			OnrampCaller:     module_onramp.OnrampCaller{BoundContract: onrampContract},
-			OnrampTransactor: module_onramp.OnrampTransactor{BoundContract: onrampContract},
-		},
-		receiverRegistry: module_receiver_registry.ReceiverRegistryContract{
-			ReceiverRegistryCaller:     module_receiver_registry.ReceiverRegistryCaller{BoundContract: receiverRegistryContract},
-			ReceiverRegistryTransactor: module_receiver_registry.ReceiverRegistryTransactor{BoundContract: receiverRegistryContract},
-		},
-		rmnRemote: module_rmn_remote.RMNRemoteContract{
-			RMNRemoteCaller:     module_rmn_remote.RMNRemoteCaller{BoundContract: rmnRemoteContract},
-			RMNRemoteTransactor: module_rmn_remote.RMNRemoteTransactor{BoundContract: rmnRemoteContract},
-		},
-		tokenAdminRegistry: module_token_admin_registry.TokenAdminRegistryContract{
-			TokenAdminRegistryCaller:     module_token_admin_registry.TokenAdminRegistryCaller{BoundContract: tokenAdminRegistryContract},
-			TokenAdminRegistryTransactor: module_token_admin_registry.TokenAdminRegistryTransactor{BoundContract: tokenAdminRegistryContract},
-		},
+		address:            address,
+		auth:               module_auth.NewAuth(address, client),
+		feeQuoter:          module_fee_quoter.NewFeeQuoter(address, client),
+		offramp:            module_offramp.NewOfframp(address, client),
+		onramp:             module_onramp.NewOnramp(address, client),
+		receiverRegistry:   module_receiver_registry.NewReceiverRegistry(address, client),
+		rmnRemote:          module_rmn_remote.NewRMNRemote(address, client),
+		tokenAdminRegistry: module_token_admin_registry.NewTokenAdminRegistry(address, client),
 	}
 }
 

--- a/bindings/ccip/fee_quoter/fee_quoter.go
+++ b/bindings/ccip/fee_quoter/fee_quoter.go
@@ -40,7 +40,7 @@ type FeeQuoter interface {
 	ApplyPremiumMultiplierWeiPerEthUpdates(opts *bind.TransactOpts, tokens []aptos.AccountAddress, premiumMultiplierWeiPerEth []uint64) (*api.PendingTransaction, error)
 	ApplyDestChainConfigUpdates(opts *bind.TransactOpts, destChainSelector uint64, isEnabled bool, maxNumberOfTokensPerMsg uint16, maxDataBytes uint32, maxPerMsgGasLimit uint32, destGasOverhead uint32, destGasPerPayloadByteBase byte, destGasPerPayloadByteHigh byte, destGasPerPayloadByteThreshold uint16, destDataAvailabilityOverheadGas uint32, destGasPerDataAvailabilityByte uint16, destDataAvailabilityMultiplierBps uint16, chainFamilySelector []byte, enforceOutOfOrder bool, defaultTokenFeeUsdCents uint16, defaultTokenDestGasOverhead uint32, defaultTxGasLimit uint32, gasMultiplierWeiPerEth uint64, gasPriceStalenessThreshold uint32, networkFeeUsdCents uint32) (*api.PendingTransaction, error)
 
-	EncodeCall() FeeQuoterEncoder
+	_Encode() FeeQuoterEncoder
 }
 
 type FeeQuoterEncoder interface {
@@ -181,7 +181,7 @@ type FeeQuoterContract struct {
 
 var _ FeeQuoter = FeeQuoterContract{}
 
-func (c FeeQuoterContract) EncodeCall() FeeQuoterEncoder {
+func (c FeeQuoterContract) _Encode() FeeQuoterEncoder {
 	return c.feeQuoterEncoder
 }
 

--- a/bindings/ccip/fee_quoter/fee_quoter.go
+++ b/bindings/ccip/fee_quoter/fee_quoter.go
@@ -40,7 +40,8 @@ type FeeQuoter interface {
 	ApplyPremiumMultiplierWeiPerEthUpdates(opts *bind.TransactOpts, tokens []aptos.AccountAddress, premiumMultiplierWeiPerEth []uint64) (*api.PendingTransaction, error)
 	ApplyDestChainConfigUpdates(opts *bind.TransactOpts, destChainSelector uint64, isEnabled bool, maxNumberOfTokensPerMsg uint16, maxDataBytes uint32, maxPerMsgGasLimit uint32, destGasOverhead uint32, destGasPerPayloadByteBase byte, destGasPerPayloadByteHigh byte, destGasPerPayloadByteThreshold uint16, destDataAvailabilityOverheadGas uint32, destGasPerDataAvailabilityByte uint16, destDataAvailabilityMultiplierBps uint16, chainFamilySelector []byte, enforceOutOfOrder bool, defaultTokenFeeUsdCents uint16, defaultTokenDestGasOverhead uint32, defaultTxGasLimit uint32, gasMultiplierWeiPerEth uint64, gasPriceStalenessThreshold uint32, networkFeeUsdCents uint32) (*api.PendingTransaction, error)
 
-	Encode_() FeeQuoterEncoder
+	// Encode returns the encoder implementation of this module.
+	Encoder() FeeQuoterEncoder
 }
 
 type FeeQuoterEncoder interface {
@@ -181,7 +182,7 @@ type FeeQuoterContract struct {
 
 var _ FeeQuoter = FeeQuoterContract{}
 
-func (c FeeQuoterContract) Encode_() FeeQuoterEncoder {
+func (c FeeQuoterContract) Encoder() FeeQuoterEncoder {
 	return c.feeQuoterEncoder
 }
 

--- a/bindings/ccip/fee_quoter/fee_quoter.go
+++ b/bindings/ccip/fee_quoter/fee_quoter.go
@@ -39,9 +39,40 @@ type FeeQuoter interface {
 	ApplyTokenTransferFeeConfigUpdates(opts *bind.TransactOpts, destChainSelector uint64, addTokens []aptos.AccountAddress, addMinFeeUsdCents []uint32, addMaxFeeUsdCents []uint32, addDeciBps []uint16, addDestGasOverhead []uint32, addDestBytesOverhead []uint32, addIsEnabled []bool, removeTokens []aptos.AccountAddress) (*api.PendingTransaction, error)
 	ApplyPremiumMultiplierWeiPerEthUpdates(opts *bind.TransactOpts, tokens []aptos.AccountAddress, premiumMultiplierWeiPerEth []uint64) (*api.PendingTransaction, error)
 	ApplyDestChainConfigUpdates(opts *bind.TransactOpts, destChainSelector uint64, isEnabled bool, maxNumberOfTokensPerMsg uint16, maxDataBytes uint32, maxPerMsgGasLimit uint32, destGasOverhead uint32, destGasPerPayloadByteBase byte, destGasPerPayloadByteHigh byte, destGasPerPayloadByteThreshold uint16, destDataAvailabilityOverheadGas uint32, destGasPerDataAvailabilityByte uint16, destDataAvailabilityMultiplierBps uint16, chainFamilySelector []byte, enforceOutOfOrder bool, defaultTokenFeeUsdCents uint16, defaultTokenDestGasOverhead uint32, defaultTxGasLimit uint32, gasMultiplierWeiPerEth uint64, gasPriceStalenessThreshold uint32, networkFeeUsdCents uint32) (*api.PendingTransaction, error)
+
+	EncodeCall() FeeQuoterEncoder
+}
+
+type FeeQuoterEncoder interface {
+	TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetTokenPrice(token aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetTokenPrices(tokens []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetDestChainGasPrice(destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetTokenAndGasPrices(token aptos.AccountAddress, destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ConvertTokenAmount(fromToken aptos.AccountAddress, fromTokenAmount uint64, toToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetFeeTokens() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetTokenTransferFeeConfig(destChainSelector uint64, token aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetPremiumMultiplierWeiPerEth(token aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetDestChainConfig(destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetStaticConfig() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Initialize(maxFeeJuelsPerMsg uint64, linkToken aptos.AccountAddress, tokenPriceStalenessThreshold uint64, feeTokens []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ApplyFeeTokenUpdates(feeTokensToRemove []aptos.AccountAddress, feeTokensToAdd []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ApplyTokenTransferFeeConfigUpdates(destChainSelector uint64, addTokens []aptos.AccountAddress, addMinFeeUsdCents []uint32, addMaxFeeUsdCents []uint32, addDeciBps []uint16, addDestGasOverhead []uint32, addDestBytesOverhead []uint32, addIsEnabled []bool, removeTokens []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ApplyPremiumMultiplierWeiPerEthUpdates(tokens []aptos.AccountAddress, premiumMultiplierWeiPerEth []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ApplyDestChainConfigUpdates(destChainSelector uint64, isEnabled bool, maxNumberOfTokensPerMsg uint16, maxDataBytes uint32, maxPerMsgGasLimit uint32, destGasOverhead uint32, destGasPerPayloadByteBase byte, destGasPerPayloadByteHigh byte, destGasPerPayloadByteThreshold uint16, destDataAvailabilityOverheadGas uint32, destGasPerDataAvailabilityByte uint16, destDataAvailabilityMultiplierBps uint16, chainFamilySelector []byte, enforceOutOfOrder bool, defaultTokenFeeUsdCents uint16, defaultTokenDestGasOverhead uint32, defaultTxGasLimit uint32, gasMultiplierWeiPerEth uint64, gasPriceStalenessThreshold uint32, networkFeeUsdCents uint32) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	UpdatePrices(sourceTokens []aptos.AccountAddress, sourceUsdPerToken []*big.Int, gasDestChainSelectors []uint64, gasUsdPerUnitGas []*big.Int) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ProcessMessageArgs(destChainSelector uint64, feeToken aptos.AccountAddress, feeTokenAmount uint64, extraArgs []byte, destTokenAddresses [][]byte, destPoolDatas [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
 const FunctionInfo = `[{"package":"ccip","module":"fee_quoter","name":"apply_dest_chain_config_updates","parameters":[{"name":"dest_chain_selector","type":"u64"},{"name":"is_enabled","type":"bool"},{"name":"max_number_of_tokens_per_msg","type":"u16"},{"name":"max_data_bytes","type":"u32"},{"name":"max_per_msg_gas_limit","type":"u32"},{"name":"dest_gas_overhead","type":"u32"},{"name":"dest_gas_per_payload_byte_base","type":"u8"},{"name":"dest_gas_per_payload_byte_high","type":"u8"},{"name":"dest_gas_per_payload_byte_threshold","type":"u16"},{"name":"dest_data_availability_overhead_gas","type":"u32"},{"name":"dest_gas_per_data_availability_byte","type":"u16"},{"name":"dest_data_availability_multiplier_bps","type":"u16"},{"name":"chain_family_selector","type":"vector\u003cu8\u003e"},{"name":"enforce_out_of_order","type":"bool"},{"name":"default_token_fee_usd_cents","type":"u16"},{"name":"default_token_dest_gas_overhead","type":"u32"},{"name":"default_tx_gas_limit","type":"u32"},{"name":"gas_multiplier_wei_per_eth","type":"u64"},{"name":"gas_price_staleness_threshold","type":"u32"},{"name":"network_fee_usd_cents","type":"u32"}]},{"package":"ccip","module":"fee_quoter","name":"apply_fee_token_updates","parameters":[{"name":"fee_tokens_to_remove","type":"vector\u003caddress\u003e"},{"name":"fee_tokens_to_add","type":"vector\u003caddress\u003e"}]},{"package":"ccip","module":"fee_quoter","name":"apply_premium_multiplier_wei_per_eth_updates","parameters":[{"name":"tokens","type":"vector\u003caddress\u003e"},{"name":"premium_multiplier_wei_per_eth","type":"vector\u003cu64\u003e"}]},{"package":"ccip","module":"fee_quoter","name":"apply_token_transfer_fee_config_updates","parameters":[{"name":"dest_chain_selector","type":"u64"},{"name":"add_tokens","type":"vector\u003caddress\u003e"},{"name":"add_min_fee_usd_cents","type":"vector\u003cu32\u003e"},{"name":"add_max_fee_usd_cents","type":"vector\u003cu32\u003e"},{"name":"add_deci_bps","type":"vector\u003cu16\u003e"},{"name":"add_dest_gas_overhead","type":"vector\u003cu32\u003e"},{"name":"add_dest_bytes_overhead","type":"vector\u003cu32\u003e"},{"name":"add_is_enabled","type":"vector\u003cbool\u003e"},{"name":"remove_tokens","type":"vector\u003caddress\u003e"}]},{"package":"ccip","module":"fee_quoter","name":"initialize","parameters":[{"name":"max_fee_juels_per_msg","type":"u64"},{"name":"link_token","type":"address"},{"name":"token_price_staleness_threshold","type":"u64"},{"name":"fee_tokens","type":"vector\u003caddress\u003e"}]},{"package":"ccip","module":"fee_quoter","name":"process_message_args","parameters":[{"name":"dest_chain_selector","type":"u64"},{"name":"fee_token","type":"address"},{"name":"fee_token_amount","type":"u64"},{"name":"extra_args","type":"vector\u003cu8\u003e"},{"name":"dest_token_addresses","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"dest_pool_datas","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"ccip","module":"fee_quoter","name":"update_prices","parameters":[{"name":"source_tokens","type":"vector\u003caddress\u003e"},{"name":"source_usd_per_token","type":"vector\u003cu256\u003e"},{"name":"gas_dest_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"gas_usd_per_unit_gas","type":"vector\u003cu256\u003e"}]}]`
+
+func NewFeeQuoter(address aptos.AccountAddress, client aptos.AptosRpcClient) FeeQuoter {
+	contract := bind.NewBoundContract(address, "ccip", "fee_quoter", client)
+	return FeeQuoterContract{
+		BoundContract:    contract,
+		feeQuoterEncoder: feeQuoterEncoder{BoundContract: contract},
+	}
+}
 
 // Structs
 
@@ -144,22 +175,20 @@ type McmsCallback struct {
 }
 
 type FeeQuoterContract struct {
-	FeeQuoterCaller
-	FeeQuoterTransactor
+	*bind.BoundContract
+	feeQuoterEncoder
+}
+
+var _ FeeQuoter = FeeQuoterContract{}
+
+func (c FeeQuoterContract) EncodeCall() FeeQuoterEncoder {
+	return c.feeQuoterEncoder
 }
 
 // View Functions
 
-type FeeQuoterCaller struct {
-	*bind.BoundContract
-}
-
-func (c FeeQuoterCaller) EncodeTypeAndVersion() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
-}
-
-func (c FeeQuoterCaller) TypeAndVersion(opts *bind.CallOpts) (string, error) {
-	module, function, typeTags, args, err := c.EncodeTypeAndVersion()
+func (c FeeQuoterContract) TypeAndVersion(opts *bind.CallOpts) (string, error) {
+	module, function, typeTags, args, err := c.feeQuoterEncoder.TypeAndVersion()
 	if err != nil {
 		return *new(string), err
 	}
@@ -179,16 +208,8 @@ func (c FeeQuoterCaller) TypeAndVersion(opts *bind.CallOpts) (string, error) {
 	return r0, nil
 }
 
-func (c FeeQuoterCaller) EncodeGetTokenPrice(token aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_token_price", nil, []string{
-		"address",
-	}, []any{
-		token,
-	})
-}
-
-func (c FeeQuoterCaller) GetTokenPrice(opts *bind.CallOpts, token aptos.AccountAddress) (TimestampedPrice, error) {
-	module, function, typeTags, args, err := c.EncodeGetTokenPrice(token)
+func (c FeeQuoterContract) GetTokenPrice(opts *bind.CallOpts, token aptos.AccountAddress) (TimestampedPrice, error) {
+	module, function, typeTags, args, err := c.feeQuoterEncoder.GetTokenPrice(token)
 	if err != nil {
 		return *new(TimestampedPrice), err
 	}
@@ -208,16 +229,8 @@ func (c FeeQuoterCaller) GetTokenPrice(opts *bind.CallOpts, token aptos.AccountA
 	return r0, nil
 }
 
-func (c FeeQuoterCaller) EncodeGetTokenPrices(tokens []aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_token_prices", nil, []string{
-		"vector<address>",
-	}, []any{
-		tokens,
-	})
-}
-
-func (c FeeQuoterCaller) GetTokenPrices(opts *bind.CallOpts, tokens []aptos.AccountAddress) ([]TimestampedPrice, error) {
-	module, function, typeTags, args, err := c.EncodeGetTokenPrices(tokens)
+func (c FeeQuoterContract) GetTokenPrices(opts *bind.CallOpts, tokens []aptos.AccountAddress) ([]TimestampedPrice, error) {
+	module, function, typeTags, args, err := c.feeQuoterEncoder.GetTokenPrices(tokens)
 	if err != nil {
 		return *new([]TimestampedPrice), err
 	}
@@ -237,16 +250,8 @@ func (c FeeQuoterCaller) GetTokenPrices(opts *bind.CallOpts, tokens []aptos.Acco
 	return r0, nil
 }
 
-func (c FeeQuoterCaller) EncodeGetDestChainGasPrice(destChainSelector uint64) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_dest_chain_gas_price", nil, []string{
-		"u64",
-	}, []any{
-		destChainSelector,
-	})
-}
-
-func (c FeeQuoterCaller) GetDestChainGasPrice(opts *bind.CallOpts, destChainSelector uint64) (TimestampedPrice, error) {
-	module, function, typeTags, args, err := c.EncodeGetDestChainGasPrice(destChainSelector)
+func (c FeeQuoterContract) GetDestChainGasPrice(opts *bind.CallOpts, destChainSelector uint64) (TimestampedPrice, error) {
+	module, function, typeTags, args, err := c.feeQuoterEncoder.GetDestChainGasPrice(destChainSelector)
 	if err != nil {
 		return *new(TimestampedPrice), err
 	}
@@ -266,18 +271,8 @@ func (c FeeQuoterCaller) GetDestChainGasPrice(opts *bind.CallOpts, destChainSele
 	return r0, nil
 }
 
-func (c FeeQuoterCaller) EncodeGetTokenAndGasPrices(token aptos.AccountAddress, destChainSelector uint64) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_token_and_gas_prices", nil, []string{
-		"address",
-		"u64",
-	}, []any{
-		token,
-		destChainSelector,
-	})
-}
-
-func (c FeeQuoterCaller) GetTokenAndGasPrices(opts *bind.CallOpts, token aptos.AccountAddress, destChainSelector uint64) (*big.Int, *big.Int, error) {
-	module, function, typeTags, args, err := c.EncodeGetTokenAndGasPrices(token, destChainSelector)
+func (c FeeQuoterContract) GetTokenAndGasPrices(opts *bind.CallOpts, token aptos.AccountAddress, destChainSelector uint64) (*big.Int, *big.Int, error) {
+	module, function, typeTags, args, err := c.feeQuoterEncoder.GetTokenAndGasPrices(token, destChainSelector)
 	if err != nil {
 		return *new(*big.Int), *new(*big.Int), err
 	}
@@ -298,20 +293,8 @@ func (c FeeQuoterCaller) GetTokenAndGasPrices(opts *bind.CallOpts, token aptos.A
 	return r0, r1, nil
 }
 
-func (c FeeQuoterCaller) EncodeConvertTokenAmount(fromToken aptos.AccountAddress, fromTokenAmount uint64, toToken aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("convert_token_amount", nil, []string{
-		"address",
-		"u64",
-		"address",
-	}, []any{
-		fromToken,
-		fromTokenAmount,
-		toToken,
-	})
-}
-
-func (c FeeQuoterCaller) ConvertTokenAmount(opts *bind.CallOpts, fromToken aptos.AccountAddress, fromTokenAmount uint64, toToken aptos.AccountAddress) (uint64, error) {
-	module, function, typeTags, args, err := c.EncodeConvertTokenAmount(fromToken, fromTokenAmount, toToken)
+func (c FeeQuoterContract) ConvertTokenAmount(opts *bind.CallOpts, fromToken aptos.AccountAddress, fromTokenAmount uint64, toToken aptos.AccountAddress) (uint64, error) {
+	module, function, typeTags, args, err := c.feeQuoterEncoder.ConvertTokenAmount(fromToken, fromTokenAmount, toToken)
 	if err != nil {
 		return *new(uint64), err
 	}
@@ -331,12 +314,8 @@ func (c FeeQuoterCaller) ConvertTokenAmount(opts *bind.CallOpts, fromToken aptos
 	return r0, nil
 }
 
-func (c FeeQuoterCaller) EncodeGetFeeTokens() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_fee_tokens", nil, []string{}, []any{})
-}
-
-func (c FeeQuoterCaller) GetFeeTokens(opts *bind.CallOpts) ([]aptos.AccountAddress, error) {
-	module, function, typeTags, args, err := c.EncodeGetFeeTokens()
+func (c FeeQuoterContract) GetFeeTokens(opts *bind.CallOpts) ([]aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.feeQuoterEncoder.GetFeeTokens()
 	if err != nil {
 		return *new([]aptos.AccountAddress), err
 	}
@@ -356,18 +335,8 @@ func (c FeeQuoterCaller) GetFeeTokens(opts *bind.CallOpts) ([]aptos.AccountAddre
 	return r0, nil
 }
 
-func (c FeeQuoterCaller) EncodeGetTokenTransferFeeConfig(destChainSelector uint64, token aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_token_transfer_fee_config", nil, []string{
-		"u64",
-		"address",
-	}, []any{
-		destChainSelector,
-		token,
-	})
-}
-
-func (c FeeQuoterCaller) GetTokenTransferFeeConfig(opts *bind.CallOpts, destChainSelector uint64, token aptos.AccountAddress) (TokenTransferFeeConfig, error) {
-	module, function, typeTags, args, err := c.EncodeGetTokenTransferFeeConfig(destChainSelector, token)
+func (c FeeQuoterContract) GetTokenTransferFeeConfig(opts *bind.CallOpts, destChainSelector uint64, token aptos.AccountAddress) (TokenTransferFeeConfig, error) {
+	module, function, typeTags, args, err := c.feeQuoterEncoder.GetTokenTransferFeeConfig(destChainSelector, token)
 	if err != nil {
 		return *new(TokenTransferFeeConfig), err
 	}
@@ -387,16 +356,8 @@ func (c FeeQuoterCaller) GetTokenTransferFeeConfig(opts *bind.CallOpts, destChai
 	return r0, nil
 }
 
-func (c FeeQuoterCaller) EncodeGetPremiumMultiplierWeiPerEth(token aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_premium_multiplier_wei_per_eth", nil, []string{
-		"address",
-	}, []any{
-		token,
-	})
-}
-
-func (c FeeQuoterCaller) GetPremiumMultiplierWeiPerEth(opts *bind.CallOpts, token aptos.AccountAddress) (uint64, error) {
-	module, function, typeTags, args, err := c.EncodeGetPremiumMultiplierWeiPerEth(token)
+func (c FeeQuoterContract) GetPremiumMultiplierWeiPerEth(opts *bind.CallOpts, token aptos.AccountAddress) (uint64, error) {
+	module, function, typeTags, args, err := c.feeQuoterEncoder.GetPremiumMultiplierWeiPerEth(token)
 	if err != nil {
 		return *new(uint64), err
 	}
@@ -416,16 +377,8 @@ func (c FeeQuoterCaller) GetPremiumMultiplierWeiPerEth(opts *bind.CallOpts, toke
 	return r0, nil
 }
 
-func (c FeeQuoterCaller) EncodeGetDestChainConfig(destChainSelector uint64) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_dest_chain_config", nil, []string{
-		"u64",
-	}, []any{
-		destChainSelector,
-	})
-}
-
-func (c FeeQuoterCaller) GetDestChainConfig(opts *bind.CallOpts, destChainSelector uint64) (DestChainConfig, error) {
-	module, function, typeTags, args, err := c.EncodeGetDestChainConfig(destChainSelector)
+func (c FeeQuoterContract) GetDestChainConfig(opts *bind.CallOpts, destChainSelector uint64) (DestChainConfig, error) {
+	module, function, typeTags, args, err := c.feeQuoterEncoder.GetDestChainConfig(destChainSelector)
 	if err != nil {
 		return *new(DestChainConfig), err
 	}
@@ -445,12 +398,8 @@ func (c FeeQuoterCaller) GetDestChainConfig(opts *bind.CallOpts, destChainSelect
 	return r0, nil
 }
 
-func (c FeeQuoterCaller) EncodeGetStaticConfig() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_static_config", nil, []string{}, []any{})
-}
-
-func (c FeeQuoterCaller) GetStaticConfig(opts *bind.CallOpts) (StaticConfig, error) {
-	module, function, typeTags, args, err := c.EncodeGetStaticConfig()
+func (c FeeQuoterContract) GetStaticConfig(opts *bind.CallOpts) (StaticConfig, error) {
+	module, function, typeTags, args, err := c.feeQuoterEncoder.GetStaticConfig()
 	if err != nil {
 		return *new(StaticConfig), err
 	}
@@ -472,11 +421,141 @@ func (c FeeQuoterCaller) GetStaticConfig(opts *bind.CallOpts) (StaticConfig, err
 
 // Entry Functions
 
-type FeeQuoterTransactor struct {
+func (c FeeQuoterContract) Initialize(opts *bind.TransactOpts, maxFeeJuelsPerMsg uint64, linkToken aptos.AccountAddress, tokenPriceStalenessThreshold uint64, feeTokens []aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.feeQuoterEncoder.Initialize(maxFeeJuelsPerMsg, linkToken, tokenPriceStalenessThreshold, feeTokens)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c FeeQuoterContract) ApplyFeeTokenUpdates(opts *bind.TransactOpts, feeTokensToRemove []aptos.AccountAddress, feeTokensToAdd []aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.feeQuoterEncoder.ApplyFeeTokenUpdates(feeTokensToRemove, feeTokensToAdd)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c FeeQuoterContract) ApplyTokenTransferFeeConfigUpdates(opts *bind.TransactOpts, destChainSelector uint64, addTokens []aptos.AccountAddress, addMinFeeUsdCents []uint32, addMaxFeeUsdCents []uint32, addDeciBps []uint16, addDestGasOverhead []uint32, addDestBytesOverhead []uint32, addIsEnabled []bool, removeTokens []aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.feeQuoterEncoder.ApplyTokenTransferFeeConfigUpdates(destChainSelector, addTokens, addMinFeeUsdCents, addMaxFeeUsdCents, addDeciBps, addDestGasOverhead, addDestBytesOverhead, addIsEnabled, removeTokens)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c FeeQuoterContract) ApplyPremiumMultiplierWeiPerEthUpdates(opts *bind.TransactOpts, tokens []aptos.AccountAddress, premiumMultiplierWeiPerEth []uint64) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.feeQuoterEncoder.ApplyPremiumMultiplierWeiPerEthUpdates(tokens, premiumMultiplierWeiPerEth)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c FeeQuoterContract) ApplyDestChainConfigUpdates(opts *bind.TransactOpts, destChainSelector uint64, isEnabled bool, maxNumberOfTokensPerMsg uint16, maxDataBytes uint32, maxPerMsgGasLimit uint32, destGasOverhead uint32, destGasPerPayloadByteBase byte, destGasPerPayloadByteHigh byte, destGasPerPayloadByteThreshold uint16, destDataAvailabilityOverheadGas uint32, destGasPerDataAvailabilityByte uint16, destDataAvailabilityMultiplierBps uint16, chainFamilySelector []byte, enforceOutOfOrder bool, defaultTokenFeeUsdCents uint16, defaultTokenDestGasOverhead uint32, defaultTxGasLimit uint32, gasMultiplierWeiPerEth uint64, gasPriceStalenessThreshold uint32, networkFeeUsdCents uint32) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.feeQuoterEncoder.ApplyDestChainConfigUpdates(destChainSelector, isEnabled, maxNumberOfTokensPerMsg, maxDataBytes, maxPerMsgGasLimit, destGasOverhead, destGasPerPayloadByteBase, destGasPerPayloadByteHigh, destGasPerPayloadByteThreshold, destDataAvailabilityOverheadGas, destGasPerDataAvailabilityByte, destDataAvailabilityMultiplierBps, chainFamilySelector, enforceOutOfOrder, defaultTokenFeeUsdCents, defaultTokenDestGasOverhead, defaultTxGasLimit, gasMultiplierWeiPerEth, gasPriceStalenessThreshold, networkFeeUsdCents)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+// Encoder
+type feeQuoterEncoder struct {
 	*bind.BoundContract
 }
 
-func (c FeeQuoterTransactor) EncodeInitialize(maxFeeJuelsPerMsg uint64, linkToken aptos.AccountAddress, tokenPriceStalenessThreshold uint64, feeTokens []aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c feeQuoterEncoder) TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
+}
+
+func (c feeQuoterEncoder) GetTokenPrice(token aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_token_price", nil, []string{
+		"address",
+	}, []any{
+		token,
+	})
+}
+
+func (c feeQuoterEncoder) GetTokenPrices(tokens []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_token_prices", nil, []string{
+		"vector<address>",
+	}, []any{
+		tokens,
+	})
+}
+
+func (c feeQuoterEncoder) GetDestChainGasPrice(destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_dest_chain_gas_price", nil, []string{
+		"u64",
+	}, []any{
+		destChainSelector,
+	})
+}
+
+func (c feeQuoterEncoder) GetTokenAndGasPrices(token aptos.AccountAddress, destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_token_and_gas_prices", nil, []string{
+		"address",
+		"u64",
+	}, []any{
+		token,
+		destChainSelector,
+	})
+}
+
+func (c feeQuoterEncoder) ConvertTokenAmount(fromToken aptos.AccountAddress, fromTokenAmount uint64, toToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("convert_token_amount", nil, []string{
+		"address",
+		"u64",
+		"address",
+	}, []any{
+		fromToken,
+		fromTokenAmount,
+		toToken,
+	})
+}
+
+func (c feeQuoterEncoder) GetFeeTokens() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_fee_tokens", nil, []string{}, []any{})
+}
+
+func (c feeQuoterEncoder) GetTokenTransferFeeConfig(destChainSelector uint64, token aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_token_transfer_fee_config", nil, []string{
+		"u64",
+		"address",
+	}, []any{
+		destChainSelector,
+		token,
+	})
+}
+
+func (c feeQuoterEncoder) GetPremiumMultiplierWeiPerEth(token aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_premium_multiplier_wei_per_eth", nil, []string{
+		"address",
+	}, []any{
+		token,
+	})
+}
+
+func (c feeQuoterEncoder) GetDestChainConfig(destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_dest_chain_config", nil, []string{
+		"u64",
+	}, []any{
+		destChainSelector,
+	})
+}
+
+func (c feeQuoterEncoder) GetStaticConfig() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_static_config", nil, []string{}, []any{})
+}
+
+func (c feeQuoterEncoder) Initialize(maxFeeJuelsPerMsg uint64, linkToken aptos.AccountAddress, tokenPriceStalenessThreshold uint64, feeTokens []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("initialize", nil, []string{
 		"u64",
 		"address",
@@ -490,16 +569,7 @@ func (c FeeQuoterTransactor) EncodeInitialize(maxFeeJuelsPerMsg uint64, linkToke
 	})
 }
 
-func (c FeeQuoterTransactor) Initialize(opts *bind.TransactOpts, maxFeeJuelsPerMsg uint64, linkToken aptos.AccountAddress, tokenPriceStalenessThreshold uint64, feeTokens []aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeInitialize(maxFeeJuelsPerMsg, linkToken, tokenPriceStalenessThreshold, feeTokens)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c FeeQuoterTransactor) EncodeApplyFeeTokenUpdates(feeTokensToRemove []aptos.AccountAddress, feeTokensToAdd []aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c feeQuoterEncoder) ApplyFeeTokenUpdates(feeTokensToRemove []aptos.AccountAddress, feeTokensToAdd []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("apply_fee_token_updates", nil, []string{
 		"vector<address>",
 		"vector<address>",
@@ -509,16 +579,7 @@ func (c FeeQuoterTransactor) EncodeApplyFeeTokenUpdates(feeTokensToRemove []apto
 	})
 }
 
-func (c FeeQuoterTransactor) ApplyFeeTokenUpdates(opts *bind.TransactOpts, feeTokensToRemove []aptos.AccountAddress, feeTokensToAdd []aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeApplyFeeTokenUpdates(feeTokensToRemove, feeTokensToAdd)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c FeeQuoterTransactor) EncodeApplyTokenTransferFeeConfigUpdates(destChainSelector uint64, addTokens []aptos.AccountAddress, addMinFeeUsdCents []uint32, addMaxFeeUsdCents []uint32, addDeciBps []uint16, addDestGasOverhead []uint32, addDestBytesOverhead []uint32, addIsEnabled []bool, removeTokens []aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c feeQuoterEncoder) ApplyTokenTransferFeeConfigUpdates(destChainSelector uint64, addTokens []aptos.AccountAddress, addMinFeeUsdCents []uint32, addMaxFeeUsdCents []uint32, addDeciBps []uint16, addDestGasOverhead []uint32, addDestBytesOverhead []uint32, addIsEnabled []bool, removeTokens []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("apply_token_transfer_fee_config_updates", nil, []string{
 		"u64",
 		"vector<address>",
@@ -542,16 +603,7 @@ func (c FeeQuoterTransactor) EncodeApplyTokenTransferFeeConfigUpdates(destChainS
 	})
 }
 
-func (c FeeQuoterTransactor) ApplyTokenTransferFeeConfigUpdates(opts *bind.TransactOpts, destChainSelector uint64, addTokens []aptos.AccountAddress, addMinFeeUsdCents []uint32, addMaxFeeUsdCents []uint32, addDeciBps []uint16, addDestGasOverhead []uint32, addDestBytesOverhead []uint32, addIsEnabled []bool, removeTokens []aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeApplyTokenTransferFeeConfigUpdates(destChainSelector, addTokens, addMinFeeUsdCents, addMaxFeeUsdCents, addDeciBps, addDestGasOverhead, addDestBytesOverhead, addIsEnabled, removeTokens)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c FeeQuoterTransactor) EncodeApplyPremiumMultiplierWeiPerEthUpdates(tokens []aptos.AccountAddress, premiumMultiplierWeiPerEth []uint64) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c feeQuoterEncoder) ApplyPremiumMultiplierWeiPerEthUpdates(tokens []aptos.AccountAddress, premiumMultiplierWeiPerEth []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("apply_premium_multiplier_wei_per_eth_updates", nil, []string{
 		"vector<address>",
 		"vector<u64>",
@@ -561,16 +613,7 @@ func (c FeeQuoterTransactor) EncodeApplyPremiumMultiplierWeiPerEthUpdates(tokens
 	})
 }
 
-func (c FeeQuoterTransactor) ApplyPremiumMultiplierWeiPerEthUpdates(opts *bind.TransactOpts, tokens []aptos.AccountAddress, premiumMultiplierWeiPerEth []uint64) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeApplyPremiumMultiplierWeiPerEthUpdates(tokens, premiumMultiplierWeiPerEth)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c FeeQuoterTransactor) EncodeApplyDestChainConfigUpdates(destChainSelector uint64, isEnabled bool, maxNumberOfTokensPerMsg uint16, maxDataBytes uint32, maxPerMsgGasLimit uint32, destGasOverhead uint32, destGasPerPayloadByteBase byte, destGasPerPayloadByteHigh byte, destGasPerPayloadByteThreshold uint16, destDataAvailabilityOverheadGas uint32, destGasPerDataAvailabilityByte uint16, destDataAvailabilityMultiplierBps uint16, chainFamilySelector []byte, enforceOutOfOrder bool, defaultTokenFeeUsdCents uint16, defaultTokenDestGasOverhead uint32, defaultTxGasLimit uint32, gasMultiplierWeiPerEth uint64, gasPriceStalenessThreshold uint32, networkFeeUsdCents uint32) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c feeQuoterEncoder) ApplyDestChainConfigUpdates(destChainSelector uint64, isEnabled bool, maxNumberOfTokensPerMsg uint16, maxDataBytes uint32, maxPerMsgGasLimit uint32, destGasOverhead uint32, destGasPerPayloadByteBase byte, destGasPerPayloadByteHigh byte, destGasPerPayloadByteThreshold uint16, destDataAvailabilityOverheadGas uint32, destGasPerDataAvailabilityByte uint16, destDataAvailabilityMultiplierBps uint16, chainFamilySelector []byte, enforceOutOfOrder bool, defaultTokenFeeUsdCents uint16, defaultTokenDestGasOverhead uint32, defaultTxGasLimit uint32, gasMultiplierWeiPerEth uint64, gasPriceStalenessThreshold uint32, networkFeeUsdCents uint32) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("apply_dest_chain_config_updates", nil, []string{
 		"u64",
 		"bool",
@@ -616,18 +659,7 @@ func (c FeeQuoterTransactor) EncodeApplyDestChainConfigUpdates(destChainSelector
 	})
 }
 
-func (c FeeQuoterTransactor) ApplyDestChainConfigUpdates(opts *bind.TransactOpts, destChainSelector uint64, isEnabled bool, maxNumberOfTokensPerMsg uint16, maxDataBytes uint32, maxPerMsgGasLimit uint32, destGasOverhead uint32, destGasPerPayloadByteBase byte, destGasPerPayloadByteHigh byte, destGasPerPayloadByteThreshold uint16, destDataAvailabilityOverheadGas uint32, destGasPerDataAvailabilityByte uint16, destDataAvailabilityMultiplierBps uint16, chainFamilySelector []byte, enforceOutOfOrder bool, defaultTokenFeeUsdCents uint16, defaultTokenDestGasOverhead uint32, defaultTxGasLimit uint32, gasMultiplierWeiPerEth uint64, gasPriceStalenessThreshold uint32, networkFeeUsdCents uint32) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeApplyDestChainConfigUpdates(destChainSelector, isEnabled, maxNumberOfTokensPerMsg, maxDataBytes, maxPerMsgGasLimit, destGasOverhead, destGasPerPayloadByteBase, destGasPerPayloadByteHigh, destGasPerPayloadByteThreshold, destDataAvailabilityOverheadGas, destGasPerDataAvailabilityByte, destDataAvailabilityMultiplierBps, chainFamilySelector, enforceOutOfOrder, defaultTokenFeeUsdCents, defaultTokenDestGasOverhead, defaultTxGasLimit, gasMultiplierWeiPerEth, gasPriceStalenessThreshold, networkFeeUsdCents)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-// Other Functions
-
-func (c FeeQuoterCaller) EncodeUpdatePrices(sourceTokens []aptos.AccountAddress, sourceUsdPerToken []*big.Int, gasDestChainSelectors []uint64, gasUsdPerUnitGas []*big.Int) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c feeQuoterEncoder) UpdatePrices(sourceTokens []aptos.AccountAddress, sourceUsdPerToken []*big.Int, gasDestChainSelectors []uint64, gasUsdPerUnitGas []*big.Int) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("update_prices", nil, []string{
 		"vector<address>",
 		"vector<u256>",
@@ -641,7 +673,7 @@ func (c FeeQuoterCaller) EncodeUpdatePrices(sourceTokens []aptos.AccountAddress,
 	})
 }
 
-func (c FeeQuoterCaller) EncodeProcessMessageArgs(destChainSelector uint64, feeToken aptos.AccountAddress, feeTokenAmount uint64, extraArgs []byte, destTokenAddresses [][]byte, destPoolDatas [][]byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c feeQuoterEncoder) ProcessMessageArgs(destChainSelector uint64, feeToken aptos.AccountAddress, feeTokenAmount uint64, extraArgs []byte, destTokenAddresses [][]byte, destPoolDatas [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("process_message_args", nil, []string{
 		"u64",
 		"address",

--- a/bindings/ccip/fee_quoter/fee_quoter.go
+++ b/bindings/ccip/fee_quoter/fee_quoter.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type FeeQuoterInterface interface {
+type FeeQuoter interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 	GetTokenPrice(opts *bind.CallOpts, token aptos.AccountAddress) (TimestampedPrice, error)
 	GetTokenPrices(opts *bind.CallOpts, tokens []aptos.AccountAddress) ([]TimestampedPrice, error)
@@ -143,7 +143,7 @@ type PremiumMultiplierWeiPerEthUpdated struct {
 type McmsCallback struct {
 }
 
-type FeeQuoter struct {
+type FeeQuoterContract struct {
 	FeeQuoterCaller
 	FeeQuoterTransactor
 }

--- a/bindings/ccip/fee_quoter/fee_quoter.go
+++ b/bindings/ccip/fee_quoter/fee_quoter.go
@@ -40,7 +40,7 @@ type FeeQuoter interface {
 	ApplyPremiumMultiplierWeiPerEthUpdates(opts *bind.TransactOpts, tokens []aptos.AccountAddress, premiumMultiplierWeiPerEth []uint64) (*api.PendingTransaction, error)
 	ApplyDestChainConfigUpdates(opts *bind.TransactOpts, destChainSelector uint64, isEnabled bool, maxNumberOfTokensPerMsg uint16, maxDataBytes uint32, maxPerMsgGasLimit uint32, destGasOverhead uint32, destGasPerPayloadByteBase byte, destGasPerPayloadByteHigh byte, destGasPerPayloadByteThreshold uint16, destDataAvailabilityOverheadGas uint32, destGasPerDataAvailabilityByte uint16, destDataAvailabilityMultiplierBps uint16, chainFamilySelector []byte, enforceOutOfOrder bool, defaultTokenFeeUsdCents uint16, defaultTokenDestGasOverhead uint32, defaultTxGasLimit uint32, gasMultiplierWeiPerEth uint64, gasPriceStalenessThreshold uint32, networkFeeUsdCents uint32) (*api.PendingTransaction, error)
 
-	// Encode returns the encoder implementation of this module.
+	// Encoder returns the encoder implementation of this module.
 	Encoder() FeeQuoterEncoder
 }
 

--- a/bindings/ccip/fee_quoter/fee_quoter.go
+++ b/bindings/ccip/fee_quoter/fee_quoter.go
@@ -40,7 +40,7 @@ type FeeQuoter interface {
 	ApplyPremiumMultiplierWeiPerEthUpdates(opts *bind.TransactOpts, tokens []aptos.AccountAddress, premiumMultiplierWeiPerEth []uint64) (*api.PendingTransaction, error)
 	ApplyDestChainConfigUpdates(opts *bind.TransactOpts, destChainSelector uint64, isEnabled bool, maxNumberOfTokensPerMsg uint16, maxDataBytes uint32, maxPerMsgGasLimit uint32, destGasOverhead uint32, destGasPerPayloadByteBase byte, destGasPerPayloadByteHigh byte, destGasPerPayloadByteThreshold uint16, destDataAvailabilityOverheadGas uint32, destGasPerDataAvailabilityByte uint16, destDataAvailabilityMultiplierBps uint16, chainFamilySelector []byte, enforceOutOfOrder bool, defaultTokenFeeUsdCents uint16, defaultTokenDestGasOverhead uint32, defaultTxGasLimit uint32, gasMultiplierWeiPerEth uint64, gasPriceStalenessThreshold uint32, networkFeeUsdCents uint32) (*api.PendingTransaction, error)
 
-	_Encode() FeeQuoterEncoder
+	Encode_() FeeQuoterEncoder
 }
 
 type FeeQuoterEncoder interface {
@@ -181,7 +181,7 @@ type FeeQuoterContract struct {
 
 var _ FeeQuoter = FeeQuoterContract{}
 
-func (c FeeQuoterContract) _Encode() FeeQuoterEncoder {
+func (c FeeQuoterContract) Encode_() FeeQuoterEncoder {
 	return c.feeQuoterEncoder
 }
 

--- a/bindings/ccip/offramp/offramp.go
+++ b/bindings/ccip/offramp/offramp.go
@@ -39,7 +39,7 @@ type Offramp interface {
 	ApplySourceChainConfigUpdates(opts *bind.TransactOpts, sourceChainsSelector []uint64, sourceChainsIsEnabled []bool, sourceChainsIsRMNVerificationDisabled []bool, sourceChainsOnRamp [][]byte) (*api.PendingTransaction, error)
 	SetOcr3Config(opts *bind.TransactOpts, configDigest []byte, ocrPluginType byte, bigF byte, isSignatureVerificationEnabled bool, signers [][]byte, transmitters []aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	// Encode returns the encoder implementation of this module.
+	// Encoder returns the encoder implementation of this module.
 	Encoder() OfframpEncoder
 }
 

--- a/bindings/ccip/offramp/offramp.go
+++ b/bindings/ccip/offramp/offramp.go
@@ -39,7 +39,7 @@ type Offramp interface {
 	ApplySourceChainConfigUpdates(opts *bind.TransactOpts, sourceChainsSelector []uint64, sourceChainsIsEnabled []bool, sourceChainsIsRMNVerificationDisabled []bool, sourceChainsOnRamp [][]byte) (*api.PendingTransaction, error)
 	SetOcr3Config(opts *bind.TransactOpts, configDigest []byte, ocrPluginType byte, bigF byte, isSignatureVerificationEnabled bool, signers [][]byte, transmitters []aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	_Encode() OfframpEncoder
+	Encode_() OfframpEncoder
 }
 
 type OfframpEncoder interface {
@@ -207,7 +207,7 @@ type OfframpContract struct {
 
 var _ Offramp = OfframpContract{}
 
-func (c OfframpContract) _Encode() OfframpEncoder {
+func (c OfframpContract) Encode_() OfframpEncoder {
 	return c.offrampEncoder
 }
 

--- a/bindings/ccip/offramp/offramp.go
+++ b/bindings/ccip/offramp/offramp.go
@@ -39,7 +39,7 @@ type Offramp interface {
 	ApplySourceChainConfigUpdates(opts *bind.TransactOpts, sourceChainsSelector []uint64, sourceChainsIsEnabled []bool, sourceChainsIsRMNVerificationDisabled []bool, sourceChainsOnRamp [][]byte) (*api.PendingTransaction, error)
 	SetOcr3Config(opts *bind.TransactOpts, configDigest []byte, ocrPluginType byte, bigF byte, isSignatureVerificationEnabled bool, signers [][]byte, transmitters []aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	EncodeCall() OfframpEncoder
+	_Encode() OfframpEncoder
 }
 
 type OfframpEncoder interface {
@@ -207,7 +207,7 @@ type OfframpContract struct {
 
 var _ Offramp = OfframpContract{}
 
-func (c OfframpContract) EncodeCall() OfframpEncoder {
+func (c OfframpContract) _Encode() OfframpEncoder {
 	return c.offrampEncoder
 }
 

--- a/bindings/ccip/offramp/offramp.go
+++ b/bindings/ccip/offramp/offramp.go
@@ -38,9 +38,37 @@ type Offramp interface {
 	SetDynamicConfig(opts *bind.TransactOpts, permissionlessExecutionThresholdSecs uint32) (*api.PendingTransaction, error)
 	ApplySourceChainConfigUpdates(opts *bind.TransactOpts, sourceChainsSelector []uint64, sourceChainsIsEnabled []bool, sourceChainsIsRMNVerificationDisabled []bool, sourceChainsOnRamp [][]byte) (*api.PendingTransaction, error)
 	SetOcr3Config(opts *bind.TransactOpts, configDigest []byte, ocrPluginType byte, bigF byte, isSignatureVerificationEnabled bool, signers [][]byte, transmitters []aptos.AccountAddress) (*api.PendingTransaction, error)
+
+	EncodeCall() OfframpEncoder
+}
+
+type OfframpEncoder interface {
+	TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetExecutionState(sourceChainSelector uint64, sequenceNumber uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetLatestPriceSequenceNumber() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetMerkleRoot(root []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetSourceChainConfig(sourceChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetStaticConfig() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetDynamicConfig() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	LatestConfigDetails(ocrPluginType byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Initialize(chainSelector uint64, permissionlessExecutionThresholdSecs uint32, sourceChainsSelector []uint64, sourceChainsIsEnabled []bool, sourceChainsIsRMNVerificationDisabled []bool, sourceChainsOnRamp [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Execute(reportContext [][]byte, report []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ManuallyExecute(reportBytes []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Commit(reportContext [][]byte, report []byte, signatures [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetDynamicConfig(permissionlessExecutionThresholdSecs uint32) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ApplySourceChainConfigUpdates(sourceChainsSelector []uint64, sourceChainsIsEnabled []bool, sourceChainsIsRMNVerificationDisabled []bool, sourceChainsOnRamp [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetOcr3Config(configDigest []byte, ocrPluginType byte, bigF byte, isSignatureVerificationEnabled bool, signers [][]byte, transmitters []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
 const FunctionInfo = `[{"package":"ccip","module":"offramp","name":"apply_source_chain_config_updates","parameters":[{"name":"source_chains_selector","type":"vector\u003cu64\u003e"},{"name":"source_chains_is_enabled","type":"vector\u003cbool\u003e"},{"name":"source_chains_is_rmn_verification_disabled","type":"vector\u003cbool\u003e"},{"name":"source_chains_on_ramp","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"ccip","module":"offramp","name":"commit","parameters":[{"name":"report_context","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"report","type":"vector\u003cu8\u003e"},{"name":"signatures","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"ccip","module":"offramp","name":"execute","parameters":[{"name":"report_context","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"report","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"offramp","name":"initialize","parameters":[{"name":"chain_selector","type":"u64"},{"name":"permissionless_execution_threshold_secs","type":"u32"},{"name":"source_chains_selector","type":"vector\u003cu64\u003e"},{"name":"source_chains_is_enabled","type":"vector\u003cbool\u003e"},{"name":"source_chains_is_rmn_verification_disabled","type":"vector\u003cbool\u003e"},{"name":"source_chains_on_ramp","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"ccip","module":"offramp","name":"manually_execute","parameters":[{"name":"report_bytes","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"offramp","name":"set_dynamic_config","parameters":[{"name":"permissionless_execution_threshold_secs","type":"u32"}]},{"package":"ccip","module":"offramp","name":"set_ocr3_config","parameters":[{"name":"config_digest","type":"vector\u003cu8\u003e"},{"name":"ocr_plugin_type","type":"u8"},{"name":"big_f","type":"u8"},{"name":"is_signature_verification_enabled","type":"bool"},{"name":"signers","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"transmitters","type":"vector\u003caddress\u003e"}]}]`
+
+func NewOfframp(address aptos.AccountAddress, client aptos.AptosRpcClient) Offramp {
+	contract := bind.NewBoundContract(address, "ccip", "offramp", client)
+	return OfframpContract{
+		BoundContract:  contract,
+		offrampEncoder: offrampEncoder{BoundContract: contract},
+	}
+}
 
 // Structs
 
@@ -173,22 +201,20 @@ type McmsCallback struct {
 }
 
 type OfframpContract struct {
-	OfframpCaller
-	OfframpTransactor
+	*bind.BoundContract
+	offrampEncoder
+}
+
+var _ Offramp = OfframpContract{}
+
+func (c OfframpContract) EncodeCall() OfframpEncoder {
+	return c.offrampEncoder
 }
 
 // View Functions
 
-type OfframpCaller struct {
-	*bind.BoundContract
-}
-
-func (c OfframpCaller) EncodeTypeAndVersion() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
-}
-
-func (c OfframpCaller) TypeAndVersion(opts *bind.CallOpts) (string, error) {
-	module, function, typeTags, args, err := c.EncodeTypeAndVersion()
+func (c OfframpContract) TypeAndVersion(opts *bind.CallOpts) (string, error) {
+	module, function, typeTags, args, err := c.offrampEncoder.TypeAndVersion()
 	if err != nil {
 		return *new(string), err
 	}
@@ -208,18 +234,8 @@ func (c OfframpCaller) TypeAndVersion(opts *bind.CallOpts) (string, error) {
 	return r0, nil
 }
 
-func (c OfframpCaller) EncodeGetExecutionState(sourceChainSelector uint64, sequenceNumber uint64) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_execution_state", nil, []string{
-		"u64",
-		"u64",
-	}, []any{
-		sourceChainSelector,
-		sequenceNumber,
-	})
-}
-
-func (c OfframpCaller) GetExecutionState(opts *bind.CallOpts, sourceChainSelector uint64, sequenceNumber uint64) (byte, error) {
-	module, function, typeTags, args, err := c.EncodeGetExecutionState(sourceChainSelector, sequenceNumber)
+func (c OfframpContract) GetExecutionState(opts *bind.CallOpts, sourceChainSelector uint64, sequenceNumber uint64) (byte, error) {
+	module, function, typeTags, args, err := c.offrampEncoder.GetExecutionState(sourceChainSelector, sequenceNumber)
 	if err != nil {
 		return *new(byte), err
 	}
@@ -239,12 +255,8 @@ func (c OfframpCaller) GetExecutionState(opts *bind.CallOpts, sourceChainSelecto
 	return r0, nil
 }
 
-func (c OfframpCaller) EncodeGetLatestPriceSequenceNumber() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_latest_price_sequence_number", nil, []string{}, []any{})
-}
-
-func (c OfframpCaller) GetLatestPriceSequenceNumber(opts *bind.CallOpts) (uint64, error) {
-	module, function, typeTags, args, err := c.EncodeGetLatestPriceSequenceNumber()
+func (c OfframpContract) GetLatestPriceSequenceNumber(opts *bind.CallOpts) (uint64, error) {
+	module, function, typeTags, args, err := c.offrampEncoder.GetLatestPriceSequenceNumber()
 	if err != nil {
 		return *new(uint64), err
 	}
@@ -264,16 +276,8 @@ func (c OfframpCaller) GetLatestPriceSequenceNumber(opts *bind.CallOpts) (uint64
 	return r0, nil
 }
 
-func (c OfframpCaller) EncodeGetMerkleRoot(root []byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_merkle_root", nil, []string{
-		"vector<u8>",
-	}, []any{
-		root,
-	})
-}
-
-func (c OfframpCaller) GetMerkleRoot(opts *bind.CallOpts, root []byte) (uint64, error) {
-	module, function, typeTags, args, err := c.EncodeGetMerkleRoot(root)
+func (c OfframpContract) GetMerkleRoot(opts *bind.CallOpts, root []byte) (uint64, error) {
+	module, function, typeTags, args, err := c.offrampEncoder.GetMerkleRoot(root)
 	if err != nil {
 		return *new(uint64), err
 	}
@@ -293,16 +297,8 @@ func (c OfframpCaller) GetMerkleRoot(opts *bind.CallOpts, root []byte) (uint64, 
 	return r0, nil
 }
 
-func (c OfframpCaller) EncodeGetSourceChainConfig(sourceChainSelector uint64) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_source_chain_config", nil, []string{
-		"u64",
-	}, []any{
-		sourceChainSelector,
-	})
-}
-
-func (c OfframpCaller) GetSourceChainConfig(opts *bind.CallOpts, sourceChainSelector uint64) (SourceChainConfig, error) {
-	module, function, typeTags, args, err := c.EncodeGetSourceChainConfig(sourceChainSelector)
+func (c OfframpContract) GetSourceChainConfig(opts *bind.CallOpts, sourceChainSelector uint64) (SourceChainConfig, error) {
+	module, function, typeTags, args, err := c.offrampEncoder.GetSourceChainConfig(sourceChainSelector)
 	if err != nil {
 		return *new(SourceChainConfig), err
 	}
@@ -322,12 +318,8 @@ func (c OfframpCaller) GetSourceChainConfig(opts *bind.CallOpts, sourceChainSele
 	return r0, nil
 }
 
-func (c OfframpCaller) EncodeGetStaticConfig() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_static_config", nil, []string{}, []any{})
-}
-
-func (c OfframpCaller) GetStaticConfig(opts *bind.CallOpts) (StaticConfig, error) {
-	module, function, typeTags, args, err := c.EncodeGetStaticConfig()
+func (c OfframpContract) GetStaticConfig(opts *bind.CallOpts) (StaticConfig, error) {
+	module, function, typeTags, args, err := c.offrampEncoder.GetStaticConfig()
 	if err != nil {
 		return *new(StaticConfig), err
 	}
@@ -347,12 +339,8 @@ func (c OfframpCaller) GetStaticConfig(opts *bind.CallOpts) (StaticConfig, error
 	return r0, nil
 }
 
-func (c OfframpCaller) EncodeGetDynamicConfig() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_dynamic_config", nil, []string{}, []any{})
-}
-
-func (c OfframpCaller) GetDynamicConfig(opts *bind.CallOpts) (DynamicConfig, error) {
-	module, function, typeTags, args, err := c.EncodeGetDynamicConfig()
+func (c OfframpContract) GetDynamicConfig(opts *bind.CallOpts) (DynamicConfig, error) {
+	module, function, typeTags, args, err := c.offrampEncoder.GetDynamicConfig()
 	if err != nil {
 		return *new(DynamicConfig), err
 	}
@@ -372,16 +360,8 @@ func (c OfframpCaller) GetDynamicConfig(opts *bind.CallOpts) (DynamicConfig, err
 	return r0, nil
 }
 
-func (c OfframpCaller) EncodeLatestConfigDetails(ocrPluginType byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("latest_config_details", nil, []string{
-		"u8",
-	}, []any{
-		ocrPluginType,
-	})
-}
-
-func (c OfframpCaller) LatestConfigDetails(opts *bind.CallOpts, ocrPluginType byte) ([]byte, byte, byte, bool, [][]byte, []aptos.AccountAddress, error) {
-	module, function, typeTags, args, err := c.EncodeLatestConfigDetails(ocrPluginType)
+func (c OfframpContract) LatestConfigDetails(opts *bind.CallOpts, ocrPluginType byte) ([]byte, byte, byte, bool, [][]byte, []aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.offrampEncoder.LatestConfigDetails(ocrPluginType)
 	if err != nil {
 		return *new([]byte), *new(byte), *new(byte), *new(bool), *new([][]byte), *new([]aptos.AccountAddress), err
 	}
@@ -408,11 +388,125 @@ func (c OfframpCaller) LatestConfigDetails(opts *bind.CallOpts, ocrPluginType by
 
 // Entry Functions
 
-type OfframpTransactor struct {
+func (c OfframpContract) Initialize(opts *bind.TransactOpts, chainSelector uint64, permissionlessExecutionThresholdSecs uint32, sourceChainsSelector []uint64, sourceChainsIsEnabled []bool, sourceChainsIsRMNVerificationDisabled []bool, sourceChainsOnRamp [][]byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.offrampEncoder.Initialize(chainSelector, permissionlessExecutionThresholdSecs, sourceChainsSelector, sourceChainsIsEnabled, sourceChainsIsRMNVerificationDisabled, sourceChainsOnRamp)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c OfframpContract) Execute(opts *bind.TransactOpts, reportContext [][]byte, report []byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.offrampEncoder.Execute(reportContext, report)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c OfframpContract) ManuallyExecute(opts *bind.TransactOpts, reportBytes []byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.offrampEncoder.ManuallyExecute(reportBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c OfframpContract) Commit(opts *bind.TransactOpts, reportContext [][]byte, report []byte, signatures [][]byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.offrampEncoder.Commit(reportContext, report, signatures)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c OfframpContract) SetDynamicConfig(opts *bind.TransactOpts, permissionlessExecutionThresholdSecs uint32) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.offrampEncoder.SetDynamicConfig(permissionlessExecutionThresholdSecs)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c OfframpContract) ApplySourceChainConfigUpdates(opts *bind.TransactOpts, sourceChainsSelector []uint64, sourceChainsIsEnabled []bool, sourceChainsIsRMNVerificationDisabled []bool, sourceChainsOnRamp [][]byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.offrampEncoder.ApplySourceChainConfigUpdates(sourceChainsSelector, sourceChainsIsEnabled, sourceChainsIsRMNVerificationDisabled, sourceChainsOnRamp)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c OfframpContract) SetOcr3Config(opts *bind.TransactOpts, configDigest []byte, ocrPluginType byte, bigF byte, isSignatureVerificationEnabled bool, signers [][]byte, transmitters []aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.offrampEncoder.SetOcr3Config(configDigest, ocrPluginType, bigF, isSignatureVerificationEnabled, signers, transmitters)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+// Encoder
+type offrampEncoder struct {
 	*bind.BoundContract
 }
 
-func (c OfframpTransactor) EncodeInitialize(chainSelector uint64, permissionlessExecutionThresholdSecs uint32, sourceChainsSelector []uint64, sourceChainsIsEnabled []bool, sourceChainsIsRMNVerificationDisabled []bool, sourceChainsOnRamp [][]byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c offrampEncoder) TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
+}
+
+func (c offrampEncoder) GetExecutionState(sourceChainSelector uint64, sequenceNumber uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_execution_state", nil, []string{
+		"u64",
+		"u64",
+	}, []any{
+		sourceChainSelector,
+		sequenceNumber,
+	})
+}
+
+func (c offrampEncoder) GetLatestPriceSequenceNumber() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_latest_price_sequence_number", nil, []string{}, []any{})
+}
+
+func (c offrampEncoder) GetMerkleRoot(root []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_merkle_root", nil, []string{
+		"vector<u8>",
+	}, []any{
+		root,
+	})
+}
+
+func (c offrampEncoder) GetSourceChainConfig(sourceChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_source_chain_config", nil, []string{
+		"u64",
+	}, []any{
+		sourceChainSelector,
+	})
+}
+
+func (c offrampEncoder) GetStaticConfig() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_static_config", nil, []string{}, []any{})
+}
+
+func (c offrampEncoder) GetDynamicConfig() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_dynamic_config", nil, []string{}, []any{})
+}
+
+func (c offrampEncoder) LatestConfigDetails(ocrPluginType byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("latest_config_details", nil, []string{
+		"u8",
+	}, []any{
+		ocrPluginType,
+	})
+}
+
+func (c offrampEncoder) Initialize(chainSelector uint64, permissionlessExecutionThresholdSecs uint32, sourceChainsSelector []uint64, sourceChainsIsEnabled []bool, sourceChainsIsRMNVerificationDisabled []bool, sourceChainsOnRamp [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("initialize", nil, []string{
 		"u64",
 		"u32",
@@ -430,16 +524,7 @@ func (c OfframpTransactor) EncodeInitialize(chainSelector uint64, permissionless
 	})
 }
 
-func (c OfframpTransactor) Initialize(opts *bind.TransactOpts, chainSelector uint64, permissionlessExecutionThresholdSecs uint32, sourceChainsSelector []uint64, sourceChainsIsEnabled []bool, sourceChainsIsRMNVerificationDisabled []bool, sourceChainsOnRamp [][]byte) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeInitialize(chainSelector, permissionlessExecutionThresholdSecs, sourceChainsSelector, sourceChainsIsEnabled, sourceChainsIsRMNVerificationDisabled, sourceChainsOnRamp)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c OfframpTransactor) EncodeExecute(reportContext [][]byte, report []byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c offrampEncoder) Execute(reportContext [][]byte, report []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("execute", nil, []string{
 		"vector<vector<u8>>",
 		"vector<u8>",
@@ -449,16 +534,7 @@ func (c OfframpTransactor) EncodeExecute(reportContext [][]byte, report []byte) 
 	})
 }
 
-func (c OfframpTransactor) Execute(opts *bind.TransactOpts, reportContext [][]byte, report []byte) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeExecute(reportContext, report)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c OfframpTransactor) EncodeManuallyExecute(reportBytes []byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c offrampEncoder) ManuallyExecute(reportBytes []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("manually_execute", nil, []string{
 		"vector<u8>",
 	}, []any{
@@ -466,16 +542,7 @@ func (c OfframpTransactor) EncodeManuallyExecute(reportBytes []byte) (aptos.Modu
 	})
 }
 
-func (c OfframpTransactor) ManuallyExecute(opts *bind.TransactOpts, reportBytes []byte) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeManuallyExecute(reportBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c OfframpTransactor) EncodeCommit(reportContext [][]byte, report []byte, signatures [][]byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c offrampEncoder) Commit(reportContext [][]byte, report []byte, signatures [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("commit", nil, []string{
 		"vector<vector<u8>>",
 		"vector<u8>",
@@ -487,16 +554,7 @@ func (c OfframpTransactor) EncodeCommit(reportContext [][]byte, report []byte, s
 	})
 }
 
-func (c OfframpTransactor) Commit(opts *bind.TransactOpts, reportContext [][]byte, report []byte, signatures [][]byte) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeCommit(reportContext, report, signatures)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c OfframpTransactor) EncodeSetDynamicConfig(permissionlessExecutionThresholdSecs uint32) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c offrampEncoder) SetDynamicConfig(permissionlessExecutionThresholdSecs uint32) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("set_dynamic_config", nil, []string{
 		"u32",
 	}, []any{
@@ -504,16 +562,7 @@ func (c OfframpTransactor) EncodeSetDynamicConfig(permissionlessExecutionThresho
 	})
 }
 
-func (c OfframpTransactor) SetDynamicConfig(opts *bind.TransactOpts, permissionlessExecutionThresholdSecs uint32) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeSetDynamicConfig(permissionlessExecutionThresholdSecs)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c OfframpTransactor) EncodeApplySourceChainConfigUpdates(sourceChainsSelector []uint64, sourceChainsIsEnabled []bool, sourceChainsIsRMNVerificationDisabled []bool, sourceChainsOnRamp [][]byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c offrampEncoder) ApplySourceChainConfigUpdates(sourceChainsSelector []uint64, sourceChainsIsEnabled []bool, sourceChainsIsRMNVerificationDisabled []bool, sourceChainsOnRamp [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("apply_source_chain_config_updates", nil, []string{
 		"vector<u64>",
 		"vector<bool>",
@@ -527,16 +576,7 @@ func (c OfframpTransactor) EncodeApplySourceChainConfigUpdates(sourceChainsSelec
 	})
 }
 
-func (c OfframpTransactor) ApplySourceChainConfigUpdates(opts *bind.TransactOpts, sourceChainsSelector []uint64, sourceChainsIsEnabled []bool, sourceChainsIsRMNVerificationDisabled []bool, sourceChainsOnRamp [][]byte) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeApplySourceChainConfigUpdates(sourceChainsSelector, sourceChainsIsEnabled, sourceChainsIsRMNVerificationDisabled, sourceChainsOnRamp)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c OfframpTransactor) EncodeSetOcr3Config(configDigest []byte, ocrPluginType byte, bigF byte, isSignatureVerificationEnabled bool, signers [][]byte, transmitters []aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c offrampEncoder) SetOcr3Config(configDigest []byte, ocrPluginType byte, bigF byte, isSignatureVerificationEnabled bool, signers [][]byte, transmitters []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("set_ocr3_config", nil, []string{
 		"vector<u8>",
 		"u8",
@@ -552,13 +592,4 @@ func (c OfframpTransactor) EncodeSetOcr3Config(configDigest []byte, ocrPluginTyp
 		signers,
 		transmitters,
 	})
-}
-
-func (c OfframpTransactor) SetOcr3Config(opts *bind.TransactOpts, configDigest []byte, ocrPluginType byte, bigF byte, isSignatureVerificationEnabled bool, signers [][]byte, transmitters []aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeSetOcr3Config(configDigest, ocrPluginType, bigF, isSignatureVerificationEnabled, signers, transmitters)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
 }

--- a/bindings/ccip/offramp/offramp.go
+++ b/bindings/ccip/offramp/offramp.go
@@ -39,7 +39,8 @@ type Offramp interface {
 	ApplySourceChainConfigUpdates(opts *bind.TransactOpts, sourceChainsSelector []uint64, sourceChainsIsEnabled []bool, sourceChainsIsRMNVerificationDisabled []bool, sourceChainsOnRamp [][]byte) (*api.PendingTransaction, error)
 	SetOcr3Config(opts *bind.TransactOpts, configDigest []byte, ocrPluginType byte, bigF byte, isSignatureVerificationEnabled bool, signers [][]byte, transmitters []aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	Encode_() OfframpEncoder
+	// Encode returns the encoder implementation of this module.
+	Encoder() OfframpEncoder
 }
 
 type OfframpEncoder interface {
@@ -207,7 +208,7 @@ type OfframpContract struct {
 
 var _ Offramp = OfframpContract{}
 
-func (c OfframpContract) Encode_() OfframpEncoder {
+func (c OfframpContract) Encoder() OfframpEncoder {
 	return c.offrampEncoder
 }
 

--- a/bindings/ccip/offramp/offramp.go
+++ b/bindings/ccip/offramp/offramp.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type OfframpInterface interface {
+type Offramp interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 	GetExecutionState(opts *bind.CallOpts, sourceChainSelector uint64, sequenceNumber uint64) (byte, error)
 	GetLatestPriceSequenceNumber(opts *bind.CallOpts) (uint64, error)
@@ -172,7 +172,7 @@ type SkippedReportExecution struct {
 type McmsCallback struct {
 }
 
-type Offramp struct {
+type OfframpContract struct {
 	OfframpCaller
 	OfframpTransactor
 }

--- a/bindings/ccip/onramp/onramp.go
+++ b/bindings/ccip/onramp/onramp.go
@@ -36,9 +36,36 @@ type Onramp interface {
 	SetDynamicConfig(opts *bind.TransactOpts, allowlistAdmin aptos.AccountAddress) (*api.PendingTransaction, error)
 	ApplyDestChainConfigUpdates(opts *bind.TransactOpts, destChainSelectors []uint64, destChainEnabled []bool, destChainAllowlistEnabled []bool) (*api.PendingTransaction, error)
 	ApplyAllowlistUpdates(opts *bind.TransactOpts, destChainSelectors []uint64, destChainAllowlistEnabled []bool, destChainAddAllowedSenders [][]aptos.AccountAddress, destChainRemoveAllowedSenders [][]aptos.AccountAddress) (*api.PendingTransaction, error)
+
+	EncodeCall() OnrampEncoder
+}
+
+type OnrampEncoder interface {
+	TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	IsChainSupported(destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetExpectedNextSequenceNumber(destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetFee(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetDestChainConfig(destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetAllowedSendersList(destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetOutboundNonce(destChainSelector uint64, sender aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetStaticConfig() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetDynamicConfig() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Initialize(chainSelector uint64, allowlistAdmin aptos.AccountAddress, destChainSelectors []uint64, destChainEnabled []bool, destChainAllowlistEnabled []bool) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetDynamicConfig(allowlistAdmin aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ApplyDestChainConfigUpdates(destChainSelectors []uint64, destChainEnabled []bool, destChainAllowlistEnabled []bool) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ApplyAllowlistUpdates(destChainSelectors []uint64, destChainAllowlistEnabled []bool, destChainAddAllowedSenders [][]aptos.AccountAddress, destChainRemoveAllowedSenders [][]aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	CCIPSend(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
 const FunctionInfo = `[{"package":"ccip","module":"onramp","name":"apply_allowlist_updates","parameters":[{"name":"dest_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"dest_chain_allowlist_enabled","type":"vector\u003cbool\u003e"},{"name":"dest_chain_add_allowed_senders","type":"vector\u003cvector\u003caddress\u003e\u003e"},{"name":"dest_chain_remove_allowed_senders","type":"vector\u003cvector\u003caddress\u003e\u003e"}]},{"package":"ccip","module":"onramp","name":"apply_dest_chain_config_updates","parameters":[{"name":"dest_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"dest_chain_enabled","type":"vector\u003cbool\u003e"},{"name":"dest_chain_allowlist_enabled","type":"vector\u003cbool\u003e"}]},{"package":"ccip","module":"onramp","name":"ccip_send","parameters":[{"name":"dest_chain_selector","type":"u64"},{"name":"receiver","type":"vector\u003cu8\u003e"},{"name":"data","type":"vector\u003cu8\u003e"},{"name":"token_addresses","type":"vector\u003caddress\u003e"},{"name":"token_amounts","type":"vector\u003cu64\u003e"},{"name":"token_store_addresses","type":"vector\u003caddress\u003e"},{"name":"fee_token","type":"address"},{"name":"fee_token_store","type":"address"},{"name":"extra_args","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"onramp","name":"initialize","parameters":[{"name":"chain_selector","type":"u64"},{"name":"allowlist_admin","type":"address"},{"name":"dest_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"dest_chain_enabled","type":"vector\u003cbool\u003e"},{"name":"dest_chain_allowlist_enabled","type":"vector\u003cbool\u003e"}]},{"package":"ccip","module":"onramp","name":"set_dynamic_config","parameters":[{"name":"allowlist_admin","type":"address"}]}]`
+
+func NewOnramp(address aptos.AccountAddress, client aptos.AptosRpcClient) Onramp {
+	contract := bind.NewBoundContract(address, "ccip", "onramp", client)
+	return OnrampContract{
+		BoundContract: contract,
+		onrampEncoder: onrampEncoder{BoundContract: contract},
+	}
+}
 
 // Structs
 
@@ -122,22 +149,20 @@ type McmsCallback struct {
 }
 
 type OnrampContract struct {
-	OnrampCaller
-	OnrampTransactor
+	*bind.BoundContract
+	onrampEncoder
+}
+
+var _ Onramp = OnrampContract{}
+
+func (c OnrampContract) EncodeCall() OnrampEncoder {
+	return c.onrampEncoder
 }
 
 // View Functions
 
-type OnrampCaller struct {
-	*bind.BoundContract
-}
-
-func (c OnrampCaller) EncodeTypeAndVersion() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
-}
-
-func (c OnrampCaller) TypeAndVersion(opts *bind.CallOpts) (string, error) {
-	module, function, typeTags, args, err := c.EncodeTypeAndVersion()
+func (c OnrampContract) TypeAndVersion(opts *bind.CallOpts) (string, error) {
+	module, function, typeTags, args, err := c.onrampEncoder.TypeAndVersion()
 	if err != nil {
 		return *new(string), err
 	}
@@ -157,16 +182,8 @@ func (c OnrampCaller) TypeAndVersion(opts *bind.CallOpts) (string, error) {
 	return r0, nil
 }
 
-func (c OnrampCaller) EncodeIsChainSupported(destChainSelector uint64) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("is_chain_supported", nil, []string{
-		"u64",
-	}, []any{
-		destChainSelector,
-	})
-}
-
-func (c OnrampCaller) IsChainSupported(opts *bind.CallOpts, destChainSelector uint64) (bool, error) {
-	module, function, typeTags, args, err := c.EncodeIsChainSupported(destChainSelector)
+func (c OnrampContract) IsChainSupported(opts *bind.CallOpts, destChainSelector uint64) (bool, error) {
+	module, function, typeTags, args, err := c.onrampEncoder.IsChainSupported(destChainSelector)
 	if err != nil {
 		return *new(bool), err
 	}
@@ -186,16 +203,8 @@ func (c OnrampCaller) IsChainSupported(opts *bind.CallOpts, destChainSelector ui
 	return r0, nil
 }
 
-func (c OnrampCaller) EncodeGetExpectedNextSequenceNumber(destChainSelector uint64) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_expected_next_sequence_number", nil, []string{
-		"u64",
-	}, []any{
-		destChainSelector,
-	})
-}
-
-func (c OnrampCaller) GetExpectedNextSequenceNumber(opts *bind.CallOpts, destChainSelector uint64) (uint64, error) {
-	module, function, typeTags, args, err := c.EncodeGetExpectedNextSequenceNumber(destChainSelector)
+func (c OnrampContract) GetExpectedNextSequenceNumber(opts *bind.CallOpts, destChainSelector uint64) (uint64, error) {
+	module, function, typeTags, args, err := c.onrampEncoder.GetExpectedNextSequenceNumber(destChainSelector)
 	if err != nil {
 		return *new(uint64), err
 	}
@@ -215,7 +224,199 @@ func (c OnrampCaller) GetExpectedNextSequenceNumber(opts *bind.CallOpts, destCha
 	return r0, nil
 }
 
-func (c OnrampCaller) EncodeGetFee(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c OnrampContract) GetFee(opts *bind.CallOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (uint64, error) {
+	module, function, typeTags, args, err := c.onrampEncoder.GetFee(destChainSelector, receiver, data, tokenAddresses, tokenAmounts, tokenStoreAddresses, feeToken, feeTokenStore, extraArgs)
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	var (
+		r0 uint64
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(uint64), err
+	}
+	return r0, nil
+}
+
+func (c OnrampContract) GetDestChainConfig(opts *bind.CallOpts, destChainSelector uint64) (bool, uint64, bool, error) {
+	module, function, typeTags, args, err := c.onrampEncoder.GetDestChainConfig(destChainSelector)
+	if err != nil {
+		return *new(bool), *new(uint64), *new(bool), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(bool), *new(uint64), *new(bool), err
+	}
+
+	var (
+		r0 bool
+		r1 uint64
+		r2 bool
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0, &r1, &r2); err != nil {
+		return *new(bool), *new(uint64), *new(bool), err
+	}
+	return r0, r1, r2, nil
+}
+
+func (c OnrampContract) GetAllowedSendersList(opts *bind.CallOpts, destChainSelector uint64) (bool, []aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.onrampEncoder.GetAllowedSendersList(destChainSelector)
+	if err != nil {
+		return *new(bool), *new([]aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(bool), *new([]aptos.AccountAddress), err
+	}
+
+	var (
+		r0 bool
+		r1 []aptos.AccountAddress
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0, &r1); err != nil {
+		return *new(bool), *new([]aptos.AccountAddress), err
+	}
+	return r0, r1, nil
+}
+
+func (c OnrampContract) GetOutboundNonce(opts *bind.CallOpts, destChainSelector uint64, sender aptos.AccountAddress) (uint64, error) {
+	module, function, typeTags, args, err := c.onrampEncoder.GetOutboundNonce(destChainSelector, sender)
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	var (
+		r0 uint64
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(uint64), err
+	}
+	return r0, nil
+}
+
+func (c OnrampContract) GetStaticConfig(opts *bind.CallOpts) (StaticConfig, error) {
+	module, function, typeTags, args, err := c.onrampEncoder.GetStaticConfig()
+	if err != nil {
+		return *new(StaticConfig), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(StaticConfig), err
+	}
+
+	var (
+		r0 StaticConfig
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(StaticConfig), err
+	}
+	return r0, nil
+}
+
+func (c OnrampContract) GetDynamicConfig(opts *bind.CallOpts) (DynamicConfig, error) {
+	module, function, typeTags, args, err := c.onrampEncoder.GetDynamicConfig()
+	if err != nil {
+		return *new(DynamicConfig), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(DynamicConfig), err
+	}
+
+	var (
+		r0 DynamicConfig
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(DynamicConfig), err
+	}
+	return r0, nil
+}
+
+// Entry Functions
+
+func (c OnrampContract) Initialize(opts *bind.TransactOpts, chainSelector uint64, allowlistAdmin aptos.AccountAddress, destChainSelectors []uint64, destChainEnabled []bool, destChainAllowlistEnabled []bool) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.onrampEncoder.Initialize(chainSelector, allowlistAdmin, destChainSelectors, destChainEnabled, destChainAllowlistEnabled)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c OnrampContract) SetDynamicConfig(opts *bind.TransactOpts, allowlistAdmin aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.onrampEncoder.SetDynamicConfig(allowlistAdmin)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c OnrampContract) ApplyDestChainConfigUpdates(opts *bind.TransactOpts, destChainSelectors []uint64, destChainEnabled []bool, destChainAllowlistEnabled []bool) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.onrampEncoder.ApplyDestChainConfigUpdates(destChainSelectors, destChainEnabled, destChainAllowlistEnabled)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c OnrampContract) ApplyAllowlistUpdates(opts *bind.TransactOpts, destChainSelectors []uint64, destChainAllowlistEnabled []bool, destChainAddAllowedSenders [][]aptos.AccountAddress, destChainRemoveAllowedSenders [][]aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.onrampEncoder.ApplyAllowlistUpdates(destChainSelectors, destChainAllowlistEnabled, destChainAddAllowedSenders, destChainRemoveAllowedSenders)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+// Encoder
+type onrampEncoder struct {
+	*bind.BoundContract
+}
+
+func (c onrampEncoder) TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
+}
+
+func (c onrampEncoder) IsChainSupported(destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("is_chain_supported", nil, []string{
+		"u64",
+	}, []any{
+		destChainSelector,
+	})
+}
+
+func (c onrampEncoder) GetExpectedNextSequenceNumber(destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_expected_next_sequence_number", nil, []string{
+		"u64",
+	}, []any{
+		destChainSelector,
+	})
+}
+
+func (c onrampEncoder) GetFee(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("get_fee", nil, []string{
 		"u64",
 		"vector<u8>",
@@ -239,28 +440,7 @@ func (c OnrampCaller) EncodeGetFee(destChainSelector uint64, receiver []byte, da
 	})
 }
 
-func (c OnrampCaller) GetFee(opts *bind.CallOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (uint64, error) {
-	module, function, typeTags, args, err := c.EncodeGetFee(destChainSelector, receiver, data, tokenAddresses, tokenAmounts, tokenStoreAddresses, feeToken, feeTokenStore, extraArgs)
-	if err != nil {
-		return *new(uint64), err
-	}
-
-	callData, err := c.Call(opts, module, function, typeTags, args)
-	if err != nil {
-		return *new(uint64), err
-	}
-
-	var (
-		r0 uint64
-	)
-
-	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
-		return *new(uint64), err
-	}
-	return r0, nil
-}
-
-func (c OnrampCaller) EncodeGetDestChainConfig(destChainSelector uint64) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c onrampEncoder) GetDestChainConfig(destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("get_dest_chain_config", nil, []string{
 		"u64",
 	}, []any{
@@ -268,30 +448,7 @@ func (c OnrampCaller) EncodeGetDestChainConfig(destChainSelector uint64) (aptos.
 	})
 }
 
-func (c OnrampCaller) GetDestChainConfig(opts *bind.CallOpts, destChainSelector uint64) (bool, uint64, bool, error) {
-	module, function, typeTags, args, err := c.EncodeGetDestChainConfig(destChainSelector)
-	if err != nil {
-		return *new(bool), *new(uint64), *new(bool), err
-	}
-
-	callData, err := c.Call(opts, module, function, typeTags, args)
-	if err != nil {
-		return *new(bool), *new(uint64), *new(bool), err
-	}
-
-	var (
-		r0 bool
-		r1 uint64
-		r2 bool
-	)
-
-	if err := codec.DecodeAptosJsonArray(callData, &r0, &r1, &r2); err != nil {
-		return *new(bool), *new(uint64), *new(bool), err
-	}
-	return r0, r1, r2, nil
-}
-
-func (c OnrampCaller) EncodeGetAllowedSendersList(destChainSelector uint64) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c onrampEncoder) GetAllowedSendersList(destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("get_allowed_senders_list", nil, []string{
 		"u64",
 	}, []any{
@@ -299,29 +456,7 @@ func (c OnrampCaller) EncodeGetAllowedSendersList(destChainSelector uint64) (apt
 	})
 }
 
-func (c OnrampCaller) GetAllowedSendersList(opts *bind.CallOpts, destChainSelector uint64) (bool, []aptos.AccountAddress, error) {
-	module, function, typeTags, args, err := c.EncodeGetAllowedSendersList(destChainSelector)
-	if err != nil {
-		return *new(bool), *new([]aptos.AccountAddress), err
-	}
-
-	callData, err := c.Call(opts, module, function, typeTags, args)
-	if err != nil {
-		return *new(bool), *new([]aptos.AccountAddress), err
-	}
-
-	var (
-		r0 bool
-		r1 []aptos.AccountAddress
-	)
-
-	if err := codec.DecodeAptosJsonArray(callData, &r0, &r1); err != nil {
-		return *new(bool), *new([]aptos.AccountAddress), err
-	}
-	return r0, r1, nil
-}
-
-func (c OnrampCaller) EncodeGetOutboundNonce(destChainSelector uint64, sender aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c onrampEncoder) GetOutboundNonce(destChainSelector uint64, sender aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("get_outbound_nonce", nil, []string{
 		"u64",
 		"address",
@@ -331,84 +466,15 @@ func (c OnrampCaller) EncodeGetOutboundNonce(destChainSelector uint64, sender ap
 	})
 }
 
-func (c OnrampCaller) GetOutboundNonce(opts *bind.CallOpts, destChainSelector uint64, sender aptos.AccountAddress) (uint64, error) {
-	module, function, typeTags, args, err := c.EncodeGetOutboundNonce(destChainSelector, sender)
-	if err != nil {
-		return *new(uint64), err
-	}
-
-	callData, err := c.Call(opts, module, function, typeTags, args)
-	if err != nil {
-		return *new(uint64), err
-	}
-
-	var (
-		r0 uint64
-	)
-
-	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
-		return *new(uint64), err
-	}
-	return r0, nil
-}
-
-func (c OnrampCaller) EncodeGetStaticConfig() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c onrampEncoder) GetStaticConfig() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("get_static_config", nil, []string{}, []any{})
 }
 
-func (c OnrampCaller) GetStaticConfig(opts *bind.CallOpts) (StaticConfig, error) {
-	module, function, typeTags, args, err := c.EncodeGetStaticConfig()
-	if err != nil {
-		return *new(StaticConfig), err
-	}
-
-	callData, err := c.Call(opts, module, function, typeTags, args)
-	if err != nil {
-		return *new(StaticConfig), err
-	}
-
-	var (
-		r0 StaticConfig
-	)
-
-	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
-		return *new(StaticConfig), err
-	}
-	return r0, nil
-}
-
-func (c OnrampCaller) EncodeGetDynamicConfig() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c onrampEncoder) GetDynamicConfig() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("get_dynamic_config", nil, []string{}, []any{})
 }
 
-func (c OnrampCaller) GetDynamicConfig(opts *bind.CallOpts) (DynamicConfig, error) {
-	module, function, typeTags, args, err := c.EncodeGetDynamicConfig()
-	if err != nil {
-		return *new(DynamicConfig), err
-	}
-
-	callData, err := c.Call(opts, module, function, typeTags, args)
-	if err != nil {
-		return *new(DynamicConfig), err
-	}
-
-	var (
-		r0 DynamicConfig
-	)
-
-	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
-		return *new(DynamicConfig), err
-	}
-	return r0, nil
-}
-
-// Entry Functions
-
-type OnrampTransactor struct {
-	*bind.BoundContract
-}
-
-func (c OnrampTransactor) EncodeInitialize(chainSelector uint64, allowlistAdmin aptos.AccountAddress, destChainSelectors []uint64, destChainEnabled []bool, destChainAllowlistEnabled []bool) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c onrampEncoder) Initialize(chainSelector uint64, allowlistAdmin aptos.AccountAddress, destChainSelectors []uint64, destChainEnabled []bool, destChainAllowlistEnabled []bool) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("initialize", nil, []string{
 		"u64",
 		"address",
@@ -424,16 +490,7 @@ func (c OnrampTransactor) EncodeInitialize(chainSelector uint64, allowlistAdmin 
 	})
 }
 
-func (c OnrampTransactor) Initialize(opts *bind.TransactOpts, chainSelector uint64, allowlistAdmin aptos.AccountAddress, destChainSelectors []uint64, destChainEnabled []bool, destChainAllowlistEnabled []bool) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeInitialize(chainSelector, allowlistAdmin, destChainSelectors, destChainEnabled, destChainAllowlistEnabled)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c OnrampTransactor) EncodeSetDynamicConfig(allowlistAdmin aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c onrampEncoder) SetDynamicConfig(allowlistAdmin aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("set_dynamic_config", nil, []string{
 		"address",
 	}, []any{
@@ -441,16 +498,7 @@ func (c OnrampTransactor) EncodeSetDynamicConfig(allowlistAdmin aptos.AccountAdd
 	})
 }
 
-func (c OnrampTransactor) SetDynamicConfig(opts *bind.TransactOpts, allowlistAdmin aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeSetDynamicConfig(allowlistAdmin)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c OnrampTransactor) EncodeApplyDestChainConfigUpdates(destChainSelectors []uint64, destChainEnabled []bool, destChainAllowlistEnabled []bool) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c onrampEncoder) ApplyDestChainConfigUpdates(destChainSelectors []uint64, destChainEnabled []bool, destChainAllowlistEnabled []bool) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("apply_dest_chain_config_updates", nil, []string{
 		"vector<u64>",
 		"vector<bool>",
@@ -462,16 +510,7 @@ func (c OnrampTransactor) EncodeApplyDestChainConfigUpdates(destChainSelectors [
 	})
 }
 
-func (c OnrampTransactor) ApplyDestChainConfigUpdates(opts *bind.TransactOpts, destChainSelectors []uint64, destChainEnabled []bool, destChainAllowlistEnabled []bool) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeApplyDestChainConfigUpdates(destChainSelectors, destChainEnabled, destChainAllowlistEnabled)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c OnrampTransactor) EncodeApplyAllowlistUpdates(destChainSelectors []uint64, destChainAllowlistEnabled []bool, destChainAddAllowedSenders [][]aptos.AccountAddress, destChainRemoveAllowedSenders [][]aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c onrampEncoder) ApplyAllowlistUpdates(destChainSelectors []uint64, destChainAllowlistEnabled []bool, destChainAddAllowedSenders [][]aptos.AccountAddress, destChainRemoveAllowedSenders [][]aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("apply_allowlist_updates", nil, []string{
 		"vector<u64>",
 		"vector<bool>",
@@ -485,18 +524,7 @@ func (c OnrampTransactor) EncodeApplyAllowlistUpdates(destChainSelectors []uint6
 	})
 }
 
-func (c OnrampTransactor) ApplyAllowlistUpdates(opts *bind.TransactOpts, destChainSelectors []uint64, destChainAllowlistEnabled []bool, destChainAddAllowedSenders [][]aptos.AccountAddress, destChainRemoveAllowedSenders [][]aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeApplyAllowlistUpdates(destChainSelectors, destChainAllowlistEnabled, destChainAddAllowedSenders, destChainRemoveAllowedSenders)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-// Other Functions
-
-func (c OnrampCaller) EncodeCCIPSend(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c onrampEncoder) CCIPSend(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("ccip_send", nil, []string{
 		"u64",
 		"vector<u8>",

--- a/bindings/ccip/onramp/onramp.go
+++ b/bindings/ccip/onramp/onramp.go
@@ -37,7 +37,7 @@ type Onramp interface {
 	ApplyDestChainConfigUpdates(opts *bind.TransactOpts, destChainSelectors []uint64, destChainEnabled []bool, destChainAllowlistEnabled []bool) (*api.PendingTransaction, error)
 	ApplyAllowlistUpdates(opts *bind.TransactOpts, destChainSelectors []uint64, destChainAllowlistEnabled []bool, destChainAddAllowedSenders [][]aptos.AccountAddress, destChainRemoveAllowedSenders [][]aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	// Encode returns the encoder implementation of this module.
+	// Encoder returns the encoder implementation of this module.
 	Encoder() OnrampEncoder
 }
 

--- a/bindings/ccip/onramp/onramp.go
+++ b/bindings/ccip/onramp/onramp.go
@@ -37,7 +37,8 @@ type Onramp interface {
 	ApplyDestChainConfigUpdates(opts *bind.TransactOpts, destChainSelectors []uint64, destChainEnabled []bool, destChainAllowlistEnabled []bool) (*api.PendingTransaction, error)
 	ApplyAllowlistUpdates(opts *bind.TransactOpts, destChainSelectors []uint64, destChainAllowlistEnabled []bool, destChainAddAllowedSenders [][]aptos.AccountAddress, destChainRemoveAllowedSenders [][]aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	Encode_() OnrampEncoder
+	// Encode returns the encoder implementation of this module.
+	Encoder() OnrampEncoder
 }
 
 type OnrampEncoder interface {
@@ -155,7 +156,7 @@ type OnrampContract struct {
 
 var _ Onramp = OnrampContract{}
 
-func (c OnrampContract) Encode_() OnrampEncoder {
+func (c OnrampContract) Encoder() OnrampEncoder {
 	return c.onrampEncoder
 }
 

--- a/bindings/ccip/onramp/onramp.go
+++ b/bindings/ccip/onramp/onramp.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type OnrampInterface interface {
+type Onramp interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 	IsChainSupported(opts *bind.CallOpts, destChainSelector uint64) (bool, error)
 	GetExpectedNextSequenceNumber(opts *bind.CallOpts, destChainSelector uint64) (uint64, error)
@@ -121,7 +121,7 @@ type AllowlistSendersRemoved struct {
 type McmsCallback struct {
 }
 
-type Onramp struct {
+type OnrampContract struct {
 	OnrampCaller
 	OnrampTransactor
 }

--- a/bindings/ccip/onramp/onramp.go
+++ b/bindings/ccip/onramp/onramp.go
@@ -37,7 +37,7 @@ type Onramp interface {
 	ApplyDestChainConfigUpdates(opts *bind.TransactOpts, destChainSelectors []uint64, destChainEnabled []bool, destChainAllowlistEnabled []bool) (*api.PendingTransaction, error)
 	ApplyAllowlistUpdates(opts *bind.TransactOpts, destChainSelectors []uint64, destChainAllowlistEnabled []bool, destChainAddAllowedSenders [][]aptos.AccountAddress, destChainRemoveAllowedSenders [][]aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	_Encode() OnrampEncoder
+	Encode_() OnrampEncoder
 }
 
 type OnrampEncoder interface {
@@ -155,7 +155,7 @@ type OnrampContract struct {
 
 var _ Onramp = OnrampContract{}
 
-func (c OnrampContract) _Encode() OnrampEncoder {
+func (c OnrampContract) Encode_() OnrampEncoder {
 	return c.onrampEncoder
 }
 

--- a/bindings/ccip/onramp/onramp.go
+++ b/bindings/ccip/onramp/onramp.go
@@ -37,7 +37,7 @@ type Onramp interface {
 	ApplyDestChainConfigUpdates(opts *bind.TransactOpts, destChainSelectors []uint64, destChainEnabled []bool, destChainAllowlistEnabled []bool) (*api.PendingTransaction, error)
 	ApplyAllowlistUpdates(opts *bind.TransactOpts, destChainSelectors []uint64, destChainAllowlistEnabled []bool, destChainAddAllowedSenders [][]aptos.AccountAddress, destChainRemoveAllowedSenders [][]aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	EncodeCall() OnrampEncoder
+	_Encode() OnrampEncoder
 }
 
 type OnrampEncoder interface {
@@ -155,7 +155,7 @@ type OnrampContract struct {
 
 var _ Onramp = OnrampContract{}
 
-func (c OnrampContract) EncodeCall() OnrampEncoder {
+func (c OnrampContract) _Encode() OnrampEncoder {
 	return c.onrampEncoder
 }
 

--- a/bindings/ccip/receiver_registry/receiver_registry.go
+++ b/bindings/ccip/receiver_registry/receiver_registry.go
@@ -23,9 +23,24 @@ var (
 
 type ReceiverRegistry interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
+
+	EncodeCall() ReceiverRegistryEncoder
+}
+
+type ReceiverRegistryEncoder interface {
+	TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	FinishReceive(receiverAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
 const FunctionInfo = `[{"package":"ccip","module":"receiver_registry","name":"finish_receive","parameters":[{"name":"receiver_address","type":"address"}]}]`
+
+func NewReceiverRegistry(address aptos.AccountAddress, client aptos.AptosRpcClient) ReceiverRegistry {
+	contract := bind.NewBoundContract(address, "ccip", "receiver_registry", client)
+	return ReceiverRegistryContract{
+		BoundContract:           contract,
+		receiverRegistryEncoder: receiverRegistryEncoder{BoundContract: contract},
+	}
+}
 
 // Structs
 
@@ -41,22 +56,20 @@ type ReceiverRegistered struct {
 }
 
 type ReceiverRegistryContract struct {
-	ReceiverRegistryCaller
-	ReceiverRegistryTransactor
+	*bind.BoundContract
+	receiverRegistryEncoder
+}
+
+var _ ReceiverRegistry = ReceiverRegistryContract{}
+
+func (c ReceiverRegistryContract) EncodeCall() ReceiverRegistryEncoder {
+	return c.receiverRegistryEncoder
 }
 
 // View Functions
 
-type ReceiverRegistryCaller struct {
-	*bind.BoundContract
-}
-
-func (c ReceiverRegistryCaller) EncodeTypeAndVersion() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
-}
-
-func (c ReceiverRegistryCaller) TypeAndVersion(opts *bind.CallOpts) (string, error) {
-	module, function, typeTags, args, err := c.EncodeTypeAndVersion()
+func (c ReceiverRegistryContract) TypeAndVersion(opts *bind.CallOpts) (string, error) {
+	module, function, typeTags, args, err := c.receiverRegistryEncoder.TypeAndVersion()
 	if err != nil {
 		return *new(string), err
 	}
@@ -78,13 +91,16 @@ func (c ReceiverRegistryCaller) TypeAndVersion(opts *bind.CallOpts) (string, err
 
 // Entry Functions
 
-type ReceiverRegistryTransactor struct {
+// Encoder
+type receiverRegistryEncoder struct {
 	*bind.BoundContract
 }
 
-// Other Functions
+func (c receiverRegistryEncoder) TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
+}
 
-func (c ReceiverRegistryCaller) EncodeFinishReceive(receiverAddress aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c receiverRegistryEncoder) FinishReceive(receiverAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("finish_receive", nil, []string{
 		"address",
 	}, []any{

--- a/bindings/ccip/receiver_registry/receiver_registry.go
+++ b/bindings/ccip/receiver_registry/receiver_registry.go
@@ -24,7 +24,7 @@ var (
 type ReceiverRegistry interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 
-	_Encode() ReceiverRegistryEncoder
+	Encode_() ReceiverRegistryEncoder
 }
 
 type ReceiverRegistryEncoder interface {
@@ -62,7 +62,7 @@ type ReceiverRegistryContract struct {
 
 var _ ReceiverRegistry = ReceiverRegistryContract{}
 
-func (c ReceiverRegistryContract) _Encode() ReceiverRegistryEncoder {
+func (c ReceiverRegistryContract) Encode_() ReceiverRegistryEncoder {
 	return c.receiverRegistryEncoder
 }
 

--- a/bindings/ccip/receiver_registry/receiver_registry.go
+++ b/bindings/ccip/receiver_registry/receiver_registry.go
@@ -24,7 +24,8 @@ var (
 type ReceiverRegistry interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 
-	Encode_() ReceiverRegistryEncoder
+	// Encode returns the encoder implementation of this module.
+	Encoder() ReceiverRegistryEncoder
 }
 
 type ReceiverRegistryEncoder interface {
@@ -62,7 +63,7 @@ type ReceiverRegistryContract struct {
 
 var _ ReceiverRegistry = ReceiverRegistryContract{}
 
-func (c ReceiverRegistryContract) Encode_() ReceiverRegistryEncoder {
+func (c ReceiverRegistryContract) Encoder() ReceiverRegistryEncoder {
 	return c.receiverRegistryEncoder
 }
 

--- a/bindings/ccip/receiver_registry/receiver_registry.go
+++ b/bindings/ccip/receiver_registry/receiver_registry.go
@@ -24,7 +24,7 @@ var (
 type ReceiverRegistry interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 
-	// Encode returns the encoder implementation of this module.
+	// Encoder returns the encoder implementation of this module.
 	Encoder() ReceiverRegistryEncoder
 }
 

--- a/bindings/ccip/receiver_registry/receiver_registry.go
+++ b/bindings/ccip/receiver_registry/receiver_registry.go
@@ -24,7 +24,7 @@ var (
 type ReceiverRegistry interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 
-	EncodeCall() ReceiverRegistryEncoder
+	_Encode() ReceiverRegistryEncoder
 }
 
 type ReceiverRegistryEncoder interface {
@@ -62,7 +62,7 @@ type ReceiverRegistryContract struct {
 
 var _ ReceiverRegistry = ReceiverRegistryContract{}
 
-func (c ReceiverRegistryContract) EncodeCall() ReceiverRegistryEncoder {
+func (c ReceiverRegistryContract) _Encode() ReceiverRegistryEncoder {
 	return c.receiverRegistryEncoder
 }
 

--- a/bindings/ccip/receiver_registry/receiver_registry.go
+++ b/bindings/ccip/receiver_registry/receiver_registry.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type ReceiverRegistryInterface interface {
+type ReceiverRegistry interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 }
 
@@ -40,7 +40,7 @@ type ReceiverRegistered struct {
 	ReceiverModuleName []byte               `move:"vector<u8>"`
 }
 
-type ReceiverRegistry struct {
+type ReceiverRegistryContract struct {
 	ReceiverRegistryCaller
 	ReceiverRegistryTransactor
 }

--- a/bindings/ccip/rmn_remote/rmn_remote.go
+++ b/bindings/ccip/rmn_remote/rmn_remote.go
@@ -34,9 +34,37 @@ type RMNRemote interface {
 	CurseMultiple(opts *bind.TransactOpts, subjects [][]byte) (*api.PendingTransaction, error)
 	Uncurse(opts *bind.TransactOpts, subject []byte) (*api.PendingTransaction, error)
 	UncurseMultiple(opts *bind.TransactOpts, subjects [][]byte) (*api.PendingTransaction, error)
+
+	EncodeCall() RMNRemoteEncoder
+}
+
+type RMNRemoteEncoder interface {
+	TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Verify(merkleRootSourceChainSelectors []uint64, merkleRootMinSequenceNumbers []uint64, merkleRootMaxSequenceNumbers []uint64, merkleRootValues [][]byte, signatures [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetVersionedConfig() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetLocalChainSelector() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetReportDigestHeader() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Initialize(localChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetConfig(rmnHomeContractConfigDigest []byte, signerOnchainPublicKeys [][]byte, nodeIndexes []uint64, fSign uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Curse(subject []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	CurseMultiple(subjects [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Uncurse(subject []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	UncurseMultiple(subjects [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetCursedSubjects() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	IsCursedGlobal() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	IsCursed(subject []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	IsCursedU128(subjectValue *big.Int) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
 const FunctionInfo = `[{"package":"ccip","module":"rmn_remote","name":"curse","parameters":[{"name":"subject","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"rmn_remote","name":"curse_multiple","parameters":[{"name":"subjects","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"ccip","module":"rmn_remote","name":"get_cursed_subjects","parameters":null},{"package":"ccip","module":"rmn_remote","name":"initialize","parameters":[{"name":"local_chain_selector","type":"u64"}]},{"package":"ccip","module":"rmn_remote","name":"is_cursed","parameters":[{"name":"subject","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"rmn_remote","name":"is_cursed_global","parameters":null},{"package":"ccip","module":"rmn_remote","name":"is_cursed_u128","parameters":[{"name":"subject_value","type":"u128"}]},{"package":"ccip","module":"rmn_remote","name":"set_config","parameters":[{"name":"rmn_home_contract_config_digest","type":"vector\u003cu8\u003e"},{"name":"signer_onchain_public_keys","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"node_indexes","type":"vector\u003cu64\u003e"},{"name":"f_sign","type":"u64"}]},{"package":"ccip","module":"rmn_remote","name":"uncurse","parameters":[{"name":"subject","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"rmn_remote","name":"uncurse_multiple","parameters":[{"name":"subjects","type":"vector\u003cvector\u003cu8\u003e\u003e"}]}]`
+
+func NewRMNRemote(address aptos.AccountAddress, client aptos.AptosRpcClient) RMNRemote {
+	contract := bind.NewBoundContract(address, "ccip", "rmn_remote", client)
+	return RMNRemoteContract{
+		BoundContract:    contract,
+		rmnRemoteEncoder: rmnRemoteEncoder{BoundContract: contract},
+	}
+}
 
 // Structs
 
@@ -90,22 +118,20 @@ type McmsCallback struct {
 }
 
 type RMNRemoteContract struct {
-	RMNRemoteCaller
-	RMNRemoteTransactor
+	*bind.BoundContract
+	rmnRemoteEncoder
+}
+
+var _ RMNRemote = RMNRemoteContract{}
+
+func (c RMNRemoteContract) EncodeCall() RMNRemoteEncoder {
+	return c.rmnRemoteEncoder
 }
 
 // View Functions
 
-type RMNRemoteCaller struct {
-	*bind.BoundContract
-}
-
-func (c RMNRemoteCaller) EncodeTypeAndVersion() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
-}
-
-func (c RMNRemoteCaller) TypeAndVersion(opts *bind.CallOpts) (string, error) {
-	module, function, typeTags, args, err := c.EncodeTypeAndVersion()
+func (c RMNRemoteContract) TypeAndVersion(opts *bind.CallOpts) (string, error) {
+	module, function, typeTags, args, err := c.rmnRemoteEncoder.TypeAndVersion()
 	if err != nil {
 		return *new(string), err
 	}
@@ -125,24 +151,8 @@ func (c RMNRemoteCaller) TypeAndVersion(opts *bind.CallOpts) (string, error) {
 	return r0, nil
 }
 
-func (c RMNRemoteCaller) EncodeVerify(merkleRootSourceChainSelectors []uint64, merkleRootMinSequenceNumbers []uint64, merkleRootMaxSequenceNumbers []uint64, merkleRootValues [][]byte, signatures [][]byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("verify", nil, []string{
-		"vector<u64>",
-		"vector<u64>",
-		"vector<u64>",
-		"vector<vector<u8>>",
-		"vector<vector<u8>>",
-	}, []any{
-		merkleRootSourceChainSelectors,
-		merkleRootMinSequenceNumbers,
-		merkleRootMaxSequenceNumbers,
-		merkleRootValues,
-		signatures,
-	})
-}
-
-func (c RMNRemoteCaller) Verify(opts *bind.CallOpts, merkleRootSourceChainSelectors []uint64, merkleRootMinSequenceNumbers []uint64, merkleRootMaxSequenceNumbers []uint64, merkleRootValues [][]byte, signatures [][]byte) (bool, error) {
-	module, function, typeTags, args, err := c.EncodeVerify(merkleRootSourceChainSelectors, merkleRootMinSequenceNumbers, merkleRootMaxSequenceNumbers, merkleRootValues, signatures)
+func (c RMNRemoteContract) Verify(opts *bind.CallOpts, merkleRootSourceChainSelectors []uint64, merkleRootMinSequenceNumbers []uint64, merkleRootMaxSequenceNumbers []uint64, merkleRootValues [][]byte, signatures [][]byte) (bool, error) {
+	module, function, typeTags, args, err := c.rmnRemoteEncoder.Verify(merkleRootSourceChainSelectors, merkleRootMinSequenceNumbers, merkleRootMaxSequenceNumbers, merkleRootValues, signatures)
 	if err != nil {
 		return *new(bool), err
 	}
@@ -162,12 +172,8 @@ func (c RMNRemoteCaller) Verify(opts *bind.CallOpts, merkleRootSourceChainSelect
 	return r0, nil
 }
 
-func (c RMNRemoteCaller) EncodeGetVersionedConfig() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_versioned_config", nil, []string{}, []any{})
-}
-
-func (c RMNRemoteCaller) GetVersionedConfig(opts *bind.CallOpts) (uint32, Config, error) {
-	module, function, typeTags, args, err := c.EncodeGetVersionedConfig()
+func (c RMNRemoteContract) GetVersionedConfig(opts *bind.CallOpts) (uint32, Config, error) {
+	module, function, typeTags, args, err := c.rmnRemoteEncoder.GetVersionedConfig()
 	if err != nil {
 		return *new(uint32), *new(Config), err
 	}
@@ -188,12 +194,8 @@ func (c RMNRemoteCaller) GetVersionedConfig(opts *bind.CallOpts) (uint32, Config
 	return r0, r1, nil
 }
 
-func (c RMNRemoteCaller) EncodeGetLocalChainSelector() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_local_chain_selector", nil, []string{}, []any{})
-}
-
-func (c RMNRemoteCaller) GetLocalChainSelector(opts *bind.CallOpts) (uint64, error) {
-	module, function, typeTags, args, err := c.EncodeGetLocalChainSelector()
+func (c RMNRemoteContract) GetLocalChainSelector(opts *bind.CallOpts) (uint64, error) {
+	module, function, typeTags, args, err := c.rmnRemoteEncoder.GetLocalChainSelector()
 	if err != nil {
 		return *new(uint64), err
 	}
@@ -213,12 +215,8 @@ func (c RMNRemoteCaller) GetLocalChainSelector(opts *bind.CallOpts) (uint64, err
 	return r0, nil
 }
 
-func (c RMNRemoteCaller) EncodeGetReportDigestHeader() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_report_digest_header", nil, []string{}, []any{})
-}
-
-func (c RMNRemoteCaller) GetReportDigestHeader(opts *bind.CallOpts) ([]byte, error) {
-	module, function, typeTags, args, err := c.EncodeGetReportDigestHeader()
+func (c RMNRemoteContract) GetReportDigestHeader(opts *bind.CallOpts) ([]byte, error) {
+	module, function, typeTags, args, err := c.rmnRemoteEncoder.GetReportDigestHeader()
 	if err != nil {
 		return *new([]byte), err
 	}
@@ -240,20 +238,8 @@ func (c RMNRemoteCaller) GetReportDigestHeader(opts *bind.CallOpts) ([]byte, err
 
 // Entry Functions
 
-type RMNRemoteTransactor struct {
-	*bind.BoundContract
-}
-
-func (c RMNRemoteTransactor) EncodeInitialize(localChainSelector uint64) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("initialize", nil, []string{
-		"u64",
-	}, []any{
-		localChainSelector,
-	})
-}
-
-func (c RMNRemoteTransactor) Initialize(opts *bind.TransactOpts, localChainSelector uint64) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeInitialize(localChainSelector)
+func (c RMNRemoteContract) Initialize(opts *bind.TransactOpts, localChainSelector uint64) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.rmnRemoteEncoder.Initialize(localChainSelector)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +247,97 @@ func (c RMNRemoteTransactor) Initialize(opts *bind.TransactOpts, localChainSelec
 	return c.BoundContract.Transact(opts, module, function, typeTags, args)
 }
 
-func (c RMNRemoteTransactor) EncodeSetConfig(rmnHomeContractConfigDigest []byte, signerOnchainPublicKeys [][]byte, nodeIndexes []uint64, fSign uint64) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c RMNRemoteContract) SetConfig(opts *bind.TransactOpts, rmnHomeContractConfigDigest []byte, signerOnchainPublicKeys [][]byte, nodeIndexes []uint64, fSign uint64) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.rmnRemoteEncoder.SetConfig(rmnHomeContractConfigDigest, signerOnchainPublicKeys, nodeIndexes, fSign)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c RMNRemoteContract) Curse(opts *bind.TransactOpts, subject []byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.rmnRemoteEncoder.Curse(subject)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c RMNRemoteContract) CurseMultiple(opts *bind.TransactOpts, subjects [][]byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.rmnRemoteEncoder.CurseMultiple(subjects)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c RMNRemoteContract) Uncurse(opts *bind.TransactOpts, subject []byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.rmnRemoteEncoder.Uncurse(subject)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c RMNRemoteContract) UncurseMultiple(opts *bind.TransactOpts, subjects [][]byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.rmnRemoteEncoder.UncurseMultiple(subjects)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+// Encoder
+type rmnRemoteEncoder struct {
+	*bind.BoundContract
+}
+
+func (c rmnRemoteEncoder) TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
+}
+
+func (c rmnRemoteEncoder) Verify(merkleRootSourceChainSelectors []uint64, merkleRootMinSequenceNumbers []uint64, merkleRootMaxSequenceNumbers []uint64, merkleRootValues [][]byte, signatures [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("verify", nil, []string{
+		"vector<u64>",
+		"vector<u64>",
+		"vector<u64>",
+		"vector<vector<u8>>",
+		"vector<vector<u8>>",
+	}, []any{
+		merkleRootSourceChainSelectors,
+		merkleRootMinSequenceNumbers,
+		merkleRootMaxSequenceNumbers,
+		merkleRootValues,
+		signatures,
+	})
+}
+
+func (c rmnRemoteEncoder) GetVersionedConfig() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_versioned_config", nil, []string{}, []any{})
+}
+
+func (c rmnRemoteEncoder) GetLocalChainSelector() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_local_chain_selector", nil, []string{}, []any{})
+}
+
+func (c rmnRemoteEncoder) GetReportDigestHeader() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_report_digest_header", nil, []string{}, []any{})
+}
+
+func (c rmnRemoteEncoder) Initialize(localChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("initialize", nil, []string{
+		"u64",
+	}, []any{
+		localChainSelector,
+	})
+}
+
+func (c rmnRemoteEncoder) SetConfig(rmnHomeContractConfigDigest []byte, signerOnchainPublicKeys [][]byte, nodeIndexes []uint64, fSign uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("set_config", nil, []string{
 		"vector<u8>",
 		"vector<vector<u8>>",
@@ -275,16 +351,7 @@ func (c RMNRemoteTransactor) EncodeSetConfig(rmnHomeContractConfigDigest []byte,
 	})
 }
 
-func (c RMNRemoteTransactor) SetConfig(opts *bind.TransactOpts, rmnHomeContractConfigDigest []byte, signerOnchainPublicKeys [][]byte, nodeIndexes []uint64, fSign uint64) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeSetConfig(rmnHomeContractConfigDigest, signerOnchainPublicKeys, nodeIndexes, fSign)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c RMNRemoteTransactor) EncodeCurse(subject []byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c rmnRemoteEncoder) Curse(subject []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("curse", nil, []string{
 		"vector<u8>",
 	}, []any{
@@ -292,16 +359,7 @@ func (c RMNRemoteTransactor) EncodeCurse(subject []byte) (aptos.ModuleId, string
 	})
 }
 
-func (c RMNRemoteTransactor) Curse(opts *bind.TransactOpts, subject []byte) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeCurse(subject)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c RMNRemoteTransactor) EncodeCurseMultiple(subjects [][]byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c rmnRemoteEncoder) CurseMultiple(subjects [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("curse_multiple", nil, []string{
 		"vector<vector<u8>>",
 	}, []any{
@@ -309,16 +367,7 @@ func (c RMNRemoteTransactor) EncodeCurseMultiple(subjects [][]byte) (aptos.Modul
 	})
 }
 
-func (c RMNRemoteTransactor) CurseMultiple(opts *bind.TransactOpts, subjects [][]byte) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeCurseMultiple(subjects)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c RMNRemoteTransactor) EncodeUncurse(subject []byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c rmnRemoteEncoder) Uncurse(subject []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("uncurse", nil, []string{
 		"vector<u8>",
 	}, []any{
@@ -326,16 +375,7 @@ func (c RMNRemoteTransactor) EncodeUncurse(subject []byte) (aptos.ModuleId, stri
 	})
 }
 
-func (c RMNRemoteTransactor) Uncurse(opts *bind.TransactOpts, subject []byte) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeUncurse(subject)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c RMNRemoteTransactor) EncodeUncurseMultiple(subjects [][]byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c rmnRemoteEncoder) UncurseMultiple(subjects [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("uncurse_multiple", nil, []string{
 		"vector<vector<u8>>",
 	}, []any{
@@ -343,26 +383,15 @@ func (c RMNRemoteTransactor) EncodeUncurseMultiple(subjects [][]byte) (aptos.Mod
 	})
 }
 
-func (c RMNRemoteTransactor) UncurseMultiple(opts *bind.TransactOpts, subjects [][]byte) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeUncurseMultiple(subjects)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-// Other Functions
-
-func (c RMNRemoteCaller) EncodeGetCursedSubjects() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c rmnRemoteEncoder) GetCursedSubjects() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("get_cursed_subjects", nil, []string{}, []any{})
 }
 
-func (c RMNRemoteCaller) EncodeIsCursedGlobal() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c rmnRemoteEncoder) IsCursedGlobal() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("is_cursed_global", nil, []string{}, []any{})
 }
 
-func (c RMNRemoteCaller) EncodeIsCursed(subject []byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c rmnRemoteEncoder) IsCursed(subject []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("is_cursed", nil, []string{
 		"vector<u8>",
 	}, []any{
@@ -370,7 +399,7 @@ func (c RMNRemoteCaller) EncodeIsCursed(subject []byte) (aptos.ModuleId, string,
 	})
 }
 
-func (c RMNRemoteCaller) EncodeIsCursedU128(subjectValue *big.Int) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c rmnRemoteEncoder) IsCursedU128(subjectValue *big.Int) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("is_cursed_u128", nil, []string{
 		"u128",
 	}, []any{

--- a/bindings/ccip/rmn_remote/rmn_remote.go
+++ b/bindings/ccip/rmn_remote/rmn_remote.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type RMNRemoteInterface interface {
+type RMNRemote interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 	Verify(opts *bind.CallOpts, merkleRootSourceChainSelectors []uint64, merkleRootMinSequenceNumbers []uint64, merkleRootMaxSequenceNumbers []uint64, merkleRootValues [][]byte, signatures [][]byte) (bool, error)
 	GetVersionedConfig(opts *bind.CallOpts) (uint32, Config, error)
@@ -89,7 +89,7 @@ type Uncursed struct {
 type McmsCallback struct {
 }
 
-type RMNRemote struct {
+type RMNRemoteContract struct {
 	RMNRemoteCaller
 	RMNRemoteTransactor
 }

--- a/bindings/ccip/rmn_remote/rmn_remote.go
+++ b/bindings/ccip/rmn_remote/rmn_remote.go
@@ -35,7 +35,7 @@ type RMNRemote interface {
 	Uncurse(opts *bind.TransactOpts, subject []byte) (*api.PendingTransaction, error)
 	UncurseMultiple(opts *bind.TransactOpts, subjects [][]byte) (*api.PendingTransaction, error)
 
-	// Encode returns the encoder implementation of this module.
+	// Encoder returns the encoder implementation of this module.
 	Encoder() RMNRemoteEncoder
 }
 

--- a/bindings/ccip/rmn_remote/rmn_remote.go
+++ b/bindings/ccip/rmn_remote/rmn_remote.go
@@ -35,7 +35,7 @@ type RMNRemote interface {
 	Uncurse(opts *bind.TransactOpts, subject []byte) (*api.PendingTransaction, error)
 	UncurseMultiple(opts *bind.TransactOpts, subjects [][]byte) (*api.PendingTransaction, error)
 
-	EncodeCall() RMNRemoteEncoder
+	_Encode() RMNRemoteEncoder
 }
 
 type RMNRemoteEncoder interface {
@@ -124,7 +124,7 @@ type RMNRemoteContract struct {
 
 var _ RMNRemote = RMNRemoteContract{}
 
-func (c RMNRemoteContract) EncodeCall() RMNRemoteEncoder {
+func (c RMNRemoteContract) _Encode() RMNRemoteEncoder {
 	return c.rmnRemoteEncoder
 }
 

--- a/bindings/ccip/rmn_remote/rmn_remote.go
+++ b/bindings/ccip/rmn_remote/rmn_remote.go
@@ -35,7 +35,7 @@ type RMNRemote interface {
 	Uncurse(opts *bind.TransactOpts, subject []byte) (*api.PendingTransaction, error)
 	UncurseMultiple(opts *bind.TransactOpts, subjects [][]byte) (*api.PendingTransaction, error)
 
-	_Encode() RMNRemoteEncoder
+	Encode_() RMNRemoteEncoder
 }
 
 type RMNRemoteEncoder interface {
@@ -124,7 +124,7 @@ type RMNRemoteContract struct {
 
 var _ RMNRemote = RMNRemoteContract{}
 
-func (c RMNRemoteContract) _Encode() RMNRemoteEncoder {
+func (c RMNRemoteContract) Encode_() RMNRemoteEncoder {
 	return c.rmnRemoteEncoder
 }
 

--- a/bindings/ccip/rmn_remote/rmn_remote.go
+++ b/bindings/ccip/rmn_remote/rmn_remote.go
@@ -35,7 +35,8 @@ type RMNRemote interface {
 	Uncurse(opts *bind.TransactOpts, subject []byte) (*api.PendingTransaction, error)
 	UncurseMultiple(opts *bind.TransactOpts, subjects [][]byte) (*api.PendingTransaction, error)
 
-	Encode_() RMNRemoteEncoder
+	// Encode returns the encoder implementation of this module.
+	Encoder() RMNRemoteEncoder
 }
 
 type RMNRemoteEncoder interface {
@@ -124,7 +125,7 @@ type RMNRemoteContract struct {
 
 var _ RMNRemote = RMNRemoteContract{}
 
-func (c RMNRemoteContract) Encode_() RMNRemoteEncoder {
+func (c RMNRemoteContract) Encoder() RMNRemoteEncoder {
 	return c.rmnRemoteEncoder
 }
 

--- a/bindings/ccip/token_admin_registry/token_admin_registry.go
+++ b/bindings/ccip/token_admin_registry/token_admin_registry.go
@@ -33,7 +33,7 @@ type TokenAdminRegistry interface {
 	TransferAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress, newAdmin aptos.AccountAddress) (*api.PendingTransaction, error)
 	AcceptAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	EncodeCall() TokenAdminRegistryEncoder
+	_Encode() TokenAdminRegistryEncoder
 }
 
 type TokenAdminRegistryEncoder interface {
@@ -132,7 +132,7 @@ type TokenAdminRegistryContract struct {
 
 var _ TokenAdminRegistry = TokenAdminRegistryContract{}
 
-func (c TokenAdminRegistryContract) EncodeCall() TokenAdminRegistryEncoder {
+func (c TokenAdminRegistryContract) _Encode() TokenAdminRegistryEncoder {
 	return c.tokenAdminRegistryEncoder
 }
 

--- a/bindings/ccip/token_admin_registry/token_admin_registry.go
+++ b/bindings/ccip/token_admin_registry/token_admin_registry.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type TokenAdminRegistryInterface interface {
+type TokenAdminRegistry interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 	GetPools(opts *bind.CallOpts, localTokens []aptos.AccountAddress) ([]aptos.AccountAddress, error)
 	GetPool(opts *bind.CallOpts, localToken aptos.AccountAddress) (aptos.AccountAddress, error)
@@ -101,7 +101,7 @@ type AdministratorTransferred struct {
 type McmsCallback struct {
 }
 
-type TokenAdminRegistry struct {
+type TokenAdminRegistryContract struct {
 	TokenAdminRegistryCaller
 	TokenAdminRegistryTransactor
 }

--- a/bindings/ccip/token_admin_registry/token_admin_registry.go
+++ b/bindings/ccip/token_admin_registry/token_admin_registry.go
@@ -33,7 +33,8 @@ type TokenAdminRegistry interface {
 	TransferAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress, newAdmin aptos.AccountAddress) (*api.PendingTransaction, error)
 	AcceptAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	Encode_() TokenAdminRegistryEncoder
+	// Encode returns the encoder implementation of this module.
+	Encoder() TokenAdminRegistryEncoder
 }
 
 type TokenAdminRegistryEncoder interface {
@@ -132,7 +133,7 @@ type TokenAdminRegistryContract struct {
 
 var _ TokenAdminRegistry = TokenAdminRegistryContract{}
 
-func (c TokenAdminRegistryContract) Encode_() TokenAdminRegistryEncoder {
+func (c TokenAdminRegistryContract) Encoder() TokenAdminRegistryEncoder {
 	return c.tokenAdminRegistryEncoder
 }
 

--- a/bindings/ccip/token_admin_registry/token_admin_registry.go
+++ b/bindings/ccip/token_admin_registry/token_admin_registry.go
@@ -33,7 +33,7 @@ type TokenAdminRegistry interface {
 	TransferAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress, newAdmin aptos.AccountAddress) (*api.PendingTransaction, error)
 	AcceptAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	// Encode returns the encoder implementation of this module.
+	// Encoder returns the encoder implementation of this module.
 	Encoder() TokenAdminRegistryEncoder
 }
 

--- a/bindings/ccip/token_admin_registry/token_admin_registry.go
+++ b/bindings/ccip/token_admin_registry/token_admin_registry.go
@@ -33,7 +33,7 @@ type TokenAdminRegistry interface {
 	TransferAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress, newAdmin aptos.AccountAddress) (*api.PendingTransaction, error)
 	AcceptAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	_Encode() TokenAdminRegistryEncoder
+	Encode_() TokenAdminRegistryEncoder
 }
 
 type TokenAdminRegistryEncoder interface {
@@ -132,7 +132,7 @@ type TokenAdminRegistryContract struct {
 
 var _ TokenAdminRegistry = TokenAdminRegistryContract{}
 
-func (c TokenAdminRegistryContract) _Encode() TokenAdminRegistryEncoder {
+func (c TokenAdminRegistryContract) Encode_() TokenAdminRegistryEncoder {
 	return c.tokenAdminRegistryEncoder
 }
 

--- a/bindings/ccip/token_admin_registry/token_admin_registry.go
+++ b/bindings/ccip/token_admin_registry/token_admin_registry.go
@@ -32,9 +32,33 @@ type TokenAdminRegistry interface {
 	SetPool(opts *bind.TransactOpts, localToken aptos.AccountAddress, tokenPoolAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 	TransferAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress, newAdmin aptos.AccountAddress) (*api.PendingTransaction, error)
 	AcceptAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error)
+
+	EncodeCall() TokenAdminRegistryEncoder
+}
+
+type TokenAdminRegistryEncoder interface {
+	TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetPools(localTokens []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetPool(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetTokenConfig(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetAllConfiguredTokens(startingBucketIndex uint64, startingVectorIndex uint64, maxCount uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	IsAdministrator(localToken aptos.AccountAddress, administrator aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetPool(localToken aptos.AccountAddress, tokenPoolAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	TransferAdminRole(localToken aptos.AccountAddress, newAdmin aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AcceptAdminRole(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	FinishLockOrBurn(tokenPoolAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	FinishReleaseOrMint(tokenPoolAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
 const FunctionInfo = `[{"package":"ccip","module":"token_admin_registry","name":"accept_admin_role","parameters":[{"name":"local_token","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"finish_lock_or_burn","parameters":[{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"finish_release_or_mint","parameters":[{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"set_pool","parameters":[{"name":"local_token","type":"address"},{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"transfer_admin_role","parameters":[{"name":"local_token","type":"address"},{"name":"new_admin","type":"address"}]}]`
+
+func NewTokenAdminRegistry(address aptos.AccountAddress, client aptos.AptosRpcClient) TokenAdminRegistry {
+	contract := bind.NewBoundContract(address, "ccip", "token_admin_registry", client)
+	return TokenAdminRegistryContract{
+		BoundContract:             contract,
+		tokenAdminRegistryEncoder: tokenAdminRegistryEncoder{BoundContract: contract},
+	}
+}
 
 // Structs
 
@@ -102,22 +126,20 @@ type McmsCallback struct {
 }
 
 type TokenAdminRegistryContract struct {
-	TokenAdminRegistryCaller
-	TokenAdminRegistryTransactor
+	*bind.BoundContract
+	tokenAdminRegistryEncoder
+}
+
+var _ TokenAdminRegistry = TokenAdminRegistryContract{}
+
+func (c TokenAdminRegistryContract) EncodeCall() TokenAdminRegistryEncoder {
+	return c.tokenAdminRegistryEncoder
 }
 
 // View Functions
 
-type TokenAdminRegistryCaller struct {
-	*bind.BoundContract
-}
-
-func (c TokenAdminRegistryCaller) EncodeTypeAndVersion() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
-}
-
-func (c TokenAdminRegistryCaller) TypeAndVersion(opts *bind.CallOpts) (string, error) {
-	module, function, typeTags, args, err := c.EncodeTypeAndVersion()
+func (c TokenAdminRegistryContract) TypeAndVersion(opts *bind.CallOpts) (string, error) {
+	module, function, typeTags, args, err := c.tokenAdminRegistryEncoder.TypeAndVersion()
 	if err != nil {
 		return *new(string), err
 	}
@@ -137,16 +159,8 @@ func (c TokenAdminRegistryCaller) TypeAndVersion(opts *bind.CallOpts) (string, e
 	return r0, nil
 }
 
-func (c TokenAdminRegistryCaller) EncodeGetPools(localTokens []aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_pools", nil, []string{
-		"vector<address>",
-	}, []any{
-		localTokens,
-	})
-}
-
-func (c TokenAdminRegistryCaller) GetPools(opts *bind.CallOpts, localTokens []aptos.AccountAddress) ([]aptos.AccountAddress, error) {
-	module, function, typeTags, args, err := c.EncodeGetPools(localTokens)
+func (c TokenAdminRegistryContract) GetPools(opts *bind.CallOpts, localTokens []aptos.AccountAddress) ([]aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.tokenAdminRegistryEncoder.GetPools(localTokens)
 	if err != nil {
 		return *new([]aptos.AccountAddress), err
 	}
@@ -166,16 +180,8 @@ func (c TokenAdminRegistryCaller) GetPools(opts *bind.CallOpts, localTokens []ap
 	return r0, nil
 }
 
-func (c TokenAdminRegistryCaller) EncodeGetPool(localToken aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_pool", nil, []string{
-		"address",
-	}, []any{
-		localToken,
-	})
-}
-
-func (c TokenAdminRegistryCaller) GetPool(opts *bind.CallOpts, localToken aptos.AccountAddress) (aptos.AccountAddress, error) {
-	module, function, typeTags, args, err := c.EncodeGetPool(localToken)
+func (c TokenAdminRegistryContract) GetPool(opts *bind.CallOpts, localToken aptos.AccountAddress) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.tokenAdminRegistryEncoder.GetPool(localToken)
 	if err != nil {
 		return *new(aptos.AccountAddress), err
 	}
@@ -195,16 +201,8 @@ func (c TokenAdminRegistryCaller) GetPool(opts *bind.CallOpts, localToken aptos.
 	return r0, nil
 }
 
-func (c TokenAdminRegistryCaller) EncodeGetTokenConfig(localToken aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_token_config", nil, []string{
-		"address",
-	}, []any{
-		localToken,
-	})
-}
-
-func (c TokenAdminRegistryCaller) GetTokenConfig(opts *bind.CallOpts, localToken aptos.AccountAddress) (aptos.AccountAddress, aptos.AccountAddress, aptos.AccountAddress, error) {
-	module, function, typeTags, args, err := c.EncodeGetTokenConfig(localToken)
+func (c TokenAdminRegistryContract) GetTokenConfig(opts *bind.CallOpts, localToken aptos.AccountAddress) (aptos.AccountAddress, aptos.AccountAddress, aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.tokenAdminRegistryEncoder.GetTokenConfig(localToken)
 	if err != nil {
 		return *new(aptos.AccountAddress), *new(aptos.AccountAddress), *new(aptos.AccountAddress), err
 	}
@@ -226,20 +224,8 @@ func (c TokenAdminRegistryCaller) GetTokenConfig(opts *bind.CallOpts, localToken
 	return r0, r1, r2, nil
 }
 
-func (c TokenAdminRegistryCaller) EncodeGetAllConfiguredTokens(startingBucketIndex uint64, startingVectorIndex uint64, maxCount uint64) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_all_configured_tokens", nil, []string{
-		"u64",
-		"u64",
-		"u64",
-	}, []any{
-		startingBucketIndex,
-		startingVectorIndex,
-		maxCount,
-	})
-}
-
-func (c TokenAdminRegistryCaller) GetAllConfiguredTokens(opts *bind.CallOpts, startingBucketIndex uint64, startingVectorIndex uint64, maxCount uint64) ([]aptos.AccountAddress, *uint64, *uint64, error) {
-	module, function, typeTags, args, err := c.EncodeGetAllConfiguredTokens(startingBucketIndex, startingVectorIndex, maxCount)
+func (c TokenAdminRegistryContract) GetAllConfiguredTokens(opts *bind.CallOpts, startingBucketIndex uint64, startingVectorIndex uint64, maxCount uint64) ([]aptos.AccountAddress, *uint64, *uint64, error) {
+	module, function, typeTags, args, err := c.tokenAdminRegistryEncoder.GetAllConfiguredTokens(startingBucketIndex, startingVectorIndex, maxCount)
 	if err != nil {
 		return *new([]aptos.AccountAddress), *new(*uint64), *new(*uint64), err
 	}
@@ -261,18 +247,8 @@ func (c TokenAdminRegistryCaller) GetAllConfiguredTokens(opts *bind.CallOpts, st
 	return r0, r1.Value(), r2.Value(), nil
 }
 
-func (c TokenAdminRegistryCaller) EncodeIsAdministrator(localToken aptos.AccountAddress, administrator aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("is_administrator", nil, []string{
-		"address",
-		"address",
-	}, []any{
-		localToken,
-		administrator,
-	})
-}
-
-func (c TokenAdminRegistryCaller) IsAdministrator(opts *bind.CallOpts, localToken aptos.AccountAddress, administrator aptos.AccountAddress) (bool, error) {
-	module, function, typeTags, args, err := c.EncodeIsAdministrator(localToken, administrator)
+func (c TokenAdminRegistryContract) IsAdministrator(opts *bind.CallOpts, localToken aptos.AccountAddress, administrator aptos.AccountAddress) (bool, error) {
+	module, function, typeTags, args, err := c.tokenAdminRegistryEncoder.IsAdministrator(localToken, administrator)
 	if err != nil {
 		return *new(bool), err
 	}
@@ -294,11 +270,89 @@ func (c TokenAdminRegistryCaller) IsAdministrator(opts *bind.CallOpts, localToke
 
 // Entry Functions
 
-type TokenAdminRegistryTransactor struct {
+func (c TokenAdminRegistryContract) SetPool(opts *bind.TransactOpts, localToken aptos.AccountAddress, tokenPoolAddress aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.tokenAdminRegistryEncoder.SetPool(localToken, tokenPoolAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c TokenAdminRegistryContract) TransferAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress, newAdmin aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.tokenAdminRegistryEncoder.TransferAdminRole(localToken, newAdmin)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c TokenAdminRegistryContract) AcceptAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.tokenAdminRegistryEncoder.AcceptAdminRole(localToken)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+// Encoder
+type tokenAdminRegistryEncoder struct {
 	*bind.BoundContract
 }
 
-func (c TokenAdminRegistryTransactor) EncodeSetPool(localToken aptos.AccountAddress, tokenPoolAddress aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c tokenAdminRegistryEncoder) TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
+}
+
+func (c tokenAdminRegistryEncoder) GetPools(localTokens []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_pools", nil, []string{
+		"vector<address>",
+	}, []any{
+		localTokens,
+	})
+}
+
+func (c tokenAdminRegistryEncoder) GetPool(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_pool", nil, []string{
+		"address",
+	}, []any{
+		localToken,
+	})
+}
+
+func (c tokenAdminRegistryEncoder) GetTokenConfig(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_token_config", nil, []string{
+		"address",
+	}, []any{
+		localToken,
+	})
+}
+
+func (c tokenAdminRegistryEncoder) GetAllConfiguredTokens(startingBucketIndex uint64, startingVectorIndex uint64, maxCount uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_all_configured_tokens", nil, []string{
+		"u64",
+		"u64",
+		"u64",
+	}, []any{
+		startingBucketIndex,
+		startingVectorIndex,
+		maxCount,
+	})
+}
+
+func (c tokenAdminRegistryEncoder) IsAdministrator(localToken aptos.AccountAddress, administrator aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("is_administrator", nil, []string{
+		"address",
+		"address",
+	}, []any{
+		localToken,
+		administrator,
+	})
+}
+
+func (c tokenAdminRegistryEncoder) SetPool(localToken aptos.AccountAddress, tokenPoolAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("set_pool", nil, []string{
 		"address",
 		"address",
@@ -308,16 +362,7 @@ func (c TokenAdminRegistryTransactor) EncodeSetPool(localToken aptos.AccountAddr
 	})
 }
 
-func (c TokenAdminRegistryTransactor) SetPool(opts *bind.TransactOpts, localToken aptos.AccountAddress, tokenPoolAddress aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeSetPool(localToken, tokenPoolAddress)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c TokenAdminRegistryTransactor) EncodeTransferAdminRole(localToken aptos.AccountAddress, newAdmin aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c tokenAdminRegistryEncoder) TransferAdminRole(localToken aptos.AccountAddress, newAdmin aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("transfer_admin_role", nil, []string{
 		"address",
 		"address",
@@ -327,16 +372,7 @@ func (c TokenAdminRegistryTransactor) EncodeTransferAdminRole(localToken aptos.A
 	})
 }
 
-func (c TokenAdminRegistryTransactor) TransferAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress, newAdmin aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeTransferAdminRole(localToken, newAdmin)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c TokenAdminRegistryTransactor) EncodeAcceptAdminRole(localToken aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c tokenAdminRegistryEncoder) AcceptAdminRole(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("accept_admin_role", nil, []string{
 		"address",
 	}, []any{
@@ -344,18 +380,7 @@ func (c TokenAdminRegistryTransactor) EncodeAcceptAdminRole(localToken aptos.Acc
 	})
 }
 
-func (c TokenAdminRegistryTransactor) AcceptAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeAcceptAdminRole(localToken)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-// Other Functions
-
-func (c TokenAdminRegistryCaller) EncodeFinishLockOrBurn(tokenPoolAddress aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c tokenAdminRegistryEncoder) FinishLockOrBurn(tokenPoolAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("finish_lock_or_burn", nil, []string{
 		"address",
 	}, []any{
@@ -363,7 +388,7 @@ func (c TokenAdminRegistryCaller) EncodeFinishLockOrBurn(tokenPoolAddress aptos.
 	})
 }
 
-func (c TokenAdminRegistryCaller) EncodeFinishReleaseOrMint(tokenPoolAddress aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c tokenAdminRegistryEncoder) FinishReleaseOrMint(tokenPoolAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("finish_release_or_mint", nil, []string{
 		"address",
 	}, []any{

--- a/bindings/ccip_dummy_receiver/ccip_dummy_receiver.go
+++ b/bindings/ccip_dummy_receiver/ccip_dummy_receiver.go
@@ -47,13 +47,9 @@ func Compile(address aptos.AccountAddress, ccipAddress aptos.AccountAddress) (co
 }
 
 func Bind(address aptos.AccountAddress, client aptos.AptosRpcClient) CCIPDummyReceiver {
-	dummyReceiverContract := bind.NewBoundContract(address, "dummy_receiver", client)
 	return CCIPDummyReceiverContract{
-		address: address,
-		dummyReceiver: module_dummy_receiver.DummyReceiverContract{
-			DummyReceiverCaller:     module_dummy_receiver.DummyReceiverCaller{BoundContract: dummyReceiverContract},
-			DummyReceiverTransactor: module_dummy_receiver.DummyReceiverTransactor{BoundContract: dummyReceiverContract},
-		},
+		address:       address,
+		dummyReceiver: module_dummy_receiver.NewDummyReceiver(address, client),
 	}
 }
 

--- a/bindings/ccip_dummy_receiver/ccip_dummy_receiver.go
+++ b/bindings/ccip_dummy_receiver/ccip_dummy_receiver.go
@@ -9,10 +9,26 @@ import (
 	"github.com/smartcontractkit/chainlink-aptos/bindings/compile"
 )
 
-type CCIPDummyReceiver struct {
-	Address aptos.AccountAddress
+type CCIPDummyReceiver interface {
+	Address() aptos.AccountAddress
 
-	DummyReceiver module_dummy_receiver.DummyReceiver
+	DummyReceiver() module_dummy_receiver.DummyReceiver
+}
+
+var _ CCIPDummyReceiver = CCIPDummyReceiverContract{}
+
+type CCIPDummyReceiverContract struct {
+	address aptos.AccountAddress
+
+	dummyReceiver module_dummy_receiver.DummyReceiver
+}
+
+func (C CCIPDummyReceiverContract) Address() aptos.AccountAddress {
+	return C.address
+}
+
+func (C CCIPDummyReceiverContract) DummyReceiver() module_dummy_receiver.DummyReceiver {
+	return C.dummyReceiver
 }
 
 var FunctionInfo = bind.MustParseFunctionInfo(
@@ -21,9 +37,9 @@ var FunctionInfo = bind.MustParseFunctionInfo(
 
 func Compile(address aptos.AccountAddress, ccipAddress aptos.AccountAddress) (compile.CompiledPackage, error) {
 	namedAddresses := map[string]aptos.AccountAddress{
-		"ccip_dummy_receiver":                      address,
-		"ccip": ccipAddress,
-		"mcms": aptos.AccountZero,
+		"ccip_dummy_receiver":       address,
+		"ccip":                      ccipAddress,
+		"mcms":                      aptos.AccountZero,
 		"mcms_register_entrypoints": aptos.AccountZero,
 	}
 	// Compile using CLI
@@ -32,10 +48,10 @@ func Compile(address aptos.AccountAddress, ccipAddress aptos.AccountAddress) (co
 
 func Bind(address aptos.AccountAddress, client aptos.AptosRpcClient) CCIPDummyReceiver {
 	dummyReceiverContract := bind.NewBoundContract(address, "dummy_receiver", client)
-	return CCIPDummyReceiver{
-		Address: address,
-		DummyReceiver: module_dummy_receiver.DummyReceiver{
-			DummyReceiverCaller: module_dummy_receiver.DummyReceiverCaller{BoundContract: dummyReceiverContract},
+	return CCIPDummyReceiverContract{
+		address: address,
+		dummyReceiver: module_dummy_receiver.DummyReceiverContract{
+			DummyReceiverCaller:     module_dummy_receiver.DummyReceiverCaller{BoundContract: dummyReceiverContract},
 			DummyReceiverTransactor: module_dummy_receiver.DummyReceiverTransactor{BoundContract: dummyReceiverContract},
 		},
 	}
@@ -49,13 +65,13 @@ func DeployToObject(
 	ccipAddress aptos.AccountAddress,
 ) (aptos.AccountAddress, *api.PendingTransaction, CCIPDummyReceiver, error) {
 	namedAddresses := map[string]aptos.AccountAddress{
-		"ccip": ccipAddress,
-		"mcms": aptos.AccountZero,
+		"ccip":                      ccipAddress,
+		"mcms":                      aptos.AccountZero,
 		"mcms_register_entrypoints": aptos.AccountZero,
 	}
 	address, tx, err := bind.DeployPackageToObject(auth, client, "ccip_dummy_receiver", namedAddresses)
 	if err != nil {
-		return aptos.AccountAddress{}, nil, CCIPDummyReceiver{}, err
+		return aptos.AccountAddress{}, nil, CCIPDummyReceiverContract{}, err
 	}
 	return address, tx, Bind(address, client), nil
 }

--- a/bindings/ccip_dummy_receiver/dummy_receiver/dummy_receiver.go
+++ b/bindings/ccip_dummy_receiver/dummy_receiver/dummy_receiver.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type DummyReceiverInterface interface {
+type DummyReceiver interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 }
 
@@ -36,7 +36,7 @@ type ReceivedMessage struct {
 type DummyReceiverProof struct {
 }
 
-type DummyReceiver struct {
+type DummyReceiverContract struct {
 	DummyReceiverCaller
 	DummyReceiverTransactor
 }

--- a/bindings/ccip_dummy_receiver/dummy_receiver/dummy_receiver.go
+++ b/bindings/ccip_dummy_receiver/dummy_receiver/dummy_receiver.go
@@ -24,7 +24,8 @@ var (
 type DummyReceiver interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 
-	Encode_() DummyReceiverEncoder
+	// Encode returns the encoder implementation of this module.
+	Encoder() DummyReceiverEncoder
 }
 
 type DummyReceiverEncoder interface {
@@ -57,7 +58,7 @@ type DummyReceiverContract struct {
 
 var _ DummyReceiver = DummyReceiverContract{}
 
-func (c DummyReceiverContract) Encode_() DummyReceiverEncoder {
+func (c DummyReceiverContract) Encoder() DummyReceiverEncoder {
 	return c.dummyReceiverEncoder
 }
 

--- a/bindings/ccip_dummy_receiver/dummy_receiver/dummy_receiver.go
+++ b/bindings/ccip_dummy_receiver/dummy_receiver/dummy_receiver.go
@@ -23,9 +23,23 @@ var (
 
 type DummyReceiver interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
+
+	EncodeCall() DummyReceiverEncoder
+}
+
+type DummyReceiverEncoder interface {
+	TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
 const FunctionInfo = `null`
+
+func NewDummyReceiver(address aptos.AccountAddress, client aptos.AptosRpcClient) DummyReceiver {
+	contract := bind.NewBoundContract(address, "ccip_dummy_receiver", "dummy_receiver", client)
+	return DummyReceiverContract{
+		BoundContract:        contract,
+		dummyReceiverEncoder: dummyReceiverEncoder{BoundContract: contract},
+	}
+}
 
 // Structs
 
@@ -37,22 +51,20 @@ type DummyReceiverProof struct {
 }
 
 type DummyReceiverContract struct {
-	DummyReceiverCaller
-	DummyReceiverTransactor
+	*bind.BoundContract
+	dummyReceiverEncoder
+}
+
+var _ DummyReceiver = DummyReceiverContract{}
+
+func (c DummyReceiverContract) EncodeCall() DummyReceiverEncoder {
+	return c.dummyReceiverEncoder
 }
 
 // View Functions
 
-type DummyReceiverCaller struct {
-	*bind.BoundContract
-}
-
-func (c DummyReceiverCaller) EncodeTypeAndVersion() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
-}
-
-func (c DummyReceiverCaller) TypeAndVersion(opts *bind.CallOpts) (string, error) {
-	module, function, typeTags, args, err := c.EncodeTypeAndVersion()
+func (c DummyReceiverContract) TypeAndVersion(opts *bind.CallOpts) (string, error) {
+	module, function, typeTags, args, err := c.dummyReceiverEncoder.TypeAndVersion()
 	if err != nil {
 		return *new(string), err
 	}
@@ -74,6 +86,11 @@ func (c DummyReceiverCaller) TypeAndVersion(opts *bind.CallOpts) (string, error)
 
 // Entry Functions
 
-type DummyReceiverTransactor struct {
+// Encoder
+type dummyReceiverEncoder struct {
 	*bind.BoundContract
+}
+
+func (c dummyReceiverEncoder) TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
 }

--- a/bindings/ccip_dummy_receiver/dummy_receiver/dummy_receiver.go
+++ b/bindings/ccip_dummy_receiver/dummy_receiver/dummy_receiver.go
@@ -24,7 +24,7 @@ var (
 type DummyReceiver interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 
-	_Encode() DummyReceiverEncoder
+	Encode_() DummyReceiverEncoder
 }
 
 type DummyReceiverEncoder interface {
@@ -57,7 +57,7 @@ type DummyReceiverContract struct {
 
 var _ DummyReceiver = DummyReceiverContract{}
 
-func (c DummyReceiverContract) _Encode() DummyReceiverEncoder {
+func (c DummyReceiverContract) Encode_() DummyReceiverEncoder {
 	return c.dummyReceiverEncoder
 }
 

--- a/bindings/ccip_dummy_receiver/dummy_receiver/dummy_receiver.go
+++ b/bindings/ccip_dummy_receiver/dummy_receiver/dummy_receiver.go
@@ -24,7 +24,7 @@ var (
 type DummyReceiver interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 
-	// Encode returns the encoder implementation of this module.
+	// Encoder returns the encoder implementation of this module.
 	Encoder() DummyReceiverEncoder
 }
 

--- a/bindings/ccip_dummy_receiver/dummy_receiver/dummy_receiver.go
+++ b/bindings/ccip_dummy_receiver/dummy_receiver/dummy_receiver.go
@@ -24,7 +24,7 @@ var (
 type DummyReceiver interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 
-	EncodeCall() DummyReceiverEncoder
+	_Encode() DummyReceiverEncoder
 }
 
 type DummyReceiverEncoder interface {
@@ -57,7 +57,7 @@ type DummyReceiverContract struct {
 
 var _ DummyReceiver = DummyReceiverContract{}
 
-func (c DummyReceiverContract) EncodeCall() DummyReceiverEncoder {
+func (c DummyReceiverContract) _Encode() DummyReceiverEncoder {
 	return c.dummyReceiverEncoder
 }
 

--- a/bindings/ccip_router/ccip_router.go
+++ b/bindings/ccip_router/ccip_router.go
@@ -7,6 +7,7 @@ import (
 	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
 	module_router "github.com/smartcontractkit/chainlink-aptos/bindings/ccip_router/router"
 	"github.com/smartcontractkit/chainlink-aptos/bindings/compile"
+	"github.com/smartcontractkit/chainlink-aptos/bindings/mcms"
 )
 
 type CCIPRouter interface {
@@ -75,4 +76,9 @@ func DeployToExistingObject(
 		return nil, CCIPRouterContract{}, err
 	}
 	return tx, Bind(objectAddress, client), nil
+}
+
+func as() {
+	mcmsBindings := mcms.Bind(aptos.AccountThree, nil)
+	mcmsBindings.MCMS().SetConfig()
 }

--- a/bindings/ccip_router/ccip_router.go
+++ b/bindings/ccip_router/ccip_router.go
@@ -51,13 +51,9 @@ func Compile(ccipAddress, mcmsAddress aptos.AccountAddress) (compile.CompiledPac
 }
 
 func Bind(address aptos.AccountAddress, client aptos.AptosRpcClient) CCIPRouter {
-	router := bind.NewBoundContract(address, "router", client)
 	return CCIPRouterContract{
 		address: address,
-		router: module_router.RouterContract{
-			RouterCaller:     module_router.RouterCaller{BoundContract: router},
-			RouterTransactor: module_router.RouterTransactor{BoundContract: router},
-		},
+		router:  module_router.NewRouter(address, client),
 	}
 }
 

--- a/bindings/ccip_router/ccip_router.go
+++ b/bindings/ccip_router/ccip_router.go
@@ -9,10 +9,26 @@ import (
 	"github.com/smartcontractkit/chainlink-aptos/bindings/compile"
 )
 
-type CCIPRouter struct {
-	Address aptos.AccountAddress
+type CCIPRouter interface {
+	Address() aptos.AccountAddress
 
-	Router module_router.Router
+	Router() module_router.Router
+}
+
+var _ CCIPRouter = CCIPRouterContract{}
+
+type CCIPRouterContract struct {
+	address aptos.AccountAddress
+
+	router module_router.Router
+}
+
+func (C CCIPRouterContract) Address() aptos.AccountAddress {
+	return C.address
+}
+
+func (C CCIPRouterContract) Router() module_router.Router {
+	return C.router
 }
 
 const (
@@ -36,9 +52,9 @@ func Compile(ccipAddress aptos.AccountAddress) (compile.CompiledPackage, error) 
 
 func Bind(address aptos.AccountAddress, client aptos.AptosRpcClient) CCIPRouter {
 	router := bind.NewBoundContract(address, "router", client)
-	return CCIPRouter{
-		Address: address,
-		Router: module_router.Router{
+	return CCIPRouterContract{
+		address: address,
+		router: module_router.RouterContract{
 			RouterCaller:     module_router.RouterCaller{BoundContract: router},
 			RouterTransactor: module_router.RouterTransactor{BoundContract: router},
 		},
@@ -61,7 +77,7 @@ func DeployToExistingObject(
 	}
 	tx, err := bind.UpgradePackageToObject(auth, client, "ccip_router", namedAddresses, objectAddress)
 	if err != nil {
-		return nil, CCIPRouter{}, err
+		return nil, CCIPRouterContract{}, err
 	}
 	return tx, Bind(objectAddress, client), nil
 }

--- a/bindings/ccip_router/router/router.go
+++ b/bindings/ccip_router/router/router.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type RouterInterface interface {
+type Router interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 	GetStateAddress(opts *bind.CallOpts) (aptos.AccountAddress, error)
 	IsChainSupported(opts *bind.CallOpts, destChainSelector uint64) (bool, error)
@@ -37,7 +37,7 @@ const FunctionInfo = `[{"package":"ccip_router","module":"router","name":"ccip_s
 type RouterState struct {
 }
 
-type Router struct {
+type RouterContract struct {
 	RouterCaller
 	RouterTransactor
 }

--- a/bindings/ccip_router/router/router.go
+++ b/bindings/ccip_router/router/router.go
@@ -29,7 +29,7 @@ type Router interface {
 
 	CCIPSend(opts *bind.TransactOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (*api.PendingTransaction, error)
 
-	_Encode() RouterEncoder
+	Encode_() RouterEncoder
 }
 
 type RouterEncoder interface {
@@ -63,7 +63,7 @@ type RouterContract struct {
 
 var _ Router = RouterContract{}
 
-func (c RouterContract) _Encode() RouterEncoder {
+func (c RouterContract) Encode_() RouterEncoder {
 	return c.routerEncoder
 }
 

--- a/bindings/ccip_router/router/router.go
+++ b/bindings/ccip_router/router/router.go
@@ -28,9 +28,28 @@ type Router interface {
 	GetFee(opts *bind.CallOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (uint64, error)
 
 	CCIPSend(opts *bind.TransactOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (*api.PendingTransaction, error)
+
+	EncodeCall() RouterEncoder
+}
+
+type RouterEncoder interface {
+	TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetStateAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	IsChainSupported(destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetFee(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	CCIPSend(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	CCIPSendWithMessageId(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
 const FunctionInfo = `[{"package":"ccip_router","module":"router","name":"ccip_send","parameters":[{"name":"dest_chain_selector","type":"u64"},{"name":"receiver","type":"vector\u003cu8\u003e"},{"name":"data","type":"vector\u003cu8\u003e"},{"name":"token_addresses","type":"vector\u003caddress\u003e"},{"name":"token_amounts","type":"vector\u003cu64\u003e"},{"name":"token_store_addresses","type":"vector\u003caddress\u003e"},{"name":"fee_token","type":"address"},{"name":"fee_token_store","type":"address"},{"name":"extra_args","type":"vector\u003cu8\u003e"}]},{"package":"ccip_router","module":"router","name":"ccip_send_with_message_id","parameters":[{"name":"dest_chain_selector","type":"u64"},{"name":"receiver","type":"vector\u003cu8\u003e"},{"name":"data","type":"vector\u003cu8\u003e"},{"name":"token_addresses","type":"vector\u003caddress\u003e"},{"name":"token_amounts","type":"vector\u003cu64\u003e"},{"name":"token_store_addresses","type":"vector\u003caddress\u003e"},{"name":"fee_token","type":"address"},{"name":"fee_token_store","type":"address"},{"name":"extra_args","type":"vector\u003cu8\u003e"}]}]`
+
+func NewRouter(address aptos.AccountAddress, client aptos.AptosRpcClient) Router {
+	contract := bind.NewBoundContract(address, "ccip_router", "router", client)
+	return RouterContract{
+		BoundContract: contract,
+		routerEncoder: routerEncoder{BoundContract: contract},
+	}
+}
 
 // Structs
 
@@ -38,22 +57,20 @@ type RouterState struct {
 }
 
 type RouterContract struct {
-	RouterCaller
-	RouterTransactor
+	*bind.BoundContract
+	routerEncoder
+}
+
+var _ Router = RouterContract{}
+
+func (c RouterContract) EncodeCall() RouterEncoder {
+	return c.routerEncoder
 }
 
 // View Functions
 
-type RouterCaller struct {
-	*bind.BoundContract
-}
-
-func (c RouterCaller) EncodeTypeAndVersion() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
-}
-
-func (c RouterCaller) TypeAndVersion(opts *bind.CallOpts) (string, error) {
-	module, function, typeTags, args, err := c.EncodeTypeAndVersion()
+func (c RouterContract) TypeAndVersion(opts *bind.CallOpts) (string, error) {
+	module, function, typeTags, args, err := c.routerEncoder.TypeAndVersion()
 	if err != nil {
 		return *new(string), err
 	}
@@ -73,12 +90,8 @@ func (c RouterCaller) TypeAndVersion(opts *bind.CallOpts) (string, error) {
 	return r0, nil
 }
 
-func (c RouterCaller) EncodeGetStateAddress() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_state_address", nil, []string{}, []any{})
-}
-
-func (c RouterCaller) GetStateAddress(opts *bind.CallOpts) (aptos.AccountAddress, error) {
-	module, function, typeTags, args, err := c.EncodeGetStateAddress()
+func (c RouterContract) GetStateAddress(opts *bind.CallOpts) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.routerEncoder.GetStateAddress()
 	if err != nil {
 		return *new(aptos.AccountAddress), err
 	}
@@ -98,16 +111,8 @@ func (c RouterCaller) GetStateAddress(opts *bind.CallOpts) (aptos.AccountAddress
 	return r0, nil
 }
 
-func (c RouterCaller) EncodeIsChainSupported(destChainSelector uint64) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("is_chain_supported", nil, []string{
-		"u64",
-	}, []any{
-		destChainSelector,
-	})
-}
-
-func (c RouterCaller) IsChainSupported(opts *bind.CallOpts, destChainSelector uint64) (bool, error) {
-	module, function, typeTags, args, err := c.EncodeIsChainSupported(destChainSelector)
+func (c RouterContract) IsChainSupported(opts *bind.CallOpts, destChainSelector uint64) (bool, error) {
+	module, function, typeTags, args, err := c.routerEncoder.IsChainSupported(destChainSelector)
 	if err != nil {
 		return *new(bool), err
 	}
@@ -127,7 +132,60 @@ func (c RouterCaller) IsChainSupported(opts *bind.CallOpts, destChainSelector ui
 	return r0, nil
 }
 
-func (c RouterCaller) EncodeGetFee(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c RouterContract) GetFee(opts *bind.CallOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (uint64, error) {
+	module, function, typeTags, args, err := c.routerEncoder.GetFee(destChainSelector, receiver, data, tokenAddresses, tokenAmounts, tokenStoreAddresses, feeToken, feeTokenStore, extraArgs)
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	var (
+		r0 uint64
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(uint64), err
+	}
+	return r0, nil
+}
+
+// Entry Functions
+
+func (c RouterContract) CCIPSend(opts *bind.TransactOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.routerEncoder.CCIPSend(destChainSelector, receiver, data, tokenAddresses, tokenAmounts, tokenStoreAddresses, feeToken, feeTokenStore, extraArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+// Encoder
+type routerEncoder struct {
+	*bind.BoundContract
+}
+
+func (c routerEncoder) TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
+}
+
+func (c routerEncoder) GetStateAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_state_address", nil, []string{}, []any{})
+}
+
+func (c routerEncoder) IsChainSupported(destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("is_chain_supported", nil, []string{
+		"u64",
+	}, []any{
+		destChainSelector,
+	})
+}
+
+func (c routerEncoder) GetFee(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("get_fee", nil, []string{
 		"u64",
 		"vector<u8>",
@@ -151,34 +209,7 @@ func (c RouterCaller) EncodeGetFee(destChainSelector uint64, receiver []byte, da
 	})
 }
 
-func (c RouterCaller) GetFee(opts *bind.CallOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (uint64, error) {
-	module, function, typeTags, args, err := c.EncodeGetFee(destChainSelector, receiver, data, tokenAddresses, tokenAmounts, tokenStoreAddresses, feeToken, feeTokenStore, extraArgs)
-	if err != nil {
-		return *new(uint64), err
-	}
-
-	callData, err := c.Call(opts, module, function, typeTags, args)
-	if err != nil {
-		return *new(uint64), err
-	}
-
-	var (
-		r0 uint64
-	)
-
-	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
-		return *new(uint64), err
-	}
-	return r0, nil
-}
-
-// Entry Functions
-
-type RouterTransactor struct {
-	*bind.BoundContract
-}
-
-func (c RouterTransactor) EncodeCCIPSend(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c routerEncoder) CCIPSend(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("ccip_send", nil, []string{
 		"u64",
 		"vector<u8>",
@@ -202,18 +233,7 @@ func (c RouterTransactor) EncodeCCIPSend(destChainSelector uint64, receiver []by
 	})
 }
 
-func (c RouterTransactor) CCIPSend(opts *bind.TransactOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeCCIPSend(destChainSelector, receiver, data, tokenAddresses, tokenAmounts, tokenStoreAddresses, feeToken, feeTokenStore, extraArgs)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-// Other Functions
-
-func (c RouterCaller) EncodeCCIPSendWithMessageId(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c routerEncoder) CCIPSendWithMessageId(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("ccip_send_with_message_id", nil, []string{
 		"u64",
 		"vector<u8>",

--- a/bindings/ccip_router/router/router.go
+++ b/bindings/ccip_router/router/router.go
@@ -29,7 +29,8 @@ type Router interface {
 
 	CCIPSend(opts *bind.TransactOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (*api.PendingTransaction, error)
 
-	Encode_() RouterEncoder
+	// Encode returns the encoder implementation of this module.
+	Encoder() RouterEncoder
 }
 
 type RouterEncoder interface {
@@ -63,7 +64,7 @@ type RouterContract struct {
 
 var _ Router = RouterContract{}
 
-func (c RouterContract) Encode_() RouterEncoder {
+func (c RouterContract) Encoder() RouterEncoder {
 	return c.routerEncoder
 }
 

--- a/bindings/ccip_router/router/router.go
+++ b/bindings/ccip_router/router/router.go
@@ -29,7 +29,7 @@ type Router interface {
 
 	CCIPSend(opts *bind.TransactOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (*api.PendingTransaction, error)
 
-	// Encode returns the encoder implementation of this module.
+	// Encoder returns the encoder implementation of this module.
 	Encoder() RouterEncoder
 }
 

--- a/bindings/ccip_router/router/router.go
+++ b/bindings/ccip_router/router/router.go
@@ -29,7 +29,7 @@ type Router interface {
 
 	CCIPSend(opts *bind.TransactOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (*api.PendingTransaction, error)
 
-	EncodeCall() RouterEncoder
+	_Encode() RouterEncoder
 }
 
 type RouterEncoder interface {
@@ -63,7 +63,7 @@ type RouterContract struct {
 
 var _ Router = RouterContract{}
 
-func (c RouterContract) EncodeCall() RouterEncoder {
+func (c RouterContract) _Encode() RouterEncoder {
 	return c.routerEncoder
 }
 

--- a/bindings/mcms/mcms.go
+++ b/bindings/mcms/mcms.go
@@ -73,32 +73,13 @@ func Bind(
 	address aptos.AccountAddress,
 	client aptos.AptosRpcClient,
 ) MCMS {
-	mcmsContract := bind.NewBoundContract(address, "mcms", client)
-	mcmsAccountContract := bind.NewBoundContract(address, "mcms_account", client)
-	mcmsDeployerContract := bind.NewBoundContract(address, "mcms_deployer", client)
-	mcmsExecutorContract := bind.NewBoundContract(address, "mcms_executor", client)
-	mcmsRegistryContract := bind.NewBoundContract(address, "mcms_registry", client)
 	return MCMSContract{
-		address: address,
-		mcms: module_mcms.MCMSContract{
-			MCMSCaller:     module_mcms.MCMSCaller{BoundContract: mcmsContract},
-			MCMSTransactor: module_mcms.MCMSTransactor{BoundContract: mcmsContract},
-		},
-		mcmsAccount: module_mcms_account.MCMSAccountContract{
-			MCMSAccountCaller:     module_mcms_account.MCMSAccountCaller{BoundContract: mcmsAccountContract},
-			MCMSAccountTransactor: module_mcms_account.MCMSAccountTransactor{BoundContract: mcmsAccountContract},
-		},
-		mcmsDeployer: module_mcms_deployer.MCMSDeployerContract{
-			MCMSDeployerTransactor: module_mcms_deployer.MCMSDeployerTransactor{BoundContract: mcmsDeployerContract},
-		},
-		mcmsExecutor: module_mcms_executor.MCMSExecutorContract{
-			MCMSExecutorCaller:     module_mcms_executor.MCMSExecutorCaller{BoundContract: mcmsExecutorContract},
-			MCMSExecutorTransactor: module_mcms_executor.MCMSExecutorTransactor{BoundContract: mcmsExecutorContract},
-		},
-		mcmsRegistry: module_mcms_registry.MCMSRegistryContract{
-			MCMSRegistryCaller:     module_mcms_registry.MCMSRegistryCaller{BoundContract: mcmsRegistryContract},
-			MCMSRegistryTransactor: module_mcms_registry.MCMSRegistryTransactor{BoundContract: mcmsRegistryContract},
-		},
+		address:      address,
+		mcms:         module_mcms.NewMCMS(address, client),
+		mcmsAccount:  module_mcms_account.NewMCMSAccount(address, client),
+		mcmsDeployer: module_mcms_deployer.NewMCMSDeployer(address, client),
+		mcmsExecutor: module_mcms_executor.NewMCMSExecutor(address, client),
+		mcmsRegistry: module_mcms_registry.NewMCMSRegistry(address, client),
 	}
 }
 

--- a/bindings/mcms/mcms.go
+++ b/bindings/mcms/mcms.go
@@ -12,14 +12,49 @@ import (
 	module_mcms_registry "github.com/smartcontractkit/chainlink-aptos/bindings/mcms/mcms_registry"
 )
 
-type MCMS struct {
-	Address aptos.AccountAddress
+type MCMS interface {
+	Address() aptos.AccountAddress
+	MCMS() module_mcms.MCMS
+	MCMSAccount() module_mcms_account.MCMSAccount
+	MCMSDeployer() module_mcms_deployer.MCMSDeployer
+	MCMSExecutor() module_mcms_executor.MCMSExecutor
+	MCMSRegistry() module_mcms_registry.MCMSRegistry
+}
 
-	MCMS         module_mcms.MCMS
-	MCMSAccount  module_mcms_account.MCMSAccount
-	MCMSDeployer module_mcms_deployer.MCMSDeployer
-	MCMSExecutor module_mcms_executor.MCMSExecutor
-	MCMSRegistry module_mcms_registry.MCMSRegistry
+var _ MCMS = MCMSContract{}
+
+type MCMSContract struct {
+	address aptos.AccountAddress
+
+	mcms         module_mcms.MCMS
+	mcmsAccount  module_mcms_account.MCMSAccount
+	mcmsDeployer module_mcms_deployer.MCMSDeployer
+	mcmsExecutor module_mcms_executor.MCMSExecutor
+	mcmsRegistry module_mcms_registry.MCMSRegistry
+}
+
+func (M MCMSContract) Address() aptos.AccountAddress {
+	return M.address
+}
+
+func (M MCMSContract) MCMS() module_mcms.MCMS {
+	return M.mcms
+}
+
+func (M MCMSContract) MCMSAccount() module_mcms_account.MCMSAccount {
+	return M.mcmsAccount
+}
+
+func (M MCMSContract) MCMSDeployer() module_mcms_deployer.MCMSDeployer {
+	return M.mcmsDeployer
+}
+
+func (M MCMSContract) MCMSExecutor() module_mcms_executor.MCMSExecutor {
+	return M.mcmsExecutor
+}
+
+func (M MCMSContract) MCMSRegistry() module_mcms_registry.MCMSRegistry {
+	return M.mcmsRegistry
 }
 
 const (
@@ -43,24 +78,24 @@ func Bind(
 	mcmsDeployerContract := bind.NewBoundContract(address, "mcms_deployer", client)
 	mcmsExecutorContract := bind.NewBoundContract(address, "mcms_executor", client)
 	mcmsRegistryContract := bind.NewBoundContract(address, "mcms_registry", client)
-	return MCMS{
-		Address: address,
-		MCMS: module_mcms.MCMS{
+	return MCMSContract{
+		address: address,
+		mcms: module_mcms.MCMSContract{
 			MCMSCaller:     module_mcms.MCMSCaller{BoundContract: mcmsContract},
 			MCMSTransactor: module_mcms.MCMSTransactor{BoundContract: mcmsContract},
 		},
-		MCMSAccount: module_mcms_account.MCMSAccount{
+		mcmsAccount: module_mcms_account.MCMSAccountContract{
 			MCMSAccountCaller:     module_mcms_account.MCMSAccountCaller{BoundContract: mcmsAccountContract},
 			MCMSAccountTransactor: module_mcms_account.MCMSAccountTransactor{BoundContract: mcmsAccountContract},
 		},
-		MCMSDeployer: module_mcms_deployer.MCMSDeployer{
+		mcmsDeployer: module_mcms_deployer.MCMSDeployerContract{
 			MCMSDeployerTransactor: module_mcms_deployer.MCMSDeployerTransactor{BoundContract: mcmsDeployerContract},
 		},
-		MCMSExecutor: module_mcms_executor.MCMSExecutor{
+		mcmsExecutor: module_mcms_executor.MCMSExecutorContract{
 			MCMSExecutorCaller:     module_mcms_executor.MCMSExecutorCaller{BoundContract: mcmsExecutorContract},
 			MCMSExecutorTransactor: module_mcms_executor.MCMSExecutorTransactor{BoundContract: mcmsExecutorContract},
 		},
-		MCMSRegistry: module_mcms_registry.MCMSRegistry{
+		mcmsRegistry: module_mcms_registry.MCMSRegistryContract{
 			MCMSRegistryCaller:     module_mcms_registry.MCMSRegistryCaller{BoundContract: mcmsRegistryContract},
 			MCMSRegistryTransactor: module_mcms_registry.MCMSRegistryTransactor{BoundContract: mcmsRegistryContract},
 		},
@@ -84,7 +119,7 @@ func DeployToResourceAccount(
 		"mcms_owner": auth.AccountAddress(),
 	})
 	if err != nil {
-		return aptos.AccountAddress{}, nil, MCMS{}, err
+		return aptos.AccountAddress{}, nil, MCMSContract{}, err
 	}
 
 	return address, tx, Bind(address, client), nil

--- a/bindings/mcms/mcms/mcms.go
+++ b/bindings/mcms/mcms/mcms.go
@@ -31,7 +31,7 @@ type MCMS interface {
 	Execute(opts *bind.TransactOpts, chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, data []byte, proof [][]byte) (*api.PendingTransaction, error)
 	SetConfig(opts *bind.TransactOpts, signerAddresses [][]byte, signerGroups []byte, groupQuorums []byte, groupParents []byte, clearRoot bool) (*api.PendingTransaction, error)
 
-	_Encode() MCMSEncoder
+	Encode_() MCMSEncoder
 }
 
 type MCMSEncoder interface {
@@ -124,7 +124,7 @@ type MCMSContract struct {
 
 var _ MCMS = MCMSContract{}
 
-func (c MCMSContract) _Encode() MCMSEncoder {
+func (c MCMSContract) Encode_() MCMSEncoder {
 	return c.mcmsEncoder
 }
 

--- a/bindings/mcms/mcms/mcms.go
+++ b/bindings/mcms/mcms/mcms.go
@@ -30,9 +30,29 @@ type MCMS interface {
 	SetRoot(opts *bind.TransactOpts, root []byte, validUntil uint64, chainId *big.Int, multisig aptos.AccountAddress, preOpCount uint64, postOpCount uint64, overridePreviousRoot bool, metadataProof [][]byte, signatures [][]byte) (*api.PendingTransaction, error)
 	Execute(opts *bind.TransactOpts, chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, data []byte, proof [][]byte) (*api.PendingTransaction, error)
 	SetConfig(opts *bind.TransactOpts, signerAddresses [][]byte, signerGroups []byte, groupQuorums []byte, groupParents []byte, clearRoot bool) (*api.PendingTransaction, error)
+
+	EncodeCall() MCMSEncoder
+}
+
+type MCMSEncoder interface {
+	GetConfig() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetOpCount() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetRoot() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetRootMetadata() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetRoot(root []byte, validUntil uint64, chainId *big.Int, multisig aptos.AccountAddress, preOpCount uint64, postOpCount uint64, overridePreviousRoot bool, metadataProof [][]byte, signatures [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Execute(chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, data []byte, proof [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetConfig(signerAddresses [][]byte, signerGroups []byte, groupQuorums []byte, groupParents []byte, clearRoot bool) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
 const FunctionInfo = `[{"package":"mcms","module":"mcms","name":"execute","parameters":[{"name":"chain_id","type":"u256"},{"name":"multisig","type":"address"},{"name":"nonce","type":"u64"},{"name":"to","type":"address"},{"name":"module_name","type":"0x1::string::String"},{"name":"function","type":"0x1::string::String"},{"name":"data","type":"vector\u003cu8\u003e"},{"name":"proof","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"mcms","module":"mcms","name":"set_config","parameters":[{"name":"signer_addresses","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"signer_groups","type":"vector\u003cu8\u003e"},{"name":"group_quorums","type":"vector\u003cu8\u003e"},{"name":"group_parents","type":"vector\u003cu8\u003e"},{"name":"clear_root","type":"bool"}]},{"package":"mcms","module":"mcms","name":"set_root","parameters":[{"name":"root","type":"vector\u003cu8\u003e"},{"name":"valid_until","type":"u64"},{"name":"chain_id","type":"u256"},{"name":"multisig","type":"address"},{"name":"pre_op_count","type":"u64"},{"name":"post_op_count","type":"u64"},{"name":"override_previous_root","type":"bool"},{"name":"metadata_proof","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"signatures","type":"vector\u003cvector\u003cu8\u003e\u003e"}]}]`
+
+func NewMCMS(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMS {
+	contract := bind.NewBoundContract(address, "mcms", "mcms", client)
+	return MCMSContract{
+		BoundContract: contract,
+		mcmsEncoder:   mcmsEncoder{BoundContract: contract},
+	}
+}
 
 // Structs
 
@@ -98,22 +118,20 @@ type OpExecuted struct {
 }
 
 type MCMSContract struct {
-	MCMSCaller
-	MCMSTransactor
+	*bind.BoundContract
+	mcmsEncoder
+}
+
+var _ MCMS = MCMSContract{}
+
+func (c MCMSContract) EncodeCall() MCMSEncoder {
+	return c.mcmsEncoder
 }
 
 // View Functions
 
-type MCMSCaller struct {
-	*bind.BoundContract
-}
-
-func (c MCMSCaller) EncodeGetConfig() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_config", nil, []string{}, []any{})
-}
-
-func (c MCMSCaller) GetConfig(opts *bind.CallOpts) (Config, error) {
-	module, function, typeTags, args, err := c.EncodeGetConfig()
+func (c MCMSContract) GetConfig(opts *bind.CallOpts) (Config, error) {
+	module, function, typeTags, args, err := c.mcmsEncoder.GetConfig()
 	if err != nil {
 		return *new(Config), err
 	}
@@ -133,12 +151,8 @@ func (c MCMSCaller) GetConfig(opts *bind.CallOpts) (Config, error) {
 	return r0, nil
 }
 
-func (c MCMSCaller) EncodeGetOpCount() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_op_count", nil, []string{}, []any{})
-}
-
-func (c MCMSCaller) GetOpCount(opts *bind.CallOpts) (uint64, error) {
-	module, function, typeTags, args, err := c.EncodeGetOpCount()
+func (c MCMSContract) GetOpCount(opts *bind.CallOpts) (uint64, error) {
+	module, function, typeTags, args, err := c.mcmsEncoder.GetOpCount()
 	if err != nil {
 		return *new(uint64), err
 	}
@@ -158,12 +172,8 @@ func (c MCMSCaller) GetOpCount(opts *bind.CallOpts) (uint64, error) {
 	return r0, nil
 }
 
-func (c MCMSCaller) EncodeGetRoot() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_root", nil, []string{}, []any{})
-}
-
-func (c MCMSCaller) GetRoot(opts *bind.CallOpts) ([]byte, uint64, error) {
-	module, function, typeTags, args, err := c.EncodeGetRoot()
+func (c MCMSContract) GetRoot(opts *bind.CallOpts) ([]byte, uint64, error) {
+	module, function, typeTags, args, err := c.mcmsEncoder.GetRoot()
 	if err != nil {
 		return *new([]byte), *new(uint64), err
 	}
@@ -184,12 +194,8 @@ func (c MCMSCaller) GetRoot(opts *bind.CallOpts) ([]byte, uint64, error) {
 	return r0, r1, nil
 }
 
-func (c MCMSCaller) EncodeGetRootMetadata() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_root_metadata", nil, []string{}, []any{})
-}
-
-func (c MCMSCaller) GetRootMetadata(opts *bind.CallOpts) (RootMetadata, error) {
-	module, function, typeTags, args, err := c.EncodeGetRootMetadata()
+func (c MCMSContract) GetRootMetadata(opts *bind.CallOpts) (RootMetadata, error) {
+	module, function, typeTags, args, err := c.mcmsEncoder.GetRootMetadata()
 	if err != nil {
 		return *new(RootMetadata), err
 	}
@@ -211,11 +217,55 @@ func (c MCMSCaller) GetRootMetadata(opts *bind.CallOpts) (RootMetadata, error) {
 
 // Entry Functions
 
-type MCMSTransactor struct {
+func (c MCMSContract) SetRoot(opts *bind.TransactOpts, root []byte, validUntil uint64, chainId *big.Int, multisig aptos.AccountAddress, preOpCount uint64, postOpCount uint64, overridePreviousRoot bool, metadataProof [][]byte, signatures [][]byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.mcmsEncoder.SetRoot(root, validUntil, chainId, multisig, preOpCount, postOpCount, overridePreviousRoot, metadataProof, signatures)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c MCMSContract) Execute(opts *bind.TransactOpts, chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, data []byte, proof [][]byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.mcmsEncoder.Execute(chainId, multisig, nonce, to, moduleName, function, data, proof)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c MCMSContract) SetConfig(opts *bind.TransactOpts, signerAddresses [][]byte, signerGroups []byte, groupQuorums []byte, groupParents []byte, clearRoot bool) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.mcmsEncoder.SetConfig(signerAddresses, signerGroups, groupQuorums, groupParents, clearRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+// Encoder
+type mcmsEncoder struct {
 	*bind.BoundContract
 }
 
-func (c MCMSTransactor) EncodeSetRoot(root []byte, validUntil uint64, chainId *big.Int, multisig aptos.AccountAddress, preOpCount uint64, postOpCount uint64, overridePreviousRoot bool, metadataProof [][]byte, signatures [][]byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsEncoder) GetConfig() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_config", nil, []string{}, []any{})
+}
+
+func (c mcmsEncoder) GetOpCount() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_op_count", nil, []string{}, []any{})
+}
+
+func (c mcmsEncoder) GetRoot() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_root", nil, []string{}, []any{})
+}
+
+func (c mcmsEncoder) GetRootMetadata() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_root_metadata", nil, []string{}, []any{})
+}
+
+func (c mcmsEncoder) SetRoot(root []byte, validUntil uint64, chainId *big.Int, multisig aptos.AccountAddress, preOpCount uint64, postOpCount uint64, overridePreviousRoot bool, metadataProof [][]byte, signatures [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("set_root", nil, []string{
 		"vector<u8>",
 		"u64",
@@ -239,16 +289,7 @@ func (c MCMSTransactor) EncodeSetRoot(root []byte, validUntil uint64, chainId *b
 	})
 }
 
-func (c MCMSTransactor) SetRoot(opts *bind.TransactOpts, root []byte, validUntil uint64, chainId *big.Int, multisig aptos.AccountAddress, preOpCount uint64, postOpCount uint64, overridePreviousRoot bool, metadataProof [][]byte, signatures [][]byte) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeSetRoot(root, validUntil, chainId, multisig, preOpCount, postOpCount, overridePreviousRoot, metadataProof, signatures)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c MCMSTransactor) EncodeExecute(chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, data []byte, proof [][]byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsEncoder) Execute(chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, data []byte, proof [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("execute", nil, []string{
 		"u256",
 		"address",
@@ -270,16 +311,7 @@ func (c MCMSTransactor) EncodeExecute(chainId *big.Int, multisig aptos.AccountAd
 	})
 }
 
-func (c MCMSTransactor) Execute(opts *bind.TransactOpts, chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, data []byte, proof [][]byte) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeExecute(chainId, multisig, nonce, to, moduleName, function, data, proof)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c MCMSTransactor) EncodeSetConfig(signerAddresses [][]byte, signerGroups []byte, groupQuorums []byte, groupParents []byte, clearRoot bool) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsEncoder) SetConfig(signerAddresses [][]byte, signerGroups []byte, groupQuorums []byte, groupParents []byte, clearRoot bool) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("set_config", nil, []string{
 		"vector<vector<u8>>",
 		"vector<u8>",
@@ -293,13 +325,4 @@ func (c MCMSTransactor) EncodeSetConfig(signerAddresses [][]byte, signerGroups [
 		groupParents,
 		clearRoot,
 	})
-}
-
-func (c MCMSTransactor) SetConfig(opts *bind.TransactOpts, signerAddresses [][]byte, signerGroups []byte, groupQuorums []byte, groupParents []byte, clearRoot bool) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeSetConfig(signerAddresses, signerGroups, groupQuorums, groupParents, clearRoot)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
 }

--- a/bindings/mcms/mcms/mcms.go
+++ b/bindings/mcms/mcms/mcms.go
@@ -31,7 +31,8 @@ type MCMS interface {
 	Execute(opts *bind.TransactOpts, chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, data []byte, proof [][]byte) (*api.PendingTransaction, error)
 	SetConfig(opts *bind.TransactOpts, signerAddresses [][]byte, signerGroups []byte, groupQuorums []byte, groupParents []byte, clearRoot bool) (*api.PendingTransaction, error)
 
-	Encode_() MCMSEncoder
+	// Encode returns the encoder implementation of this module.
+	Encoder() MCMSEncoder
 }
 
 type MCMSEncoder interface {
@@ -124,7 +125,7 @@ type MCMSContract struct {
 
 var _ MCMS = MCMSContract{}
 
-func (c MCMSContract) Encode_() MCMSEncoder {
+func (c MCMSContract) Encoder() MCMSEncoder {
 	return c.mcmsEncoder
 }
 

--- a/bindings/mcms/mcms/mcms.go
+++ b/bindings/mcms/mcms/mcms.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type MCMSInterface interface {
+type MCMS interface {
 	GetConfig(opts *bind.CallOpts) (Config, error)
 	GetOpCount(opts *bind.CallOpts) (uint64, error)
 	GetRoot(opts *bind.CallOpts) ([]byte, uint64, error)
@@ -97,7 +97,7 @@ type OpExecuted struct {
 	Data       []byte               `move:"vector<u8>"`
 }
 
-type MCMS struct {
+type MCMSContract struct {
 	MCMSCaller
 	MCMSTransactor
 }

--- a/bindings/mcms/mcms/mcms.go
+++ b/bindings/mcms/mcms/mcms.go
@@ -31,7 +31,7 @@ type MCMS interface {
 	Execute(opts *bind.TransactOpts, chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, data []byte, proof [][]byte) (*api.PendingTransaction, error)
 	SetConfig(opts *bind.TransactOpts, signerAddresses [][]byte, signerGroups []byte, groupQuorums []byte, groupParents []byte, clearRoot bool) (*api.PendingTransaction, error)
 
-	EncodeCall() MCMSEncoder
+	_Encode() MCMSEncoder
 }
 
 type MCMSEncoder interface {
@@ -124,7 +124,7 @@ type MCMSContract struct {
 
 var _ MCMS = MCMSContract{}
 
-func (c MCMSContract) EncodeCall() MCMSEncoder {
+func (c MCMSContract) _Encode() MCMSEncoder {
 	return c.mcmsEncoder
 }
 

--- a/bindings/mcms/mcms/mcms.go
+++ b/bindings/mcms/mcms/mcms.go
@@ -31,7 +31,7 @@ type MCMS interface {
 	Execute(opts *bind.TransactOpts, chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, data []byte, proof [][]byte) (*api.PendingTransaction, error)
 	SetConfig(opts *bind.TransactOpts, signerAddresses [][]byte, signerGroups []byte, groupQuorums []byte, groupParents []byte, clearRoot bool) (*api.PendingTransaction, error)
 
-	// Encode returns the encoder implementation of this module.
+	// Encoder returns the encoder implementation of this module.
 	Encoder() MCMSEncoder
 }
 

--- a/bindings/mcms/mcms_account/mcms_account.go
+++ b/bindings/mcms/mcms_account/mcms_account.go
@@ -28,7 +28,7 @@ type MCMSAccount interface {
 	TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
 	TransferOwnershipToSelf(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 
-	_Encode() MCMSAccountEncoder
+	Encode_() MCMSAccountEncoder
 }
 
 type MCMSAccountEncoder interface {
@@ -74,7 +74,7 @@ type MCMSAccountContract struct {
 
 var _ MCMSAccount = MCMSAccountContract{}
 
-func (c MCMSAccountContract) _Encode() MCMSAccountEncoder {
+func (c MCMSAccountContract) Encode_() MCMSAccountEncoder {
 	return c.mcmsAccountEncoder
 }
 

--- a/bindings/mcms/mcms_account/mcms_account.go
+++ b/bindings/mcms/mcms_account/mcms_account.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type MCMSAccountInterface interface {
+type MCMSAccount interface {
 	Owner(opts *bind.CallOpts) (aptos.AccountAddress, error)
 	IsSelfOwned(opts *bind.CallOpts) (bool, error)
 
@@ -48,7 +48,7 @@ type OwnershipTransferred struct {
 	To   aptos.AccountAddress `move:"address"`
 }
 
-type MCMSAccount struct {
+type MCMSAccountContract struct {
 	MCMSAccountCaller
 	MCMSAccountTransactor
 }

--- a/bindings/mcms/mcms_account/mcms_account.go
+++ b/bindings/mcms/mcms_account/mcms_account.go
@@ -28,7 +28,8 @@ type MCMSAccount interface {
 	TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
 	TransferOwnershipToSelf(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 
-	Encode_() MCMSAccountEncoder
+	// Encode returns the encoder implementation of this module.
+	Encoder() MCMSAccountEncoder
 }
 
 type MCMSAccountEncoder interface {
@@ -74,7 +75,7 @@ type MCMSAccountContract struct {
 
 var _ MCMSAccount = MCMSAccountContract{}
 
-func (c MCMSAccountContract) Encode_() MCMSAccountEncoder {
+func (c MCMSAccountContract) Encoder() MCMSAccountEncoder {
 	return c.mcmsAccountEncoder
 }
 

--- a/bindings/mcms/mcms_account/mcms_account.go
+++ b/bindings/mcms/mcms_account/mcms_account.go
@@ -28,7 +28,7 @@ type MCMSAccount interface {
 	TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
 	TransferOwnershipToSelf(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 
-	EncodeCall() MCMSAccountEncoder
+	_Encode() MCMSAccountEncoder
 }
 
 type MCMSAccountEncoder interface {
@@ -74,7 +74,7 @@ type MCMSAccountContract struct {
 
 var _ MCMSAccount = MCMSAccountContract{}
 
-func (c MCMSAccountContract) EncodeCall() MCMSAccountEncoder {
+func (c MCMSAccountContract) _Encode() MCMSAccountEncoder {
 	return c.mcmsAccountEncoder
 }
 

--- a/bindings/mcms/mcms_account/mcms_account.go
+++ b/bindings/mcms/mcms_account/mcms_account.go
@@ -27,9 +27,28 @@ type MCMSAccount interface {
 
 	TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
 	TransferOwnershipToSelf(opts *bind.TransactOpts) (*api.PendingTransaction, error)
+
+	EncodeCall() MCMSAccountEncoder
+}
+
+type MCMSAccountEncoder interface {
+	Owner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	IsSelfOwned() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	TransferOwnershipToSelf() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AssertIsOwner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
 const FunctionInfo = `[{"package":"mcms","module":"mcms_account","name":"accept_ownership","parameters":null},{"package":"mcms","module":"mcms_account","name":"assert_is_owner","parameters":null},{"package":"mcms","module":"mcms_account","name":"transfer_ownership","parameters":[{"name":"to","type":"address"}]},{"package":"mcms","module":"mcms_account","name":"transfer_ownership_to_self","parameters":null}]`
+
+func NewMCMSAccount(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSAccount {
+	contract := bind.NewBoundContract(address, "mcms", "mcms_account", client)
+	return MCMSAccountContract{
+		BoundContract:      contract,
+		mcmsAccountEncoder: mcmsAccountEncoder{BoundContract: contract},
+	}
+}
 
 // Structs
 
@@ -49,22 +68,20 @@ type OwnershipTransferred struct {
 }
 
 type MCMSAccountContract struct {
-	MCMSAccountCaller
-	MCMSAccountTransactor
+	*bind.BoundContract
+	mcmsAccountEncoder
+}
+
+var _ MCMSAccount = MCMSAccountContract{}
+
+func (c MCMSAccountContract) EncodeCall() MCMSAccountEncoder {
+	return c.mcmsAccountEncoder
 }
 
 // View Functions
 
-type MCMSAccountCaller struct {
-	*bind.BoundContract
-}
-
-func (c MCMSAccountCaller) EncodeOwner() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("owner", nil, []string{}, []any{})
-}
-
-func (c MCMSAccountCaller) Owner(opts *bind.CallOpts) (aptos.AccountAddress, error) {
-	module, function, typeTags, args, err := c.EncodeOwner()
+func (c MCMSAccountContract) Owner(opts *bind.CallOpts) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.mcmsAccountEncoder.Owner()
 	if err != nil {
 		return *new(aptos.AccountAddress), err
 	}
@@ -84,12 +101,8 @@ func (c MCMSAccountCaller) Owner(opts *bind.CallOpts) (aptos.AccountAddress, err
 	return r0, nil
 }
 
-func (c MCMSAccountCaller) EncodeIsSelfOwned() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("is_self_owned", nil, []string{}, []any{})
-}
-
-func (c MCMSAccountCaller) IsSelfOwned(opts *bind.CallOpts) (bool, error) {
-	module, function, typeTags, args, err := c.EncodeIsSelfOwned()
+func (c MCMSAccountContract) IsSelfOwned(opts *bind.CallOpts) (bool, error) {
+	module, function, typeTags, args, err := c.mcmsAccountEncoder.IsSelfOwned()
 	if err != nil {
 		return *new(bool), err
 	}
@@ -111,11 +124,38 @@ func (c MCMSAccountCaller) IsSelfOwned(opts *bind.CallOpts) (bool, error) {
 
 // Entry Functions
 
-type MCMSAccountTransactor struct {
+func (c MCMSAccountContract) TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.mcmsAccountEncoder.TransferOwnership(to)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c MCMSAccountContract) TransferOwnershipToSelf(opts *bind.TransactOpts) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.mcmsAccountEncoder.TransferOwnershipToSelf()
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+// Encoder
+type mcmsAccountEncoder struct {
 	*bind.BoundContract
 }
 
-func (c MCMSAccountTransactor) EncodeTransferOwnership(to aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsAccountEncoder) Owner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("owner", nil, []string{}, []any{})
+}
+
+func (c mcmsAccountEncoder) IsSelfOwned() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("is_self_owned", nil, []string{}, []any{})
+}
+
+func (c mcmsAccountEncoder) TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("transfer_ownership", nil, []string{
 		"address",
 	}, []any{
@@ -123,34 +163,14 @@ func (c MCMSAccountTransactor) EncodeTransferOwnership(to aptos.AccountAddress) 
 	})
 }
 
-func (c MCMSAccountTransactor) TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeTransferOwnership(to)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c MCMSAccountTransactor) EncodeTransferOwnershipToSelf() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsAccountEncoder) TransferOwnershipToSelf() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("transfer_ownership_to_self", nil, []string{}, []any{})
 }
 
-func (c MCMSAccountTransactor) TransferOwnershipToSelf(opts *bind.TransactOpts) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeTransferOwnershipToSelf()
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-// Other Functions
-
-func (c MCMSAccountCaller) EncodeAcceptOwnership() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsAccountEncoder) AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("accept_ownership", nil, []string{}, []any{})
 }
 
-func (c MCMSAccountCaller) EncodeAssertIsOwner() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsAccountEncoder) AssertIsOwner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("assert_is_owner", nil, []string{}, []any{})
 }

--- a/bindings/mcms/mcms_account/mcms_account.go
+++ b/bindings/mcms/mcms_account/mcms_account.go
@@ -28,7 +28,7 @@ type MCMSAccount interface {
 	TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
 	TransferOwnershipToSelf(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 
-	// Encode returns the encoder implementation of this module.
+	// Encoder returns the encoder implementation of this module.
 	Encoder() MCMSAccountEncoder
 }
 

--- a/bindings/mcms/mcms_deployer/mcms_deployer.go
+++ b/bindings/mcms/mcms_deployer/mcms_deployer.go
@@ -26,9 +26,26 @@ type MCMSDeployer interface {
 	StageCodeChunkAndPublishToObject(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, newOwnerSeed []byte) (*api.PendingTransaction, error)
 	StageCodeChunkAndUpgradeObjectCode(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, codeObjectAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 	CleanupStagingArea(opts *bind.TransactOpts) (*api.PendingTransaction, error)
+
+	EncodeCall() MCMSDeployerEncoder
+}
+
+type MCMSDeployerEncoder interface {
+	StageCodeChunk(metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	StageCodeChunkAndPublishToObject(metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, newOwnerSeed []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	StageCodeChunkAndUpgradeObjectCode(metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, codeObjectAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	CleanupStagingArea() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
 const FunctionInfo = `[{"package":"mcms","module":"mcms_deployer","name":"cleanup_staging_area","parameters":null},{"package":"mcms","module":"mcms_deployer","name":"stage_code_chunk","parameters":[{"name":"metadata_chunk","type":"vector\u003cu8\u003e"},{"name":"code_indices","type":"vector\u003cu16\u003e"},{"name":"code_chunks","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"mcms","module":"mcms_deployer","name":"stage_code_chunk_and_publish_to_object","parameters":[{"name":"metadata_chunk","type":"vector\u003cu8\u003e"},{"name":"code_indices","type":"vector\u003cu16\u003e"},{"name":"code_chunks","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"new_owner_seed","type":"vector\u003cu8\u003e"}]},{"package":"mcms","module":"mcms_deployer","name":"stage_code_chunk_and_upgrade_object_code","parameters":[{"name":"metadata_chunk","type":"vector\u003cu8\u003e"},{"name":"code_indices","type":"vector\u003cu16\u003e"},{"name":"code_chunks","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"code_object_address","type":"address"}]}]`
+
+func NewMCMSDeployer(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSDeployer {
+	contract := bind.NewBoundContract(address, "mcms", "mcms_deployer", client)
+	return MCMSDeployerContract{
+		BoundContract:       contract,
+		mcmsDeployerEncoder: mcmsDeployerEncoder{BoundContract: contract},
+	}
+}
 
 // Structs
 
@@ -38,23 +55,62 @@ type StagingArea struct {
 }
 
 type MCMSDeployerContract struct {
-	MCMSDeployerCaller
-	MCMSDeployerTransactor
+	*bind.BoundContract
+	mcmsDeployerEncoder
+}
+
+var _ MCMSDeployer = MCMSDeployerContract{}
+
+func (c MCMSDeployerContract) EncodeCall() MCMSDeployerEncoder {
+	return c.mcmsDeployerEncoder
 }
 
 // View Functions
 
-type MCMSDeployerCaller struct {
-	*bind.BoundContract
-}
-
 // Entry Functions
 
-type MCMSDeployerTransactor struct {
+func (c MCMSDeployerContract) StageCodeChunk(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.mcmsDeployerEncoder.StageCodeChunk(metadataChunk, codeIndices, codeChunks)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c MCMSDeployerContract) StageCodeChunkAndPublishToObject(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, newOwnerSeed []byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.mcmsDeployerEncoder.StageCodeChunkAndPublishToObject(metadataChunk, codeIndices, codeChunks, newOwnerSeed)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c MCMSDeployerContract) StageCodeChunkAndUpgradeObjectCode(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, codeObjectAddress aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.mcmsDeployerEncoder.StageCodeChunkAndUpgradeObjectCode(metadataChunk, codeIndices, codeChunks, codeObjectAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c MCMSDeployerContract) CleanupStagingArea(opts *bind.TransactOpts) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.mcmsDeployerEncoder.CleanupStagingArea()
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+// Encoder
+type mcmsDeployerEncoder struct {
 	*bind.BoundContract
 }
 
-func (c MCMSDeployerTransactor) EncodeStageCodeChunk(metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsDeployerEncoder) StageCodeChunk(metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("stage_code_chunk", nil, []string{
 		"vector<u8>",
 		"vector<u16>",
@@ -66,16 +122,7 @@ func (c MCMSDeployerTransactor) EncodeStageCodeChunk(metadataChunk []byte, codeI
 	})
 }
 
-func (c MCMSDeployerTransactor) StageCodeChunk(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeStageCodeChunk(metadataChunk, codeIndices, codeChunks)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c MCMSDeployerTransactor) EncodeStageCodeChunkAndPublishToObject(metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, newOwnerSeed []byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsDeployerEncoder) StageCodeChunkAndPublishToObject(metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, newOwnerSeed []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("stage_code_chunk_and_publish_to_object", nil, []string{
 		"vector<u8>",
 		"vector<u16>",
@@ -89,16 +136,7 @@ func (c MCMSDeployerTransactor) EncodeStageCodeChunkAndPublishToObject(metadataC
 	})
 }
 
-func (c MCMSDeployerTransactor) StageCodeChunkAndPublishToObject(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, newOwnerSeed []byte) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeStageCodeChunkAndPublishToObject(metadataChunk, codeIndices, codeChunks, newOwnerSeed)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c MCMSDeployerTransactor) EncodeStageCodeChunkAndUpgradeObjectCode(metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, codeObjectAddress aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsDeployerEncoder) StageCodeChunkAndUpgradeObjectCode(metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, codeObjectAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("stage_code_chunk_and_upgrade_object_code", nil, []string{
 		"vector<u8>",
 		"vector<u16>",
@@ -112,24 +150,6 @@ func (c MCMSDeployerTransactor) EncodeStageCodeChunkAndUpgradeObjectCode(metadat
 	})
 }
 
-func (c MCMSDeployerTransactor) StageCodeChunkAndUpgradeObjectCode(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, codeObjectAddress aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeStageCodeChunkAndUpgradeObjectCode(metadataChunk, codeIndices, codeChunks, codeObjectAddress)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c MCMSDeployerTransactor) EncodeCleanupStagingArea() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsDeployerEncoder) CleanupStagingArea() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("cleanup_staging_area", nil, []string{}, []any{})
-}
-
-func (c MCMSDeployerTransactor) CleanupStagingArea(opts *bind.TransactOpts) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeCleanupStagingArea()
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
 }

--- a/bindings/mcms/mcms_deployer/mcms_deployer.go
+++ b/bindings/mcms/mcms_deployer/mcms_deployer.go
@@ -27,7 +27,8 @@ type MCMSDeployer interface {
 	StageCodeChunkAndUpgradeObjectCode(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, codeObjectAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 	CleanupStagingArea(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 
-	Encode_() MCMSDeployerEncoder
+	// Encode returns the encoder implementation of this module.
+	Encoder() MCMSDeployerEncoder
 }
 
 type MCMSDeployerEncoder interface {
@@ -61,7 +62,7 @@ type MCMSDeployerContract struct {
 
 var _ MCMSDeployer = MCMSDeployerContract{}
 
-func (c MCMSDeployerContract) Encode_() MCMSDeployerEncoder {
+func (c MCMSDeployerContract) Encoder() MCMSDeployerEncoder {
 	return c.mcmsDeployerEncoder
 }
 

--- a/bindings/mcms/mcms_deployer/mcms_deployer.go
+++ b/bindings/mcms/mcms_deployer/mcms_deployer.go
@@ -27,7 +27,7 @@ type MCMSDeployer interface {
 	StageCodeChunkAndUpgradeObjectCode(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, codeObjectAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 	CleanupStagingArea(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 
-	EncodeCall() MCMSDeployerEncoder
+	_Encode() MCMSDeployerEncoder
 }
 
 type MCMSDeployerEncoder interface {
@@ -61,7 +61,7 @@ type MCMSDeployerContract struct {
 
 var _ MCMSDeployer = MCMSDeployerContract{}
 
-func (c MCMSDeployerContract) EncodeCall() MCMSDeployerEncoder {
+func (c MCMSDeployerContract) _Encode() MCMSDeployerEncoder {
 	return c.mcmsDeployerEncoder
 }
 

--- a/bindings/mcms/mcms_deployer/mcms_deployer.go
+++ b/bindings/mcms/mcms_deployer/mcms_deployer.go
@@ -27,7 +27,7 @@ type MCMSDeployer interface {
 	StageCodeChunkAndUpgradeObjectCode(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, codeObjectAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 	CleanupStagingArea(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 
-	// Encode returns the encoder implementation of this module.
+	// Encoder returns the encoder implementation of this module.
 	Encoder() MCMSDeployerEncoder
 }
 

--- a/bindings/mcms/mcms_deployer/mcms_deployer.go
+++ b/bindings/mcms/mcms_deployer/mcms_deployer.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type MCMSDeployerInterface interface {
+type MCMSDeployer interface {
 	StageCodeChunk(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte) (*api.PendingTransaction, error)
 	StageCodeChunkAndPublishToObject(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, newOwnerSeed []byte) (*api.PendingTransaction, error)
 	StageCodeChunkAndUpgradeObjectCode(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, codeObjectAddress aptos.AccountAddress) (*api.PendingTransaction, error)
@@ -37,7 +37,7 @@ type StagingArea struct {
 	LastModuleIdx      uint64 `move:"u64"`
 }
 
-type MCMSDeployer struct {
+type MCMSDeployerContract struct {
 	MCMSDeployerCaller
 	MCMSDeployerTransactor
 }

--- a/bindings/mcms/mcms_deployer/mcms_deployer.go
+++ b/bindings/mcms/mcms_deployer/mcms_deployer.go
@@ -27,7 +27,7 @@ type MCMSDeployer interface {
 	StageCodeChunkAndUpgradeObjectCode(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, codeObjectAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 	CleanupStagingArea(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 
-	_Encode() MCMSDeployerEncoder
+	Encode_() MCMSDeployerEncoder
 }
 
 type MCMSDeployerEncoder interface {
@@ -61,7 +61,7 @@ type MCMSDeployerContract struct {
 
 var _ MCMSDeployer = MCMSDeployerContract{}
 
-func (c MCMSDeployerContract) _Encode() MCMSDeployerEncoder {
+func (c MCMSDeployerContract) Encode_() MCMSDeployerEncoder {
 	return c.mcmsDeployerEncoder
 }
 

--- a/bindings/mcms/mcms_executor/mcms_executor.go
+++ b/bindings/mcms/mcms_executor/mcms_executor.go
@@ -26,7 +26,7 @@ type MCMSExecutor interface {
 	StageDataAndExecute(opts *bind.TransactOpts, chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, dataChunk []byte, partialProofs [][]byte) (*api.PendingTransaction, error)
 	ClearStagedData(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 
-	// Encode returns the encoder implementation of this module.
+	// Encoder returns the encoder implementation of this module.
 	Encoder() MCMSExecutorEncoder
 }
 

--- a/bindings/mcms/mcms_executor/mcms_executor.go
+++ b/bindings/mcms/mcms_executor/mcms_executor.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type MCMSExecutorInterface interface {
+type MCMSExecutor interface {
 	StageData(opts *bind.TransactOpts, dataChunk []byte, partialProofs [][]byte) (*api.PendingTransaction, error)
 	StageDataAndExecute(opts *bind.TransactOpts, chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, dataChunk []byte, partialProofs [][]byte) (*api.PendingTransaction, error)
 	ClearStagedData(opts *bind.TransactOpts) (*api.PendingTransaction, error)
@@ -36,7 +36,7 @@ type PendingExecute struct {
 	Proofs [][]byte `move:"vector<vector<u8>>"`
 }
 
-type MCMSExecutor struct {
+type MCMSExecutorContract struct {
 	MCMSExecutorCaller
 	MCMSExecutorTransactor
 }

--- a/bindings/mcms/mcms_executor/mcms_executor.go
+++ b/bindings/mcms/mcms_executor/mcms_executor.go
@@ -25,9 +25,25 @@ type MCMSExecutor interface {
 	StageData(opts *bind.TransactOpts, dataChunk []byte, partialProofs [][]byte) (*api.PendingTransaction, error)
 	StageDataAndExecute(opts *bind.TransactOpts, chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, dataChunk []byte, partialProofs [][]byte) (*api.PendingTransaction, error)
 	ClearStagedData(opts *bind.TransactOpts) (*api.PendingTransaction, error)
+
+	EncodeCall() MCMSExecutorEncoder
+}
+
+type MCMSExecutorEncoder interface {
+	StageData(dataChunk []byte, partialProofs [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	StageDataAndExecute(chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, dataChunk []byte, partialProofs [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ClearStagedData() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
 const FunctionInfo = `[{"package":"mcms","module":"mcms_executor","name":"clear_staged_data","parameters":null},{"package":"mcms","module":"mcms_executor","name":"stage_data","parameters":[{"name":"data_chunk","type":"vector\u003cu8\u003e"},{"name":"partial_proofs","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"mcms","module":"mcms_executor","name":"stage_data_and_execute","parameters":[{"name":"chain_id","type":"u256"},{"name":"multisig","type":"address"},{"name":"nonce","type":"u64"},{"name":"to","type":"address"},{"name":"module_name","type":"0x1::string::String"},{"name":"function","type":"0x1::string::String"},{"name":"data_chunk","type":"vector\u003cu8\u003e"},{"name":"partial_proofs","type":"vector\u003cvector\u003cu8\u003e\u003e"}]}]`
+
+func NewMCMSExecutor(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSExecutor {
+	contract := bind.NewBoundContract(address, "mcms", "mcms_executor", client)
+	return MCMSExecutorContract{
+		BoundContract:       contract,
+		mcmsExecutorEncoder: mcmsExecutorEncoder{BoundContract: contract},
+	}
+}
 
 // Structs
 
@@ -37,23 +53,53 @@ type PendingExecute struct {
 }
 
 type MCMSExecutorContract struct {
-	MCMSExecutorCaller
-	MCMSExecutorTransactor
+	*bind.BoundContract
+	mcmsExecutorEncoder
+}
+
+var _ MCMSExecutor = MCMSExecutorContract{}
+
+func (c MCMSExecutorContract) EncodeCall() MCMSExecutorEncoder {
+	return c.mcmsExecutorEncoder
 }
 
 // View Functions
 
-type MCMSExecutorCaller struct {
-	*bind.BoundContract
-}
-
 // Entry Functions
 
-type MCMSExecutorTransactor struct {
+func (c MCMSExecutorContract) StageData(opts *bind.TransactOpts, dataChunk []byte, partialProofs [][]byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.mcmsExecutorEncoder.StageData(dataChunk, partialProofs)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c MCMSExecutorContract) StageDataAndExecute(opts *bind.TransactOpts, chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, dataChunk []byte, partialProofs [][]byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.mcmsExecutorEncoder.StageDataAndExecute(chainId, multisig, nonce, to, moduleName, function, dataChunk, partialProofs)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c MCMSExecutorContract) ClearStagedData(opts *bind.TransactOpts) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.mcmsExecutorEncoder.ClearStagedData()
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+// Encoder
+type mcmsExecutorEncoder struct {
 	*bind.BoundContract
 }
 
-func (c MCMSExecutorTransactor) EncodeStageData(dataChunk []byte, partialProofs [][]byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsExecutorEncoder) StageData(dataChunk []byte, partialProofs [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("stage_data", nil, []string{
 		"vector<u8>",
 		"vector<vector<u8>>",
@@ -63,16 +109,7 @@ func (c MCMSExecutorTransactor) EncodeStageData(dataChunk []byte, partialProofs 
 	})
 }
 
-func (c MCMSExecutorTransactor) StageData(opts *bind.TransactOpts, dataChunk []byte, partialProofs [][]byte) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeStageData(dataChunk, partialProofs)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c MCMSExecutorTransactor) EncodeStageDataAndExecute(chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, dataChunk []byte, partialProofs [][]byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsExecutorEncoder) StageDataAndExecute(chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, dataChunk []byte, partialProofs [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("stage_data_and_execute", nil, []string{
 		"u256",
 		"address",
@@ -94,24 +131,6 @@ func (c MCMSExecutorTransactor) EncodeStageDataAndExecute(chainId *big.Int, mult
 	})
 }
 
-func (c MCMSExecutorTransactor) StageDataAndExecute(opts *bind.TransactOpts, chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, dataChunk []byte, partialProofs [][]byte) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeStageDataAndExecute(chainId, multisig, nonce, to, moduleName, function, dataChunk, partialProofs)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c MCMSExecutorTransactor) EncodeClearStagedData() (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsExecutorEncoder) ClearStagedData() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("clear_staged_data", nil, []string{}, []any{})
-}
-
-func (c MCMSExecutorTransactor) ClearStagedData(opts *bind.TransactOpts) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeClearStagedData()
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
 }

--- a/bindings/mcms/mcms_executor/mcms_executor.go
+++ b/bindings/mcms/mcms_executor/mcms_executor.go
@@ -26,7 +26,7 @@ type MCMSExecutor interface {
 	StageDataAndExecute(opts *bind.TransactOpts, chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, dataChunk []byte, partialProofs [][]byte) (*api.PendingTransaction, error)
 	ClearStagedData(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 
-	_Encode() MCMSExecutorEncoder
+	Encode_() MCMSExecutorEncoder
 }
 
 type MCMSExecutorEncoder interface {
@@ -59,7 +59,7 @@ type MCMSExecutorContract struct {
 
 var _ MCMSExecutor = MCMSExecutorContract{}
 
-func (c MCMSExecutorContract) _Encode() MCMSExecutorEncoder {
+func (c MCMSExecutorContract) Encode_() MCMSExecutorEncoder {
 	return c.mcmsExecutorEncoder
 }
 

--- a/bindings/mcms/mcms_executor/mcms_executor.go
+++ b/bindings/mcms/mcms_executor/mcms_executor.go
@@ -26,7 +26,8 @@ type MCMSExecutor interface {
 	StageDataAndExecute(opts *bind.TransactOpts, chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, dataChunk []byte, partialProofs [][]byte) (*api.PendingTransaction, error)
 	ClearStagedData(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 
-	Encode_() MCMSExecutorEncoder
+	// Encode returns the encoder implementation of this module.
+	Encoder() MCMSExecutorEncoder
 }
 
 type MCMSExecutorEncoder interface {
@@ -59,7 +60,7 @@ type MCMSExecutorContract struct {
 
 var _ MCMSExecutor = MCMSExecutorContract{}
 
-func (c MCMSExecutorContract) Encode_() MCMSExecutorEncoder {
+func (c MCMSExecutorContract) Encoder() MCMSExecutorEncoder {
 	return c.mcmsExecutorEncoder
 }
 

--- a/bindings/mcms/mcms_executor/mcms_executor.go
+++ b/bindings/mcms/mcms_executor/mcms_executor.go
@@ -26,7 +26,7 @@ type MCMSExecutor interface {
 	StageDataAndExecute(opts *bind.TransactOpts, chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, dataChunk []byte, partialProofs [][]byte) (*api.PendingTransaction, error)
 	ClearStagedData(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 
-	EncodeCall() MCMSExecutorEncoder
+	_Encode() MCMSExecutorEncoder
 }
 
 type MCMSExecutorEncoder interface {
@@ -59,7 +59,7 @@ type MCMSExecutorContract struct {
 
 var _ MCMSExecutor = MCMSExecutorContract{}
 
-func (c MCMSExecutorContract) EncodeCall() MCMSExecutorEncoder {
+func (c MCMSExecutorContract) _Encode() MCMSExecutorEncoder {
 	return c.mcmsExecutorEncoder
 }
 

--- a/bindings/mcms/mcms_registry/mcms_registry.go
+++ b/bindings/mcms/mcms_registry/mcms_registry.go
@@ -33,7 +33,8 @@ type MCMSRegistry interface {
 	AcceptCodeObject(opts *bind.TransactOpts, objectAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 	ExecuteCodeObjectTransfer(opts *bind.TransactOpts, objectAddress aptos.AccountAddress, newOwnerAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	Encode_() MCMSRegistryEncoder
+	// Encode returns the encoder implementation of this module.
+	Encoder() MCMSRegistryEncoder
 }
 
 type MCMSRegistryEncoder interface {
@@ -131,7 +132,7 @@ type MCMSRegistryContract struct {
 
 var _ MCMSRegistry = MCMSRegistryContract{}
 
-func (c MCMSRegistryContract) Encode_() MCMSRegistryEncoder {
+func (c MCMSRegistryContract) Encoder() MCMSRegistryEncoder {
 	return c.mcmsRegistryEncoder
 }
 

--- a/bindings/mcms/mcms_registry/mcms_registry.go
+++ b/bindings/mcms/mcms_registry/mcms_registry.go
@@ -33,7 +33,7 @@ type MCMSRegistry interface {
 	AcceptCodeObject(opts *bind.TransactOpts, objectAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 	ExecuteCodeObjectTransfer(opts *bind.TransactOpts, objectAddress aptos.AccountAddress, newOwnerAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	// Encode returns the encoder implementation of this module.
+	// Encoder returns the encoder implementation of this module.
 	Encoder() MCMSRegistryEncoder
 }
 

--- a/bindings/mcms/mcms_registry/mcms_registry.go
+++ b/bindings/mcms/mcms_registry/mcms_registry.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type MCMSRegistryInterface interface {
+type MCMSRegistry interface {
 	GetNewCodeObjectOwnerAddress(opts *bind.CallOpts, newOwnerSeed []byte) (aptos.AccountAddress, error)
 	GetNewCodeObjectAddress(opts *bind.CallOpts, newOwnerSeed []byte) (aptos.AccountAddress, error)
 	GetPreexistingCodeObjectOwnerAddress(opts *bind.CallOpts, objectAddress aptos.AccountAddress) (aptos.AccountAddress, error)
@@ -101,7 +101,7 @@ type OwnerCreatedForEntrypoint struct {
 	AccountOrObjectAddress aptos.AccountAddress `move:"address"`
 }
 
-type MCMSRegistry struct {
+type MCMSRegistryContract struct {
 	MCMSRegistryCaller
 	MCMSRegistryTransactor
 }

--- a/bindings/mcms/mcms_registry/mcms_registry.go
+++ b/bindings/mcms/mcms_registry/mcms_registry.go
@@ -32,9 +32,32 @@ type MCMSRegistry interface {
 	TransferCodeObject(opts *bind.TransactOpts, objectAddress aptos.AccountAddress, newOwnerAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 	AcceptCodeObject(opts *bind.TransactOpts, objectAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 	ExecuteCodeObjectTransfer(opts *bind.TransactOpts, objectAddress aptos.AccountAddress, newOwnerAddress aptos.AccountAddress) (*api.PendingTransaction, error)
+
+	EncodeCall() MCMSRegistryEncoder
+}
+
+type MCMSRegistryEncoder interface {
+	GetNewCodeObjectOwnerAddress(newOwnerSeed []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetNewCodeObjectAddress(newOwnerSeed []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetPreexistingCodeObjectOwnerAddress(objectAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetRegisteredOwnerAddress(accountAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	IsOwnedCodeObject(objectAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	CreateOwnerForPreexistingCodeObject(objectAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	TransferCodeObject(objectAddress aptos.AccountAddress, newOwnerAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AcceptCodeObject(objectAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ExecuteCodeObjectTransfer(objectAddress aptos.AccountAddress, newOwnerAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	FinishDispatch(callbackAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
 const FunctionInfo = `[{"package":"mcms","module":"mcms_registry","name":"accept_code_object","parameters":[{"name":"object_address","type":"address"}]},{"package":"mcms","module":"mcms_registry","name":"create_owner_for_preexisting_code_object","parameters":[{"name":"object_address","type":"address"}]},{"package":"mcms","module":"mcms_registry","name":"execute_code_object_transfer","parameters":[{"name":"object_address","type":"address"},{"name":"new_owner_address","type":"address"}]},{"package":"mcms","module":"mcms_registry","name":"finish_dispatch","parameters":[{"name":"callback_address","type":"address"}]},{"package":"mcms","module":"mcms_registry","name":"transfer_code_object","parameters":[{"name":"object_address","type":"address"},{"name":"new_owner_address","type":"address"}]}]`
+
+func NewMCMSRegistry(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSRegistry {
+	contract := bind.NewBoundContract(address, "mcms", "mcms_registry", client)
+	return MCMSRegistryContract{
+		BoundContract:       contract,
+		mcmsRegistryEncoder: mcmsRegistryEncoder{BoundContract: contract},
+	}
+}
 
 // Structs
 
@@ -102,26 +125,20 @@ type OwnerCreatedForEntrypoint struct {
 }
 
 type MCMSRegistryContract struct {
-	MCMSRegistryCaller
-	MCMSRegistryTransactor
+	*bind.BoundContract
+	mcmsRegistryEncoder
+}
+
+var _ MCMSRegistry = MCMSRegistryContract{}
+
+func (c MCMSRegistryContract) EncodeCall() MCMSRegistryEncoder {
+	return c.mcmsRegistryEncoder
 }
 
 // View Functions
 
-type MCMSRegistryCaller struct {
-	*bind.BoundContract
-}
-
-func (c MCMSRegistryCaller) EncodeGetNewCodeObjectOwnerAddress(newOwnerSeed []byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_new_code_object_owner_address", nil, []string{
-		"vector<u8>",
-	}, []any{
-		newOwnerSeed,
-	})
-}
-
-func (c MCMSRegistryCaller) GetNewCodeObjectOwnerAddress(opts *bind.CallOpts, newOwnerSeed []byte) (aptos.AccountAddress, error) {
-	module, function, typeTags, args, err := c.EncodeGetNewCodeObjectOwnerAddress(newOwnerSeed)
+func (c MCMSRegistryContract) GetNewCodeObjectOwnerAddress(opts *bind.CallOpts, newOwnerSeed []byte) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.mcmsRegistryEncoder.GetNewCodeObjectOwnerAddress(newOwnerSeed)
 	if err != nil {
 		return *new(aptos.AccountAddress), err
 	}
@@ -141,16 +158,8 @@ func (c MCMSRegistryCaller) GetNewCodeObjectOwnerAddress(opts *bind.CallOpts, ne
 	return r0, nil
 }
 
-func (c MCMSRegistryCaller) EncodeGetNewCodeObjectAddress(newOwnerSeed []byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_new_code_object_address", nil, []string{
-		"vector<u8>",
-	}, []any{
-		newOwnerSeed,
-	})
-}
-
-func (c MCMSRegistryCaller) GetNewCodeObjectAddress(opts *bind.CallOpts, newOwnerSeed []byte) (aptos.AccountAddress, error) {
-	module, function, typeTags, args, err := c.EncodeGetNewCodeObjectAddress(newOwnerSeed)
+func (c MCMSRegistryContract) GetNewCodeObjectAddress(opts *bind.CallOpts, newOwnerSeed []byte) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.mcmsRegistryEncoder.GetNewCodeObjectAddress(newOwnerSeed)
 	if err != nil {
 		return *new(aptos.AccountAddress), err
 	}
@@ -170,16 +179,8 @@ func (c MCMSRegistryCaller) GetNewCodeObjectAddress(opts *bind.CallOpts, newOwne
 	return r0, nil
 }
 
-func (c MCMSRegistryCaller) EncodeGetPreexistingCodeObjectOwnerAddress(objectAddress aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_preexisting_code_object_owner_address", nil, []string{
-		"address",
-	}, []any{
-		objectAddress,
-	})
-}
-
-func (c MCMSRegistryCaller) GetPreexistingCodeObjectOwnerAddress(opts *bind.CallOpts, objectAddress aptos.AccountAddress) (aptos.AccountAddress, error) {
-	module, function, typeTags, args, err := c.EncodeGetPreexistingCodeObjectOwnerAddress(objectAddress)
+func (c MCMSRegistryContract) GetPreexistingCodeObjectOwnerAddress(opts *bind.CallOpts, objectAddress aptos.AccountAddress) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.mcmsRegistryEncoder.GetPreexistingCodeObjectOwnerAddress(objectAddress)
 	if err != nil {
 		return *new(aptos.AccountAddress), err
 	}
@@ -199,16 +200,8 @@ func (c MCMSRegistryCaller) GetPreexistingCodeObjectOwnerAddress(opts *bind.Call
 	return r0, nil
 }
 
-func (c MCMSRegistryCaller) EncodeGetRegisteredOwnerAddress(accountAddress aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_registered_owner_address", nil, []string{
-		"address",
-	}, []any{
-		accountAddress,
-	})
-}
-
-func (c MCMSRegistryCaller) GetRegisteredOwnerAddress(opts *bind.CallOpts, accountAddress aptos.AccountAddress) (aptos.AccountAddress, error) {
-	module, function, typeTags, args, err := c.EncodeGetRegisteredOwnerAddress(accountAddress)
+func (c MCMSRegistryContract) GetRegisteredOwnerAddress(opts *bind.CallOpts, accountAddress aptos.AccountAddress) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.mcmsRegistryEncoder.GetRegisteredOwnerAddress(accountAddress)
 	if err != nil {
 		return *new(aptos.AccountAddress), err
 	}
@@ -228,16 +221,8 @@ func (c MCMSRegistryCaller) GetRegisteredOwnerAddress(opts *bind.CallOpts, accou
 	return r0, nil
 }
 
-func (c MCMSRegistryCaller) EncodeIsOwnedCodeObject(objectAddress aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("is_owned_code_object", nil, []string{
-		"address",
-	}, []any{
-		objectAddress,
-	})
-}
-
-func (c MCMSRegistryCaller) IsOwnedCodeObject(opts *bind.CallOpts, objectAddress aptos.AccountAddress) (bool, error) {
-	module, function, typeTags, args, err := c.EncodeIsOwnedCodeObject(objectAddress)
+func (c MCMSRegistryContract) IsOwnedCodeObject(opts *bind.CallOpts, objectAddress aptos.AccountAddress) (bool, error) {
+	module, function, typeTags, args, err := c.mcmsRegistryEncoder.IsOwnedCodeObject(objectAddress)
 	if err != nil {
 		return *new(bool), err
 	}
@@ -259,20 +244,8 @@ func (c MCMSRegistryCaller) IsOwnedCodeObject(opts *bind.CallOpts, objectAddress
 
 // Entry Functions
 
-type MCMSRegistryTransactor struct {
-	*bind.BoundContract
-}
-
-func (c MCMSRegistryTransactor) EncodeCreateOwnerForPreexistingCodeObject(objectAddress aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("create_owner_for_preexisting_code_object", nil, []string{
-		"address",
-	}, []any{
-		objectAddress,
-	})
-}
-
-func (c MCMSRegistryTransactor) CreateOwnerForPreexistingCodeObject(opts *bind.TransactOpts, objectAddress aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeCreateOwnerForPreexistingCodeObject(objectAddress)
+func (c MCMSRegistryContract) CreateOwnerForPreexistingCodeObject(opts *bind.TransactOpts, objectAddress aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.mcmsRegistryEncoder.CreateOwnerForPreexistingCodeObject(objectAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +253,87 @@ func (c MCMSRegistryTransactor) CreateOwnerForPreexistingCodeObject(opts *bind.T
 	return c.BoundContract.Transact(opts, module, function, typeTags, args)
 }
 
-func (c MCMSRegistryTransactor) EncodeTransferCodeObject(objectAddress aptos.AccountAddress, newOwnerAddress aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c MCMSRegistryContract) TransferCodeObject(opts *bind.TransactOpts, objectAddress aptos.AccountAddress, newOwnerAddress aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.mcmsRegistryEncoder.TransferCodeObject(objectAddress, newOwnerAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c MCMSRegistryContract) AcceptCodeObject(opts *bind.TransactOpts, objectAddress aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.mcmsRegistryEncoder.AcceptCodeObject(objectAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c MCMSRegistryContract) ExecuteCodeObjectTransfer(opts *bind.TransactOpts, objectAddress aptos.AccountAddress, newOwnerAddress aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.mcmsRegistryEncoder.ExecuteCodeObjectTransfer(objectAddress, newOwnerAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+// Encoder
+type mcmsRegistryEncoder struct {
+	*bind.BoundContract
+}
+
+func (c mcmsRegistryEncoder) GetNewCodeObjectOwnerAddress(newOwnerSeed []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_new_code_object_owner_address", nil, []string{
+		"vector<u8>",
+	}, []any{
+		newOwnerSeed,
+	})
+}
+
+func (c mcmsRegistryEncoder) GetNewCodeObjectAddress(newOwnerSeed []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_new_code_object_address", nil, []string{
+		"vector<u8>",
+	}, []any{
+		newOwnerSeed,
+	})
+}
+
+func (c mcmsRegistryEncoder) GetPreexistingCodeObjectOwnerAddress(objectAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_preexisting_code_object_owner_address", nil, []string{
+		"address",
+	}, []any{
+		objectAddress,
+	})
+}
+
+func (c mcmsRegistryEncoder) GetRegisteredOwnerAddress(accountAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_registered_owner_address", nil, []string{
+		"address",
+	}, []any{
+		accountAddress,
+	})
+}
+
+func (c mcmsRegistryEncoder) IsOwnedCodeObject(objectAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("is_owned_code_object", nil, []string{
+		"address",
+	}, []any{
+		objectAddress,
+	})
+}
+
+func (c mcmsRegistryEncoder) CreateOwnerForPreexistingCodeObject(objectAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("create_owner_for_preexisting_code_object", nil, []string{
+		"address",
+	}, []any{
+		objectAddress,
+	})
+}
+
+func (c mcmsRegistryEncoder) TransferCodeObject(objectAddress aptos.AccountAddress, newOwnerAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("transfer_code_object", nil, []string{
 		"address",
 		"address",
@@ -290,16 +343,7 @@ func (c MCMSRegistryTransactor) EncodeTransferCodeObject(objectAddress aptos.Acc
 	})
 }
 
-func (c MCMSRegistryTransactor) TransferCodeObject(opts *bind.TransactOpts, objectAddress aptos.AccountAddress, newOwnerAddress aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeTransferCodeObject(objectAddress, newOwnerAddress)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c MCMSRegistryTransactor) EncodeAcceptCodeObject(objectAddress aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsRegistryEncoder) AcceptCodeObject(objectAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("accept_code_object", nil, []string{
 		"address",
 	}, []any{
@@ -307,16 +351,7 @@ func (c MCMSRegistryTransactor) EncodeAcceptCodeObject(objectAddress aptos.Accou
 	})
 }
 
-func (c MCMSRegistryTransactor) AcceptCodeObject(opts *bind.TransactOpts, objectAddress aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeAcceptCodeObject(objectAddress)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-func (c MCMSRegistryTransactor) EncodeExecuteCodeObjectTransfer(objectAddress aptos.AccountAddress, newOwnerAddress aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsRegistryEncoder) ExecuteCodeObjectTransfer(objectAddress aptos.AccountAddress, newOwnerAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("execute_code_object_transfer", nil, []string{
 		"address",
 		"address",
@@ -326,18 +361,7 @@ func (c MCMSRegistryTransactor) EncodeExecuteCodeObjectTransfer(objectAddress ap
 	})
 }
 
-func (c MCMSRegistryTransactor) ExecuteCodeObjectTransfer(opts *bind.TransactOpts, objectAddress aptos.AccountAddress, newOwnerAddress aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.EncodeExecuteCodeObjectTransfer(objectAddress, newOwnerAddress)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.BoundContract.Transact(opts, module, function, typeTags, args)
-}
-
-// Other Functions
-
-func (c MCMSRegistryCaller) EncodeFinishDispatch(callbackAddress aptos.AccountAddress) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsRegistryEncoder) FinishDispatch(callbackAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("finish_dispatch", nil, []string{
 		"address",
 	}, []any{

--- a/bindings/mcms/mcms_registry/mcms_registry.go
+++ b/bindings/mcms/mcms_registry/mcms_registry.go
@@ -33,7 +33,7 @@ type MCMSRegistry interface {
 	AcceptCodeObject(opts *bind.TransactOpts, objectAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 	ExecuteCodeObjectTransfer(opts *bind.TransactOpts, objectAddress aptos.AccountAddress, newOwnerAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	EncodeCall() MCMSRegistryEncoder
+	_Encode() MCMSRegistryEncoder
 }
 
 type MCMSRegistryEncoder interface {
@@ -131,7 +131,7 @@ type MCMSRegistryContract struct {
 
 var _ MCMSRegistry = MCMSRegistryContract{}
 
-func (c MCMSRegistryContract) EncodeCall() MCMSRegistryEncoder {
+func (c MCMSRegistryContract) _Encode() MCMSRegistryEncoder {
 	return c.mcmsRegistryEncoder
 }
 

--- a/bindings/mcms/mcms_registry/mcms_registry.go
+++ b/bindings/mcms/mcms_registry/mcms_registry.go
@@ -33,7 +33,7 @@ type MCMSRegistry interface {
 	AcceptCodeObject(opts *bind.TransactOpts, objectAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 	ExecuteCodeObjectTransfer(opts *bind.TransactOpts, objectAddress aptos.AccountAddress, newOwnerAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 
-	_Encode() MCMSRegistryEncoder
+	Encode_() MCMSRegistryEncoder
 }
 
 type MCMSRegistryEncoder interface {
@@ -131,7 +131,7 @@ type MCMSRegistryContract struct {
 
 var _ MCMSRegistry = MCMSRegistryContract{}
 
-func (c MCMSRegistryContract) _Encode() MCMSRegistryEncoder {
+func (c MCMSRegistryContract) Encode_() MCMSRegistryEncoder {
 	return c.mcmsRegistryEncoder
 }
 

--- a/bindings/mcms_test/mcms_user/mcms_user.go
+++ b/bindings/mcms_test/mcms_user/mcms_user.go
@@ -22,9 +22,23 @@ var (
 )
 
 type MCMSUser interface {
+	EncodeCall() MCMSUserEncoder
+}
+
+type MCMSUserEncoder interface {
+	FunctionOne(arg1 string, arg2 []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	FunctionTwo(arg1 aptos.AccountAddress, arg2 *big.Int) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
 const FunctionInfo = `[{"package":"mcms_test","module":"mcms_user","name":"function_one","parameters":[{"name":"arg1","type":"0x1::string::String"},{"name":"arg2","type":"vector\u003cu8\u003e"}]},{"package":"mcms_test","module":"mcms_user","name":"function_two","parameters":[{"name":"arg1","type":"address"},{"name":"arg2","type":"u128"}]}]`
+
+func NewMCMSUser(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSUser {
+	contract := bind.NewBoundContract(address, "mcms_test", "mcms_user", client)
+	return MCMSUserContract{
+		BoundContract:   contract,
+		mcmsUserEncoder: mcmsUserEncoder{BoundContract: contract},
+	}
+}
 
 // Structs
 
@@ -40,25 +54,26 @@ type SampleMcmsCallback struct {
 }
 
 type MCMSUserContract struct {
-	MCMSUserCaller
-	MCMSUserTransactor
+	*bind.BoundContract
+	mcmsUserEncoder
+}
+
+var _ MCMSUser = MCMSUserContract{}
+
+func (c MCMSUserContract) EncodeCall() MCMSUserEncoder {
+	return c.mcmsUserEncoder
 }
 
 // View Functions
 
-type MCMSUserCaller struct {
-	*bind.BoundContract
-}
-
 // Entry Functions
 
-type MCMSUserTransactor struct {
+// Encoder
+type mcmsUserEncoder struct {
 	*bind.BoundContract
 }
 
-// Other Functions
-
-func (c MCMSUserCaller) EncodeFunctionOne(arg1 string, arg2 []byte) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsUserEncoder) FunctionOne(arg1 string, arg2 []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("function_one", nil, []string{
 		"0x1::string::String",
 		"vector<u8>",
@@ -68,7 +83,7 @@ func (c MCMSUserCaller) EncodeFunctionOne(arg1 string, arg2 []byte) (aptos.Modul
 	})
 }
 
-func (c MCMSUserCaller) EncodeFunctionTwo(arg1 aptos.AccountAddress, arg2 *big.Int) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+func (c mcmsUserEncoder) FunctionTwo(arg1 aptos.AccountAddress, arg2 *big.Int) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("function_two", nil, []string{
 		"address",
 		"u128",

--- a/bindings/mcms_test/mcms_user/mcms_user.go
+++ b/bindings/mcms_test/mcms_user/mcms_user.go
@@ -22,7 +22,9 @@ var (
 )
 
 type MCMSUser interface {
-	Encode_() MCMSUserEncoder
+
+	// Encode returns the encoder implementation of this module.
+	Encoder() MCMSUserEncoder
 }
 
 type MCMSUserEncoder interface {
@@ -60,7 +62,7 @@ type MCMSUserContract struct {
 
 var _ MCMSUser = MCMSUserContract{}
 
-func (c MCMSUserContract) Encode_() MCMSUserEncoder {
+func (c MCMSUserContract) Encoder() MCMSUserEncoder {
 	return c.mcmsUserEncoder
 }
 

--- a/bindings/mcms_test/mcms_user/mcms_user.go
+++ b/bindings/mcms_test/mcms_user/mcms_user.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type MCMSUserInterface interface {
+type MCMSUser interface {
 }
 
 const FunctionInfo = `[{"package":"mcms_test","module":"mcms_user","name":"function_one","parameters":[{"name":"arg1","type":"0x1::string::String"},{"name":"arg2","type":"vector\u003cu8\u003e"}]},{"package":"mcms_test","module":"mcms_user","name":"function_two","parameters":[{"name":"arg1","type":"address"},{"name":"arg2","type":"u128"}]}]`
@@ -39,7 +39,7 @@ type UserData struct {
 type SampleMcmsCallback struct {
 }
 
-type MCMSUser struct {
+type MCMSUserContract struct {
 	MCMSUserCaller
 	MCMSUserTransactor
 }

--- a/bindings/mcms_test/mcms_user/mcms_user.go
+++ b/bindings/mcms_test/mcms_user/mcms_user.go
@@ -23,7 +23,7 @@ var (
 
 type MCMSUser interface {
 
-	// Encode returns the encoder implementation of this module.
+	// Encoder returns the encoder implementation of this module.
 	Encoder() MCMSUserEncoder
 }
 

--- a/bindings/mcms_test/mcms_user/mcms_user.go
+++ b/bindings/mcms_test/mcms_user/mcms_user.go
@@ -22,7 +22,7 @@ var (
 )
 
 type MCMSUser interface {
-	EncodeCall() MCMSUserEncoder
+	Encode_() MCMSUserEncoder
 }
 
 type MCMSUserEncoder interface {
@@ -60,7 +60,7 @@ type MCMSUserContract struct {
 
 var _ MCMSUser = MCMSUserContract{}
 
-func (c MCMSUserContract) EncodeCall() MCMSUserEncoder {
+func (c MCMSUserContract) Encode_() MCMSUserEncoder {
 	return c.mcmsUserEncoder
 }
 

--- a/bindings/mcms_test/mcmstest.go
+++ b/bindings/mcms_test/mcmstest.go
@@ -10,10 +10,26 @@ import (
 	"github.com/smartcontractkit/chainlink-aptos/contracts"
 )
 
-type MCMSTest struct {
-	Address aptos.AccountAddress
+type MCMSTest interface {
+	Address() aptos.AccountAddress
 
-	MCMSUser module_mcms_user.MCMSUser
+	MCMSUser() module_mcms_user.MCMSUser
+}
+
+var _ MCMSTest = MCMSTestContract{}
+
+type MCMSTestContract struct {
+	address aptos.AccountAddress
+
+	mcmsUser module_mcms_user.MCMSUser
+}
+
+func (M MCMSTestContract) Address() aptos.AccountAddress {
+	return M.address
+}
+
+func (M MCMSTestContract) MCMSUser() module_mcms_user.MCMSUser {
+	return M.mcmsUser
 }
 
 var FunctionInfo = bind.MustParseFunctionInfo(
@@ -29,9 +45,9 @@ func Compile(MCMSAddress aptos.AccountAddress) (compile.CompiledPackage, error) 
 
 func Bind(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSTest {
 	mcmsUser := bind.NewBoundContract(address, "mcms_user", client)
-	return MCMSTest{
-		Address: address,
-		MCMSUser: module_mcms_user.MCMSUser{
+	return MCMSTestContract{
+		address: address,
+		mcmsUser: module_mcms_user.MCMSUserContract{
 			MCMSUserCaller:     module_mcms_user.MCMSUserCaller{BoundContract: mcmsUser},
 			MCMSUserTransactor: module_mcms_user.MCMSUserTransactor{BoundContract: mcmsUser},
 		},
@@ -48,7 +64,7 @@ func DeployToObject(
 	}
 	address, tx, err := bind.DeployPackageToObject(auth, client, contracts.MCMSTest, namedAddresses)
 	if err != nil {
-		return aptos.AccountAddress{}, nil, MCMSTest{}, err
+		return aptos.AccountAddress{}, nil, MCMSTestContract{}, err
 	}
 	return address, tx, Bind(address, client), nil
 }

--- a/bindings/mcms_test/mcmstest.go
+++ b/bindings/mcms_test/mcmstest.go
@@ -44,13 +44,9 @@ func Compile(MCMSAddress aptos.AccountAddress) (compile.CompiledPackage, error) 
 }
 
 func Bind(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSTest {
-	mcmsUser := bind.NewBoundContract(address, "mcms_user", client)
 	return MCMSTestContract{
-		address: address,
-		mcmsUser: module_mcms_user.MCMSUserContract{
-			MCMSUserCaller:     module_mcms_user.MCMSUserCaller{BoundContract: mcmsUser},
-			MCMSUserTransactor: module_mcms_user.MCMSUserTransactor{BoundContract: mcmsUser},
-		},
+		address:  address,
+		mcmsUser: module_mcms_user.NewMCMSUser(address, client),
 	}
 }
 

--- a/cmd/bindgen/template/go.tmpl
+++ b/cmd/bindgen/template/go.tmpl
@@ -30,9 +30,31 @@ type {{toUpperCamel .Module}} interface {
   {{ range .EntryFuncs}}
     {{.Name}}(opts *bind.TransactOpts, {{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) (*api.PendingTransaction, error)
   {{- end}}
+
+  EncodeCall() {{toUpperCamel .Module}}Encoder
+}
+
+type {{toUpperCamel .Module}}Encoder interface {
+  {{- range .ViewFuncs}}
+    {{.Name}}({{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+  {{- end}}
+  {{- range .EntryFuncs}}
+    {{.Name}}({{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+  {{- end}}
+  {{- range .OtherFuncs}}
+    {{.Name}}({{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+  {{- end}}
 }
 
 const FunctionInfo = `{{.FunctionInfo}}`
+
+func New{{toUpperCamel .Module}}(address aptos.AccountAddress, client aptos.AptosRpcClient) {{toUpperCamel .Module}} {
+  contract := bind.NewBoundContract(address, "{{.Package}}", "{{.Module}}", client)
+  return {{toUpperCamel .Module}}Contract {
+    BoundContract: contract,
+    {{toLowerCamel .Module}}Encoder: {{toLowerCamel .Module}}Encoder{BoundContract: contract},
+  }
+}
 
 // Structs
 
@@ -44,31 +66,21 @@ const FunctionInfo = `{{.FunctionInfo}}`
 {{end}}
 
 type {{toUpperCamel .Module}}Contract struct {
-  {{toUpperCamel .Module}}Caller
-  {{toUpperCamel .Module}}Transactor
+  *bind.BoundContract
+  {{toLowerCamel .Module}}Encoder
+}
+
+var _ {{toUpperCamel .Module}} = {{toUpperCamel .Module}}Contract{}
+
+func (c {{toUpperCamel .Module}}Contract) EncodeCall() {{toUpperCamel .Module}}Encoder {
+  return c.{{toLowerCamel .Module}}Encoder
 }
 
 // View Functions
 
-type {{toUpperCamel .Module}}Caller struct {
-  *bind.BoundContract
-}
-
 {{range .ViewFuncs}}
-  func (c {{toUpperCamel $.Module}}Caller) Encode{{.Name}}({{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-    return c.BoundContract.Encode("{{.MoveName}}", nil, []string{
-      {{- range .Params}}
-        "{{.Type.MoveType}}",
-      {{- end}}
-      }, []any{
-      {{- range .Params}}
-        {{.Name}},
-      {{- end}}
-      })
-  }
-
-  func (c {{toUpperCamel $.Module}}Caller) {{.Name}}(opts *bind.CallOpts, {{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) ({{range .Returns}}{{.GoType}},{{end}} error) {
-    module, function, typeTags, args, err := c.Encode{{.Name}}({{range .Params}}{{.Name}}, {{end}})
+  func (c {{toUpperCamel $.Module}}Contract) {{.Name}}(opts *bind.CallOpts, {{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) ({{range .Returns}}{{.GoType}},{{end}} error) {
+    module, function, typeTags, args, err := c.{{toLowerCamel $.Module}}Encoder.{{.Name}}({{range .Params}}{{.Name}}, {{end}})
     if err != nil {
       return {{range .Returns}}*new({{.GoType}}),{{end}} err
     }
@@ -93,25 +105,9 @@ type {{toUpperCamel .Module}}Caller struct {
 
 // Entry Functions
 
-type {{toUpperCamel .Module}}Transactor struct {
-  *bind.BoundContract
-}
-
 {{range .EntryFuncs}}
-  func (c {{toUpperCamel $.Module}}Transactor) Encode{{.Name}}({{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
-    return c.BoundContract.Encode("{{.MoveName}}", nil, []string{
-      {{- range .Params}}
-        "{{.Type.MoveType}}",
-      {{- end}}
-      }, []any{
-      {{- range .Params}}
-        {{.Name}},
-      {{- end}}
-      })
-  }
-
-  func (c {{toUpperCamel $.Module}}Transactor) {{.Name}}(opts *bind.TransactOpts, {{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) (*api.PendingTransaction, error) {
-    module, function, typeTags, args, err := c.Encode{{.Name}}({{range .Params}}{{.Name}}, {{end}})
+  func (c {{toUpperCamel $.Module}}Contract) {{.Name}}(opts *bind.TransactOpts, {{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) (*api.PendingTransaction, error) {
+  module, function, typeTags, args, err := c.{{toLowerCamel $.Module}}Encoder.{{.Name}}({{range .Params}}{{.Name}}, {{end}})
     if err != nil {
       return nil, err
     }
@@ -120,9 +116,41 @@ type {{toUpperCamel .Module}}Transactor struct {
   }
 {{end}}
 
-{{if .OtherFuncs}}// Other Functions{{end}}
+// Encoder
+type {{toLowerCamel .Module}}Encoder struct {
+  *bind.BoundContract
+}
+
+{{range .ViewFuncs}}
+  func (c {{toLowerCamel $.Module}}Encoder) {{.Name}}({{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+  return c.BoundContract.Encode("{{.MoveName}}", nil, []string{
+  {{- range .Params}}
+    "{{.Type.MoveType}}",
+  {{- end}}
+  }, []any{
+  {{- range .Params}}
+      {{.Name}},
+  {{- end}}
+  })
+  }
+{{end}}
+
+{{range .EntryFuncs}}
+  func (c {{toLowerCamel $.Module}}Encoder) {{.Name}}({{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+    return c.BoundContract.Encode("{{.MoveName}}", nil, []string{
+    {{- range .Params}}
+      "{{.Type.MoveType}}",
+    {{- end}}
+    }, []any{
+    {{- range .Params}}
+        {{.Name}},
+    {{- end}}
+    })
+  }
+{{end}}
+
 {{range .OtherFuncs}}
-  func (c {{toUpperCamel $.Module}}Caller) Encode{{.Name}}({{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) (aptos.ModuleId, string, []aptos.TypeTag, [][]byte, error) {
+  func (c {{toLowerCamel $.Module}}Encoder) {{.Name}}({{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
     return c.BoundContract.Encode("{{.MoveName}}", nil, []string{
     {{- range .Params}}
       "{{.Type.MoveType}}",

--- a/cmd/bindgen/template/go.tmpl
+++ b/cmd/bindgen/template/go.tmpl
@@ -31,7 +31,7 @@ type {{toUpperCamel .Module}} interface {
     {{.Name}}(opts *bind.TransactOpts, {{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) (*api.PendingTransaction, error)
   {{- end}}
 
-  _Encode() {{toUpperCamel .Module}}Encoder
+  Encode_() {{toUpperCamel .Module}}Encoder
 }
 
 type {{toUpperCamel .Module}}Encoder interface {
@@ -72,7 +72,7 @@ type {{toUpperCamel .Module}}Contract struct {
 
 var _ {{toUpperCamel .Module}} = {{toUpperCamel .Module}}Contract{}
 
-func (c {{toUpperCamel .Module}}Contract) _Encode() {{toUpperCamel .Module}}Encoder {
+func (c {{toUpperCamel .Module}}Contract) Encode_() {{toUpperCamel .Module}}Encoder {
   return c.{{toLowerCamel .Module}}Encoder
 }
 

--- a/cmd/bindgen/template/go.tmpl
+++ b/cmd/bindgen/template/go.tmpl
@@ -31,7 +31,7 @@ type {{toUpperCamel .Module}} interface {
     {{.Name}}(opts *bind.TransactOpts, {{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) (*api.PendingTransaction, error)
   {{- end}}
 
-  // Encode returns the encoder implementation of this module.
+  // Encoder returns the encoder implementation of this module.
   Encoder() {{toUpperCamel .Module}}Encoder
 }
 

--- a/cmd/bindgen/template/go.tmpl
+++ b/cmd/bindgen/template/go.tmpl
@@ -31,7 +31,8 @@ type {{toUpperCamel .Module}} interface {
     {{.Name}}(opts *bind.TransactOpts, {{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) (*api.PendingTransaction, error)
   {{- end}}
 
-  Encode_() {{toUpperCamel .Module}}Encoder
+  // Encode returns the encoder implementation of this module.
+  Encoder() {{toUpperCamel .Module}}Encoder
 }
 
 type {{toUpperCamel .Module}}Encoder interface {
@@ -72,7 +73,7 @@ type {{toUpperCamel .Module}}Contract struct {
 
 var _ {{toUpperCamel .Module}} = {{toUpperCamel .Module}}Contract{}
 
-func (c {{toUpperCamel .Module}}Contract) Encode_() {{toUpperCamel .Module}}Encoder {
+func (c {{toUpperCamel .Module}}Contract) Encoder() {{toUpperCamel .Module}}Encoder {
   return c.{{toLowerCamel .Module}}Encoder
 }
 

--- a/cmd/bindgen/template/go.tmpl
+++ b/cmd/bindgen/template/go.tmpl
@@ -31,7 +31,7 @@ type {{toUpperCamel .Module}} interface {
     {{.Name}}(opts *bind.TransactOpts, {{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) (*api.PendingTransaction, error)
   {{- end}}
 
-  EncodeCall() {{toUpperCamel .Module}}Encoder
+  _Encode() {{toUpperCamel .Module}}Encoder
 }
 
 type {{toUpperCamel .Module}}Encoder interface {
@@ -72,7 +72,7 @@ type {{toUpperCamel .Module}}Contract struct {
 
 var _ {{toUpperCamel .Module}} = {{toUpperCamel .Module}}Contract{}
 
-func (c {{toUpperCamel .Module}}Contract) EncodeCall() {{toUpperCamel .Module}}Encoder {
+func (c {{toUpperCamel .Module}}Contract) _Encode() {{toUpperCamel .Module}}Encoder {
   return c.{{toLowerCamel .Module}}Encoder
 }
 

--- a/cmd/bindgen/template/go.tmpl
+++ b/cmd/bindgen/template/go.tmpl
@@ -22,7 +22,7 @@ var (
   _ = codec.DecodeAptosJsonValue
 )
 
-type {{toUpperCamel .Module}}Interface interface {
+type {{toUpperCamel .Module}} interface {
   {{- range .ViewFuncs}}
     {{.Name}}(opts *bind.CallOpts, {{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) ({{range .Returns}}{{.GoType}},{{end}} error)
   {{- end}}
@@ -43,7 +43,7 @@ const FunctionInfo = `{{.FunctionInfo}}`
   }
 {{end}}
 
-type {{toUpperCamel .Module}} struct {
+type {{toUpperCamel .Module}}Contract struct {
   {{toUpperCamel .Module}}Caller
   {{toUpperCamel .Module}}Transactor
 }


### PR DESCRIPTION
Add package-level interfaces for all bindings, to allow for mocks.

Breaking changes:
- To use a bound module now requires to use the interface method to get the module: `mcmsBindings.MCMS.SetConfig(...) => mcmsBindings.MCMS().SetConfig(...)`
- The EncodeXXX methods have been made part of the module-level interface as well: `mcmsBindings.MCMS.EncodeSetConfig(...) => mcmsBindings.MCMS().Encoder().SetConfig(...)`
- The Encode methods now return a `bind.ModuleInformation` instead of the previous `aptos.ModuleId`. This allows us to return the package name from these methods
