### PR TITLE
chore: rename secrets, and environments

### DIFF
--- a/.github/workflows/aptos-release.yml
+++ b/.github/workflows/aptos-release.yml
@@ -33,7 +33,7 @@ jobs:
   build-push:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    environment: integration
+    environment: publish
     permissions:
       id-token: write
       contents: write
@@ -44,9 +44,9 @@ jobs:
       id: setup-github-token
       uses: smartcontractkit/.github/actions/setup-github-token@ef78fa97bf3c77de6563db1175422703e9e6674f # setup-github-token@0.2.1
       with:
-        aws-role-arn: ${{ secrets.AWS_ROLE_ARN_CII_RELEASE }}
-        aws-lambda-url: ${{ secrets.GATI_LAMBDA_FOUNDATIONS_URL }}
-        aws-region: ${{ secrets.QA_AWS_REGION }}
+        aws-role-arn: ${{ secrets.AWS_ROLE_ARN_GATI_CHANGESETS }}
+        aws-lambda-url: ${{ secrets.AWS_LAMBDA_URL_GATI }}
+        aws-region: ${{ secrets.AWS_REGION }}
 
     - name: Checkout this repository
       uses: actions/checkout@v4

--- a/.github/workflows/aptos-run-smoke-tests.yml
+++ b/.github/workflows/aptos-run-smoke-tests.yml
@@ -43,8 +43,8 @@ jobs:
         path: temp/chainlink
 
     - name: Build chainlink image
+      working-directory: temp/chainlink
       run: |
-        cd temp/chainlink
         docker buildx build --build-arg COMMIT_SHA=$(git rev-parse HEAD) -t local_chainlink -f plugins/chainlink.Dockerfile .
 
     - name: Build chainlink-aptos image
@@ -99,15 +99,6 @@ jobs:
       run: |
         cd integration-tests
         TEST_LOG_LEVEL=${{env.TEST_LOG_LEVEL}} go test -timeout 24h -count=1 -run TestOCR3Keystone ./smoke
-
-    - name: Setup GitHub Token
-      if: success()
-      id: setup-github-token
-      uses: smartcontractkit/.github/actions/setup-github-token@ef78fa97bf3c77de6563db1175422703e9e6674f # setup-github-token@0.2.1
-      with:
-        aws-role-arn: ${{ secrets.AWS_ROLE_ARN_GLOBAL_READ_ONLY }}
-        aws-lambda-url: ${{ secrets.GATI_LAMBDA_RELENG_URL }}
-        aws-region: ${{ secrets.QA_AWS_REGION }}
 
     - name: Configure AWS Credentials
       if: success()


### PR DESCRIPTION
Some secrets and environments are being renamed so they better match the underlying resources.

`AWS_ROLE_ARN_CII_RELEASE` --> `AWS_ROLE_ARN_GATI_CHANGESETS`
`GATI_LAMBDA_FOUNDATIONS_URL` --> `AWS_LAMBDA_URL_GATI`
`aptos-release.jobs.build-push.enviroment: integration` --> `publish`
