### PR TITLE
Add mcms address to router compilation

### DIFF
--- a/bindings/ccip_router/ccip_router.go
+++ b/bindings/ccip_router/ccip_router.go
@@ -23,7 +23,7 @@ var FunctionInfo = bind.MustParseFunctionInfo(
 	module_router.FunctionInfo,
 )
 
-func Compile(ccipAddress aptos.AccountAddress, mcmsAddress aptos.AccountAddress) (compile.CompiledPackage, error) {
+func Compile(ccipAddress, mcmsAddress aptos.AccountAddress) (compile.CompiledPackage, error) {
 	namedAddresses := map[string]aptos.AccountAddress{
 		"ccip":                      ccipAddress,
 		"ccip_router":               ccipAddress,
@@ -50,9 +50,7 @@ func Bind(address aptos.AccountAddress, client aptos.AptosRpcClient) CCIPRouter 
 func DeployToExistingObject(
 	auth aptos.TransactionSigner,
 	client aptos.AptosRpcClient,
-	objectAddress aptos.AccountAddress,
-	ccipAddress aptos.AccountAddress,
-	mcmsAddress aptos.AccountAddress,
+	objectAddress, ccipAddress, mcmsAddress aptos.AccountAddress,
 ) (*api.PendingTransaction, CCIPRouter, error) {
 	// no need for mcms addresses since the router does not interact with mcms directly.
 	namedAddresses := map[string]aptos.AccountAddress{

--- a/bindings/ccip_router/ccip_router.go
+++ b/bindings/ccip_router/ccip_router.go
@@ -23,11 +23,11 @@ var FunctionInfo = bind.MustParseFunctionInfo(
 	module_router.FunctionInfo,
 )
 
-func Compile(ccipAddress aptos.AccountAddress) (compile.CompiledPackage, error) {
+func Compile(ccipAddress aptos.AccountAddress, mcmsAddress aptos.AccountAddress) (compile.CompiledPackage, error) {
 	namedAddresses := map[string]aptos.AccountAddress{
 		"ccip":                      ccipAddress,
 		"ccip_router":               ccipAddress,
-		"mcms":                      aptos.AccountZero,
+		"mcms":                      mcmsAddress,
 		"mcms_register_entrypoints": aptos.AccountZero,
 	}
 	// Compile using CLI
@@ -52,11 +52,12 @@ func DeployToExistingObject(
 	client aptos.AptosRpcClient,
 	objectAddress aptos.AccountAddress,
 	ccipAddress aptos.AccountAddress,
+	mcmsAddress aptos.AccountAddress,
 ) (*api.PendingTransaction, CCIPRouter, error) {
 	// no need for mcms addresses since the router does not interact with mcms directly.
 	namedAddresses := map[string]aptos.AccountAddress{
 		"ccip":                      ccipAddress,
-		"mcms":                      aptos.AccountZero,
+		"mcms":                      mcmsAddress,
 		"mcms_register_entrypoints": aptos.AccountZero,
 	}
 	tx, err := bind.UpgradePackageToObject(auth, client, "ccip_router", namedAddresses, objectAddress)


### PR DESCRIPTION
Add the MCMS address back to the named addresses for compiling the CCIP Router.
It's transitively required by CCIP.