### PR TITLE
relayer: update mapstructure package

### DIFF
--- a/relayer/chainreader/chainreader.go
+++ b/relayer/chainreader/chainreader.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/aptos-labs/aptos-go-sdk"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"

--- a/relayer/chainwriter/chainwriter.go
+++ b/relayer/chainwriter/chainwriter.go
@@ -7,7 +7,7 @@ import (
 	"math/big"
 
 	"github.com/aptos-labs/aptos-go-sdk"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"

--- a/relayer/codec/decode_util.go
+++ b/relayer/codec/decode_util.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 func DecodeAptosJsonArray(from []any, to ...any) error {

--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -7,10 +7,10 @@ toolchain go1.23.4
 require (
 	github.com/aptos-labs/aptos-go-sdk v1.5.1-0.20250322153135-0c35be181ce8
 	github.com/ethereum/go-ethereum v1.14.11
+	github.com/go-viper/mapstructure/v2 v2.1.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-plugin v1.6.2
 	github.com/jpillora/backoff v1.0.0
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pelletier/go-toml/v2 v2.2.0
 	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250314131019-e227d4e2dc2f
 	github.com/stretchr/testify v1.10.0
@@ -57,7 +57,6 @@ require (
 	github.com/go-playground/locales v0.13.0 // indirect
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/go-playground/validator/v10 v10.4.1 // indirect
-	github.com/go-viper/mapstructure/v2 v2.1.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1 // indirect

--- a/relayer/txm/txm_multisig_local_test.go
+++ b/relayer/txm/txm_multisig_local_test.go
@@ -25,8 +25,8 @@ import (
 	aptoscrypto "github.com/aptos-labs/aptos-go-sdk/crypto"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/google/uuid"
-	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/sha3"
 


### PR DESCRIPTION
the current one is archived, this is the one used in chainlink-common