### PR TITLE
Add mcms_entrypoints and bindings for token pools

### DIFF
--- a/bindings/ccip/auth/auth.go
+++ b/bindings/ccip/auth/auth.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type Auth interface {
+type AuthInterface interface {
 	Owner(opts *bind.CallOpts) (aptos.AccountAddress, error)
 
 	TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
@@ -45,7 +45,7 @@ type AuthEncoder interface {
 
 const FunctionInfo = `[{"package":"ccip","module":"auth","name":"accept_ownership","parameters":null},{"package":"ccip","module":"auth","name":"assert_is_router","parameters":[{"name":"caller","type":"address"}]},{"package":"ccip","module":"auth","name":"assert_only_owner","parameters":[{"name":"caller","type":"address"}]},{"package":"ccip","module":"auth","name":"execute_ownership_transfer","parameters":[{"name":"to","type":"address"}]},{"package":"ccip","module":"auth","name":"mcms_entrypoint","parameters":[{"name":"_metadata","type":"address"}]},{"package":"ccip","module":"auth","name":"transfer_ownership","parameters":[{"name":"to","type":"address"}]}]`
 
-func NewAuth(address aptos.AccountAddress, client aptos.AptosRpcClient) Auth {
+func NewAuth(address aptos.AccountAddress, client aptos.AptosRpcClient) AuthInterface {
 	contract := bind.NewBoundContract(address, "ccip", "auth", client)
 	return AuthContract{
 		BoundContract: contract,
@@ -67,7 +67,7 @@ type AuthContract struct {
 	authEncoder
 }
 
-var _ Auth = AuthContract{}
+var _ AuthInterface = AuthContract{}
 
 func (c AuthContract) Encoder() AuthEncoder {
 	return c.authEncoder

--- a/bindings/ccip/ccip.go
+++ b/bindings/ccip/ccip.go
@@ -19,13 +19,13 @@ import (
 type CCIP interface {
 	Address() aptos.AccountAddress
 
-	Auth() module_auth.Auth
-	FeeQuoter() module_fee_quoter.FeeQuoter
-	Offramp() module_offramp.Offramp
-	Onramp() module_onramp.Onramp
-	ReceiverRegistry() module_receiver_registry.ReceiverRegistry
-	RMNRemote() module_rmn_remote.RMNRemote
-	TokenAdminRegistry() module_token_admin_registry.TokenAdminRegistry
+	Auth() module_auth.AuthInterface
+	FeeQuoter() module_fee_quoter.FeeQuoterInterface
+	Offramp() module_offramp.OfframpInterface
+	Onramp() module_onramp.OnrampInterface
+	ReceiverRegistry() module_receiver_registry.ReceiverRegistryInterface
+	RMNRemote() module_rmn_remote.RMNRemoteInterface
+	TokenAdminRegistry() module_token_admin_registry.TokenAdminRegistryInterface
 }
 
 var _ CCIP = CCIPContract{}
@@ -33,44 +33,44 @@ var _ CCIP = CCIPContract{}
 type CCIPContract struct {
 	address aptos.AccountAddress
 
-	auth               module_auth.Auth
-	feeQuoter          module_fee_quoter.FeeQuoter
-	offramp            module_offramp.Offramp
-	onramp             module_onramp.Onramp
-	receiverRegistry   module_receiver_registry.ReceiverRegistry
-	rmnRemote          module_rmn_remote.RMNRemote
-	tokenAdminRegistry module_token_admin_registry.TokenAdminRegistry
+	auth               module_auth.AuthInterface
+	feeQuoter          module_fee_quoter.FeeQuoterInterface
+	offramp            module_offramp.OfframpInterface
+	onramp             module_onramp.OnrampInterface
+	receiverRegistry   module_receiver_registry.ReceiverRegistryInterface
+	rmnRemote          module_rmn_remote.RMNRemoteInterface
+	tokenAdminRegistry module_token_admin_registry.TokenAdminRegistryInterface
 }
 
 func (C CCIPContract) Address() aptos.AccountAddress {
 	return C.address
 }
 
-func (C CCIPContract) Auth() module_auth.Auth {
+func (C CCIPContract) Auth() module_auth.AuthInterface {
 	return C.auth
 }
 
-func (C CCIPContract) FeeQuoter() module_fee_quoter.FeeQuoter {
+func (C CCIPContract) FeeQuoter() module_fee_quoter.FeeQuoterInterface {
 	return C.feeQuoter
 }
 
-func (C CCIPContract) Offramp() module_offramp.Offramp {
+func (C CCIPContract) Offramp() module_offramp.OfframpInterface {
 	return C.offramp
 }
 
-func (C CCIPContract) Onramp() module_onramp.Onramp {
+func (C CCIPContract) Onramp() module_onramp.OnrampInterface {
 	return C.onramp
 }
 
-func (C CCIPContract) ReceiverRegistry() module_receiver_registry.ReceiverRegistry {
+func (C CCIPContract) ReceiverRegistry() module_receiver_registry.ReceiverRegistryInterface {
 	return C.receiverRegistry
 }
 
-func (C CCIPContract) RMNRemote() module_rmn_remote.RMNRemote {
+func (C CCIPContract) RMNRemote() module_rmn_remote.RMNRemoteInterface {
 	return C.rmnRemote
 }
 
-func (C CCIPContract) TokenAdminRegistry() module_token_admin_registry.TokenAdminRegistry {
+func (C CCIPContract) TokenAdminRegistry() module_token_admin_registry.TokenAdminRegistryInterface {
 	return C.tokenAdminRegistry
 }
 

--- a/bindings/ccip/fee_quoter/fee_quoter.go
+++ b/bindings/ccip/fee_quoter/fee_quoter.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type FeeQuoter interface {
+type FeeQuoterInterface interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 	GetTokenPrice(opts *bind.CallOpts, token aptos.AccountAddress) (TimestampedPrice, error)
 	GetTokenPrices(opts *bind.CallOpts, tokens []aptos.AccountAddress) ([]TimestampedPrice, error)
@@ -77,7 +77,7 @@ type FeeQuoterEncoder interface {
 
 const FunctionInfo = `[{"package":"ccip","module":"fee_quoter","name":"apply_dest_chain_config_updates","parameters":[{"name":"dest_chain_selector","type":"u64"},{"name":"is_enabled","type":"bool"},{"name":"max_number_of_tokens_per_msg","type":"u16"},{"name":"max_data_bytes","type":"u32"},{"name":"max_per_msg_gas_limit","type":"u32"},{"name":"dest_gas_overhead","type":"u32"},{"name":"dest_gas_per_payload_byte_base","type":"u8"},{"name":"dest_gas_per_payload_byte_high","type":"u8"},{"name":"dest_gas_per_payload_byte_threshold","type":"u16"},{"name":"dest_data_availability_overhead_gas","type":"u32"},{"name":"dest_gas_per_data_availability_byte","type":"u16"},{"name":"dest_data_availability_multiplier_bps","type":"u16"},{"name":"chain_family_selector","type":"vector\u003cu8\u003e"},{"name":"enforce_out_of_order","type":"bool"},{"name":"default_token_fee_usd_cents","type":"u16"},{"name":"default_token_dest_gas_overhead","type":"u32"},{"name":"default_tx_gas_limit","type":"u32"},{"name":"gas_multiplier_wei_per_eth","type":"u64"},{"name":"gas_price_staleness_threshold","type":"u32"},{"name":"network_fee_usd_cents","type":"u32"}]},{"package":"ccip","module":"fee_quoter","name":"apply_fee_token_updates","parameters":[{"name":"fee_tokens_to_remove","type":"vector\u003caddress\u003e"},{"name":"fee_tokens_to_add","type":"vector\u003caddress\u003e"}]},{"package":"ccip","module":"fee_quoter","name":"apply_premium_multiplier_wei_per_eth_updates","parameters":[{"name":"tokens","type":"vector\u003caddress\u003e"},{"name":"premium_multiplier_wei_per_eth","type":"vector\u003cu64\u003e"}]},{"package":"ccip","module":"fee_quoter","name":"apply_token_transfer_fee_config_updates","parameters":[{"name":"dest_chain_selector","type":"u64"},{"name":"add_tokens","type":"vector\u003caddress\u003e"},{"name":"add_min_fee_usd_cents","type":"vector\u003cu32\u003e"},{"name":"add_max_fee_usd_cents","type":"vector\u003cu32\u003e"},{"name":"add_deci_bps","type":"vector\u003cu16\u003e"},{"name":"add_dest_gas_overhead","type":"vector\u003cu32\u003e"},{"name":"add_dest_bytes_overhead","type":"vector\u003cu32\u003e"},{"name":"add_is_enabled","type":"vector\u003cbool\u003e"},{"name":"remove_tokens","type":"vector\u003caddress\u003e"}]},{"package":"ccip","module":"fee_quoter","name":"calc_usd_value_from_token_amount","parameters":[{"name":"token_amount","type":"u64"},{"name":"token_price","type":"u256"}]},{"package":"ccip","module":"fee_quoter","name":"decode_generic_extra_args","parameters":[{"name":"extra_args","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"fee_quoter","name":"decode_generic_extra_args_v2","parameters":[{"name":"extra_args","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"fee_quoter","name":"decode_svm_extra_args","parameters":[{"name":"extra_args","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"fee_quoter","name":"decode_svm_extra_args_v1","parameters":[{"name":"extra_args","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"fee_quoter","name":"encode_generic_extra_args_v2","parameters":[{"name":"gas_limit","type":"u256"},{"name":"allow_out_of_order_execution","type":"bool"}]},{"package":"ccip","module":"fee_quoter","name":"initialize","parameters":[{"name":"max_fee_juels_per_msg","type":"u64"},{"name":"link_token","type":"address"},{"name":"token_price_staleness_threshold","type":"u64"},{"name":"fee_tokens","type":"vector\u003caddress\u003e"}]},{"package":"ccip","module":"fee_quoter","name":"mcms_entrypoint","parameters":[{"name":"_metadata","type":"address"}]},{"package":"ccip","module":"fee_quoter","name":"update_prices","parameters":[{"name":"source_tokens","type":"vector\u003caddress\u003e"},{"name":"source_usd_per_token","type":"vector\u003cu256\u003e"},{"name":"gas_dest_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"gas_usd_per_unit_gas","type":"vector\u003cu256\u003e"}]},{"package":"ccip","module":"fee_quoter","name":"validate_32byte_address","parameters":[{"name":"encoded_address","type":"vector\u003cu8\u003e"},{"name":"must_be_non_zero","type":"bool"}]},{"package":"ccip","module":"fee_quoter","name":"validate_evm_address","parameters":[{"name":"encoded_address","type":"vector\u003cu8\u003e"}]}]`
 
-func NewFeeQuoter(address aptos.AccountAddress, client aptos.AptosRpcClient) FeeQuoter {
+func NewFeeQuoter(address aptos.AccountAddress, client aptos.AptosRpcClient) FeeQuoterInterface {
 	contract := bind.NewBoundContract(address, "ccip", "fee_quoter", client)
 	return FeeQuoterContract{
 		BoundContract:    contract,
@@ -190,7 +190,7 @@ type FeeQuoterContract struct {
 	feeQuoterEncoder
 }
 
-var _ FeeQuoter = FeeQuoterContract{}
+var _ FeeQuoterInterface = FeeQuoterContract{}
 
 func (c FeeQuoterContract) Encoder() FeeQuoterEncoder {
 	return c.feeQuoterEncoder

--- a/bindings/ccip/ocr3_base/ocr3_base.go
+++ b/bindings/ccip/ocr3_base/ocr3_base.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type Ocr3Base interface {
+type Ocr3BaseInterface interface {
 
 	// Encoder returns the encoder implementation of this module.
 	Encoder() Ocr3BaseEncoder
@@ -37,7 +37,7 @@ type Ocr3BaseEncoder interface {
 
 const FunctionInfo = `[{"package":"ccip","module":"ocr3_base","name":"deserialize_sequence_bytes","parameters":[{"name":"sequence_bytes","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"ocr3_base","name":"hash_report","parameters":[{"name":"report","type":"vector\u003cu8\u003e"},{"name":"config_digest","type":"vector\u003cu8\u003e"},{"name":"sequence_bytes","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"ocr3_base","name":"new","parameters":null},{"package":"ccip","module":"ocr3_base","name":"ocr_plugin_type_commit","parameters":null},{"package":"ccip","module":"ocr3_base","name":"ocr_plugin_type_execution","parameters":null}]`
 
-func NewOcr3Base(address aptos.AccountAddress, client aptos.AptosRpcClient) Ocr3Base {
+func NewOcr3Base(address aptos.AccountAddress, client aptos.AptosRpcClient) Ocr3BaseInterface {
 	contract := bind.NewBoundContract(address, "ccip", "ocr3_base", client)
 	return Ocr3BaseContract{
 		BoundContract:   contract,
@@ -88,7 +88,7 @@ type Ocr3BaseContract struct {
 	ocr3BaseEncoder
 }
 
-var _ Ocr3Base = Ocr3BaseContract{}
+var _ Ocr3BaseInterface = Ocr3BaseContract{}
 
 func (c Ocr3BaseContract) Encoder() Ocr3BaseEncoder {
 	return c.ocr3BaseEncoder

--- a/bindings/ccip/offramp/offramp.go
+++ b/bindings/ccip/offramp/offramp.go
@@ -22,7 +22,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type Offramp interface {
+type OfframpInterface interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 	GetExecutionState(opts *bind.CallOpts, sourceChainSelector uint64, sequenceNumber uint64) (byte, error)
 	GetLatestPriceSequenceNumber(opts *bind.CallOpts) (uint64, error)
@@ -73,7 +73,7 @@ type OfframpEncoder interface {
 
 const FunctionInfo = `[{"package":"ccip","module":"offramp","name":"apply_source_chain_config_updates","parameters":[{"name":"source_chains_selector","type":"vector\u003cu64\u003e"},{"name":"source_chains_is_enabled","type":"vector\u003cbool\u003e"},{"name":"source_chains_is_rmn_verification_disabled","type":"vector\u003cbool\u003e"},{"name":"source_chains_on_ramp","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"ccip","module":"offramp","name":"calculate_metadata_hash","parameters":[{"name":"source_chain_selector","type":"u64"},{"name":"dest_chain_selector","type":"u64"},{"name":"on_ramp","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"offramp","name":"commit","parameters":[{"name":"report_context","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"report","type":"vector\u003cu8\u003e"},{"name":"signatures","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"ccip","module":"offramp","name":"create_dynamic_config","parameters":[{"name":"permissionless_execution_threshold_seconds","type":"u32"}]},{"package":"ccip","module":"offramp","name":"create_static_config","parameters":[{"name":"chain_selector","type":"u64"}]},{"package":"ccip","module":"offramp","name":"deserialize_commit_report","parameters":[{"name":"report_bytes","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"offramp","name":"deserialize_execution_report","parameters":[{"name":"report_bytes","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"offramp","name":"deserialize_execution_reports","parameters":[{"name":"reports_bytes","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"offramp","name":"execute","parameters":[{"name":"report_context","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"report","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"offramp","name":"initialize","parameters":[{"name":"chain_selector","type":"u64"},{"name":"permissionless_execution_threshold_seconds","type":"u32"},{"name":"source_chains_selector","type":"vector\u003cu64\u003e"},{"name":"source_chains_is_enabled","type":"vector\u003cbool\u003e"},{"name":"source_chains_is_rmn_verification_disabled","type":"vector\u003cbool\u003e"},{"name":"source_chains_on_ramp","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"ccip","module":"offramp","name":"manually_execute","parameters":[{"name":"report_bytes","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"offramp","name":"mcms_entrypoint","parameters":[{"name":"_metadata","type":"address"}]},{"package":"ccip","module":"offramp","name":"set_dynamic_config","parameters":[{"name":"permissionless_execution_threshold_seconds","type":"u32"}]},{"package":"ccip","module":"offramp","name":"set_ocr3_config","parameters":[{"name":"config_digest","type":"vector\u003cu8\u003e"},{"name":"ocr_plugin_type","type":"u8"},{"name":"big_f","type":"u8"},{"name":"is_signature_verification_enabled","type":"bool"},{"name":"signers","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"transmitters","type":"vector\u003caddress\u003e"}]}]`
 
-func NewOfframp(address aptos.AccountAddress, client aptos.AptosRpcClient) Offramp {
+func NewOfframp(address aptos.AccountAddress, client aptos.AptosRpcClient) OfframpInterface {
 	contract := bind.NewBoundContract(address, "ccip", "offramp", client)
 	return OfframpContract{
 		BoundContract:  contract,
@@ -220,7 +220,7 @@ type OfframpContract struct {
 	offrampEncoder
 }
 
-var _ Offramp = OfframpContract{}
+var _ OfframpInterface = OfframpContract{}
 
 func (c OfframpContract) Encoder() OfframpEncoder {
 	return c.offrampEncoder

--- a/bindings/ccip/onramp/onramp.go
+++ b/bindings/ccip/onramp/onramp.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type Onramp interface {
+type OnrampInterface interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 	IsChainSupported(opts *bind.CallOpts, destChainSelector uint64) (bool, error)
 	GetExpectedNextSequenceNumber(opts *bind.CallOpts, destChainSelector uint64) (uint64, error)
@@ -64,7 +64,7 @@ type OnrampEncoder interface {
 
 const FunctionInfo = `[{"package":"ccip","module":"onramp","name":"apply_allowlist_updates","parameters":[{"name":"dest_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"dest_chain_allowlist_enabled","type":"vector\u003cbool\u003e"},{"name":"dest_chain_add_allowed_senders","type":"vector\u003cvector\u003caddress\u003e\u003e"},{"name":"dest_chain_remove_allowed_senders","type":"vector\u003cvector\u003caddress\u003e\u003e"}]},{"package":"ccip","module":"onramp","name":"apply_dest_chain_config_updates","parameters":[{"name":"dest_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"dest_chain_enabled","type":"vector\u003cbool\u003e"},{"name":"dest_chain_allowlist_enabled","type":"vector\u003cbool\u003e"}]},{"package":"ccip","module":"onramp","name":"calculate_metadata_hash","parameters":[{"name":"source_chain_selector","type":"u64"},{"name":"dest_chain_selector","type":"u64"}]},{"package":"ccip","module":"onramp","name":"ccip_send","parameters":[{"name":"dest_chain_selector","type":"u64"},{"name":"receiver","type":"vector\u003cu8\u003e"},{"name":"data","type":"vector\u003cu8\u003e"},{"name":"token_addresses","type":"vector\u003caddress\u003e"},{"name":"token_amounts","type":"vector\u003cu64\u003e"},{"name":"token_store_addresses","type":"vector\u003caddress\u003e"},{"name":"fee_token","type":"address"},{"name":"fee_token_store","type":"address"},{"name":"extra_args","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"onramp","name":"initialize","parameters":[{"name":"chain_selector","type":"u64"},{"name":"allowlist_admin","type":"address"},{"name":"dest_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"dest_chain_enabled","type":"vector\u003cbool\u003e"},{"name":"dest_chain_allowlist_enabled","type":"vector\u003cbool\u003e"}]},{"package":"ccip","module":"onramp","name":"mcms_entrypoint","parameters":[{"name":"_metadata","type":"address"}]},{"package":"ccip","module":"onramp","name":"resolve_fungible_asset","parameters":[{"name":"token","type":"address"}]},{"package":"ccip","module":"onramp","name":"resolve_fungible_store","parameters":[{"name":"owner","type":"address"},{"name":"token","type":"address"},{"name":"store_address","type":"address"}]},{"package":"ccip","module":"onramp","name":"set_dynamic_config","parameters":[{"name":"allowlist_admin","type":"address"}]}]`
 
-func NewOnramp(address aptos.AccountAddress, client aptos.AptosRpcClient) Onramp {
+func NewOnramp(address aptos.AccountAddress, client aptos.AptosRpcClient) OnrampInterface {
 	contract := bind.NewBoundContract(address, "ccip", "onramp", client)
 	return OnrampContract{
 		BoundContract: contract,
@@ -158,7 +158,7 @@ type OnrampContract struct {
 	onrampEncoder
 }
 
-var _ Onramp = OnrampContract{}
+var _ OnrampInterface = OnrampContract{}
 
 func (c OnrampContract) Encoder() OnrampEncoder {
 	return c.onrampEncoder

--- a/bindings/ccip/receiver_registry/receiver_registry.go
+++ b/bindings/ccip/receiver_registry/receiver_registry.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type ReceiverRegistry interface {
+type ReceiverRegistryInterface interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 
 	// Encoder returns the encoder implementation of this module.
@@ -35,7 +35,7 @@ type ReceiverRegistryEncoder interface {
 
 const FunctionInfo = `[{"package":"ccip","module":"receiver_registry","name":"finish_receive","parameters":[{"name":"receiver_address","type":"address"}]}]`
 
-func NewReceiverRegistry(address aptos.AccountAddress, client aptos.AptosRpcClient) ReceiverRegistry {
+func NewReceiverRegistry(address aptos.AccountAddress, client aptos.AptosRpcClient) ReceiverRegistryInterface {
 	contract := bind.NewBoundContract(address, "ccip", "receiver_registry", client)
 	return ReceiverRegistryContract{
 		BoundContract:           contract,
@@ -62,7 +62,7 @@ type ReceiverRegistryContract struct {
 	receiverRegistryEncoder
 }
 
-var _ ReceiverRegistry = ReceiverRegistryContract{}
+var _ ReceiverRegistryInterface = ReceiverRegistryContract{}
 
 func (c ReceiverRegistryContract) Encoder() ReceiverRegistryEncoder {
 	return c.receiverRegistryEncoder

--- a/bindings/ccip/rmn_remote/rmn_remote.go
+++ b/bindings/ccip/rmn_remote/rmn_remote.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type RMNRemote interface {
+type RMNRemoteInterface interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 	Verify(opts *bind.CallOpts, merkleRootSourceChainSelectors []uint64, merkleRootMinSeqNrs []uint64, merkleRootMaxSeqNrs []uint64, merkleRootValues [][]byte, signatures [][]byte) (bool, error)
 	GetArm(opts *bind.CallOpts) (aptos.AccountAddress, error)
@@ -66,7 +66,7 @@ type RMNRemoteEncoder interface {
 
 const FunctionInfo = `[{"package":"ccip","module":"rmn_remote","name":"curse","parameters":[{"name":"subject","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"rmn_remote","name":"curse_multiple","parameters":[{"name":"subjects","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"ccip","module":"rmn_remote","name":"initialize","parameters":[{"name":"local_chain_selector","type":"u64"}]},{"package":"ccip","module":"rmn_remote","name":"mcms_entrypoint","parameters":[{"name":"_metadata","type":"address"}]},{"package":"ccip","module":"rmn_remote","name":"set_config","parameters":[{"name":"rmn_home_contract_config_digest","type":"vector\u003cu8\u003e"},{"name":"signer_onchain_public_keys","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"node_indexes","type":"vector\u003cu64\u003e"},{"name":"f_sign","type":"u64"}]},{"package":"ccip","module":"rmn_remote","name":"uncurse","parameters":[{"name":"subject","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"rmn_remote","name":"uncurse_multiple","parameters":[{"name":"subjects","type":"vector\u003cvector\u003cu8\u003e\u003e"}]}]`
 
-func NewRMNRemote(address aptos.AccountAddress, client aptos.AptosRpcClient) RMNRemote {
+func NewRMNRemote(address aptos.AccountAddress, client aptos.AptosRpcClient) RMNRemoteInterface {
 	contract := bind.NewBoundContract(address, "ccip", "rmn_remote", client)
 	return RMNRemoteContract{
 		BoundContract:    contract,
@@ -135,7 +135,7 @@ type RMNRemoteContract struct {
 	rmnRemoteEncoder
 }
 
-var _ RMNRemote = RMNRemoteContract{}
+var _ RMNRemoteInterface = RMNRemoteContract{}
 
 func (c RMNRemoteContract) Encoder() RMNRemoteEncoder {
 	return c.rmnRemoteEncoder

--- a/bindings/ccip/token_admin_registry/token_admin_registry.go
+++ b/bindings/ccip/token_admin_registry/token_admin_registry.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type TokenAdminRegistry interface {
+type TokenAdminRegistryInterface interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 	GetPools(opts *bind.CallOpts, localTokens []aptos.AccountAddress) ([]aptos.AccountAddress, error)
 	GetPool(opts *bind.CallOpts, localToken aptos.AccountAddress) (aptos.AccountAddress, error)
@@ -56,7 +56,7 @@ type TokenAdminRegistryEncoder interface {
 
 const FunctionInfo = `[{"package":"ccip","module":"token_admin_registry","name":"accept_admin_role","parameters":[{"name":"local_token","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"assert_can_register","parameters":[{"name":"registry_owner_address","type":"address"},{"name":"token_pool_address","type":"address"},{"name":"fungible_asset_metadata","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"finish_lock_or_burn","parameters":[{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"finish_release_or_mint","parameters":[{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"mcms_entrypoint","parameters":[{"name":"_metadata","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"set_pool","parameters":[{"name":"local_token","type":"address"},{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"start_lock_or_burn","parameters":[{"name":"token_pool_address","type":"address"},{"name":"sender","type":"address"},{"name":"remote_chain_selector","type":"u64"},{"name":"receiver","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"token_admin_registry","name":"transfer_admin_role","parameters":[{"name":"local_token","type":"address"},{"name":"new_admin","type":"address"}]}]`
 
-func NewTokenAdminRegistry(address aptos.AccountAddress, client aptos.AptosRpcClient) TokenAdminRegistry {
+func NewTokenAdminRegistry(address aptos.AccountAddress, client aptos.AptosRpcClient) TokenAdminRegistryInterface {
 	contract := bind.NewBoundContract(address, "ccip", "token_admin_registry", client)
 	return TokenAdminRegistryContract{
 		BoundContract:             contract,
@@ -136,7 +136,7 @@ type TokenAdminRegistryContract struct {
 	tokenAdminRegistryEncoder
 }
 
-var _ TokenAdminRegistry = TokenAdminRegistryContract{}
+var _ TokenAdminRegistryInterface = TokenAdminRegistryContract{}
 
 func (c TokenAdminRegistryContract) Encoder() TokenAdminRegistryEncoder {
 	return c.tokenAdminRegistryEncoder

--- a/bindings/ccip_dummy_receiver/ccip_dummy_receiver.go
+++ b/bindings/ccip_dummy_receiver/ccip_dummy_receiver.go
@@ -13,7 +13,7 @@ import (
 type CCIPDummyReceiver interface {
 	Address() aptos.AccountAddress
 
-	DummyReceiver() module_dummy_receiver.DummyReceiver
+	DummyReceiver() module_dummy_receiver.DummyReceiverInterface
 }
 
 var _ CCIPDummyReceiver = CCIPDummyReceiverContract{}
@@ -21,14 +21,14 @@ var _ CCIPDummyReceiver = CCIPDummyReceiverContract{}
 type CCIPDummyReceiverContract struct {
 	address aptos.AccountAddress
 
-	dummyReceiver module_dummy_receiver.DummyReceiver
+	dummyReceiver module_dummy_receiver.DummyReceiverInterface
 }
 
 func (C CCIPDummyReceiverContract) Address() aptos.AccountAddress {
 	return C.address
 }
 
-func (C CCIPDummyReceiverContract) DummyReceiver() module_dummy_receiver.DummyReceiver {
+func (C CCIPDummyReceiverContract) DummyReceiver() module_dummy_receiver.DummyReceiverInterface {
 	return C.dummyReceiver
 }
 
@@ -59,7 +59,7 @@ func Bind(address aptos.AccountAddress, client aptos.AptosRpcClient) CCIPDummyRe
 func DeployToObject(
 	auth aptos.TransactionSigner,
 	client aptos.AptosRpcClient,
-	ccipAddress aptos.AccountAddress,
+	ccipAddress,
 	mcmsAddress aptos.AccountAddress,
 ) (aptos.AccountAddress, *api.PendingTransaction, CCIPDummyReceiver, error) {
 	namedAddresses := map[string]aptos.AccountAddress{
@@ -69,7 +69,7 @@ func DeployToObject(
 	}
 	address, tx, err := bind.DeployPackageToObject(auth, client, contracts.CCIPDummyReceiver, namedAddresses)
 	if err != nil {
-		return aptos.AccountAddress{}, nil, CCIPDummyReceiverContract{}, err
+		return aptos.AccountAddress{}, nil, nil, err
 	}
 	return address, tx, Bind(address, client), nil
 }

--- a/bindings/ccip_dummy_receiver/dummy_receiver/dummy_receiver.go
+++ b/bindings/ccip_dummy_receiver/dummy_receiver/dummy_receiver.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type DummyReceiver interface {
+type DummyReceiverInterface interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 
 	// Encoder returns the encoder implementation of this module.
@@ -35,7 +35,7 @@ type DummyReceiverEncoder interface {
 
 const FunctionInfo = `[{"package":"ccip_dummy_receiver","module":"dummy_receiver","name":"ccip_receive","parameters":[{"name":"_metadata","type":"address"}]}]`
 
-func NewDummyReceiver(address aptos.AccountAddress, client aptos.AptosRpcClient) DummyReceiver {
+func NewDummyReceiver(address aptos.AccountAddress, client aptos.AptosRpcClient) DummyReceiverInterface {
 	contract := bind.NewBoundContract(address, "ccip_dummy_receiver", "dummy_receiver", client)
 	return DummyReceiverContract{
 		BoundContract:        contract,
@@ -57,7 +57,7 @@ type DummyReceiverContract struct {
 	dummyReceiverEncoder
 }
 
-var _ DummyReceiver = DummyReceiverContract{}
+var _ DummyReceiverInterface = DummyReceiverContract{}
 
 func (c DummyReceiverContract) Encoder() DummyReceiverEncoder {
 	return c.dummyReceiverEncoder

--- a/bindings/ccip_router/ccip_router.go
+++ b/bindings/ccip_router/ccip_router.go
@@ -13,7 +13,7 @@ import (
 type CCIPRouter interface {
 	Address() aptos.AccountAddress
 
-	Router() module_router.Router
+	Router() module_router.RouterInterface
 }
 
 var _ CCIPRouter = CCIPRouterContract{}
@@ -21,14 +21,14 @@ var _ CCIPRouter = CCIPRouterContract{}
 type CCIPRouterContract struct {
 	address aptos.AccountAddress
 
-	router module_router.Router
+	router module_router.RouterInterface
 }
 
 func (C CCIPRouterContract) Address() aptos.AccountAddress {
 	return C.address
 }
 
-func (C CCIPRouterContract) Router() module_router.Router {
+func (C CCIPRouterContract) Router() module_router.RouterInterface {
 	return C.router
 }
 
@@ -40,12 +40,15 @@ var FunctionInfo = bind.MustParseFunctionInfo(
 	module_router.FunctionInfo,
 )
 
-func Compile(ccipAddress, mcmsAddress aptos.AccountAddress) (compile.CompiledPackage, error) {
+func Compile(ccipAddress, mcmsAddress aptos.AccountAddress, registerMCMSEntrypoints bool) (compile.CompiledPackage, error) {
 	namedAddresses := map[string]aptos.AccountAddress{
 		"ccip":                      ccipAddress,
 		"ccip_router":               ccipAddress,
 		"mcms":                      mcmsAddress,
 		"mcms_register_entrypoints": aptos.AccountZero,
+	}
+	if registerMCMSEntrypoints {
+		namedAddresses["mcms_register_entrypoints"] = ccipAddress
 	}
 	// Compile using CLI
 	return compile.CompilePackage(contracts.CCIPRouter, namedAddresses)
@@ -65,7 +68,6 @@ func DeployToExistingObject(
 	client aptos.AptosRpcClient,
 	objectAddress, ccipAddress, mcmsAddress aptos.AccountAddress,
 ) (*api.PendingTransaction, CCIPRouter, error) {
-	// no need for mcms addresses since the router does not interact with mcms directly.
 	namedAddresses := map[string]aptos.AccountAddress{
 		"ccip":                      ccipAddress,
 		"mcms":                      mcmsAddress,
@@ -73,7 +75,7 @@ func DeployToExistingObject(
 	}
 	tx, err := bind.UpgradePackageToObject(auth, client, contracts.CCIPRouter, namedAddresses, objectAddress)
 	if err != nil {
-		return nil, CCIPRouterContract{}, err
+		return nil, nil, err
 	}
 	return tx, Bind(objectAddress, client), nil
 }

--- a/bindings/ccip_router/router/router.go
+++ b/bindings/ccip_router/router/router.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type Router interface {
+type RouterInterface interface {
 	TypeAndVersion(opts *bind.CallOpts) (string, error)
 	GetStateAddress(opts *bind.CallOpts) (aptos.AccountAddress, error)
 	IsChainSupported(opts *bind.CallOpts, destChainSelector uint64) (bool, error)
@@ -47,7 +47,7 @@ type RouterEncoder interface {
 
 const FunctionInfo = `[{"package":"ccip_router","module":"router","name":"ccip_send","parameters":[{"name":"dest_chain_selector","type":"u64"},{"name":"receiver","type":"vector\u003cu8\u003e"},{"name":"data","type":"vector\u003cu8\u003e"},{"name":"token_addresses","type":"vector\u003caddress\u003e"},{"name":"token_amounts","type":"vector\u003cu64\u003e"},{"name":"token_store_addresses","type":"vector\u003caddress\u003e"},{"name":"fee_token","type":"address"},{"name":"fee_token_store","type":"address"},{"name":"extra_args","type":"vector\u003cu8\u003e"}]},{"package":"ccip_router","module":"router","name":"ccip_send_with_message_id","parameters":[{"name":"dest_chain_selector","type":"u64"},{"name":"receiver","type":"vector\u003cu8\u003e"},{"name":"data","type":"vector\u003cu8\u003e"},{"name":"token_addresses","type":"vector\u003caddress\u003e"},{"name":"token_amounts","type":"vector\u003cu64\u003e"},{"name":"token_store_addresses","type":"vector\u003caddress\u003e"},{"name":"fee_token","type":"address"},{"name":"fee_token_store","type":"address"},{"name":"extra_args","type":"vector\u003cu8\u003e"}]},{"package":"ccip_router","module":"router","name":"get_on_ramp_versions","parameters":[{"name":"dest_chain_selectors","type":"vector\u003cu64\u003e"}]},{"package":"ccip_router","module":"router","name":"mcms_entrypoint","parameters":[{"name":"_metadata","type":"address"}]},{"package":"ccip_router","module":"router","name":"set_on_ramp_versions","parameters":[{"name":"dest_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"on_ramp_versions","type":"vector\u003cvector\u003cu8\u003e\u003e"}]}]`
 
-func NewRouter(address aptos.AccountAddress, client aptos.AptosRpcClient) Router {
+func NewRouter(address aptos.AccountAddress, client aptos.AptosRpcClient) RouterInterface {
 	contract := bind.NewBoundContract(address, "ccip_router", "router", client)
 	return RouterContract{
 		BoundContract: contract,
@@ -73,7 +73,7 @@ type RouterContract struct {
 	routerEncoder
 }
 
-var _ Router = RouterContract{}
+var _ RouterInterface = RouterContract{}
 
 func (c RouterContract) Encoder() RouterEncoder {
 	return c.routerEncoder

--- a/bindings/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool.go
+++ b/bindings/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool.go
@@ -1,0 +1,83 @@
+package burn_mint_token_pool
+
+import (
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/api"
+
+	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	module_burn_mint_token_pool "github.com/smartcontractkit/chainlink-aptos/bindings/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool"
+	"github.com/smartcontractkit/chainlink-aptos/bindings/compile"
+	"github.com/smartcontractkit/chainlink-aptos/contracts"
+)
+
+type BurnMintTokenPool interface {
+	Address() aptos.AccountAddress
+
+	BurnMintTokenPool() module_burn_mint_token_pool.BurnMintTokenPoolInterface
+}
+
+var _ BurnMintTokenPool = BurnMintTokenPoolContract{}
+
+type BurnMintTokenPoolContract struct {
+	address aptos.AccountAddress
+
+	burnMintTokenPool module_burn_mint_token_pool.BurnMintTokenPoolInterface
+}
+
+func (c BurnMintTokenPoolContract) Address() aptos.AccountAddress {
+	return c.address
+}
+
+func (c BurnMintTokenPoolContract) BurnMintTokenPool() module_burn_mint_token_pool.BurnMintTokenPoolInterface {
+	return c.burnMintTokenPool
+}
+
+var FunctionInfo = bind.MustParseFunctionInfo(
+	module_burn_mint_token_pool.FunctionInfo,
+)
+
+func Compile(address, ccipAddress, mcmsAddress, ccipTokenPoolAddress, localTokenAddress aptos.AccountAddress, registerMCMSEntrypoints bool) (compile.CompiledPackage, error) {
+	namedAddresses := map[string]aptos.AccountAddress{
+		"burn_mint_token_pool":      address,
+		"ccip":                      ccipAddress,
+		"ccip_token_pool":           ccipTokenPoolAddress,
+		"local_token":               localTokenAddress,
+		"mcms":                      mcmsAddress,
+		"mcms_register_entrypoints": aptos.AccountZero,
+	}
+	if registerMCMSEntrypoints {
+		namedAddresses["mcms_register_entrypoints"] = ccipAddress
+	}
+	// Compile using CLI
+	return compile.CompilePackage(contracts.CCIPBurnMintPool, namedAddresses)
+}
+
+func Bind(address aptos.AccountAddress, client aptos.AptosRpcClient) BurnMintTokenPool {
+	return BurnMintTokenPoolContract{
+		address:           address,
+		burnMintTokenPool: module_burn_mint_token_pool.NewBurnMintTokenPool(address, client),
+	}
+}
+
+// DeployToObject deploys the BurnMintTokenPool to a new named object.
+func DeployToObject(
+	auth aptos.TransactionSigner,
+	client aptos.AptosRpcClient,
+	ccipAddress,
+	mcmsAddress,
+	ccipTokenPoolAddress,
+	localTokenAddress aptos.AccountAddress,
+) (aptos.AccountAddress, *api.PendingTransaction, BurnMintTokenPool, error) {
+	namedAddresses := map[string]aptos.AccountAddress{
+		"ccip":                      ccipAddress,
+		"ccip_token_pool":           ccipTokenPoolAddress,
+		"local_token":               localTokenAddress,
+		"mcms":                      mcmsAddress,
+		"mcms_register_entrypoints": aptos.AccountZero,
+	}
+	address, tx, err := bind.DeployPackageToObject(auth, client, contracts.CCIPBurnMintPool, namedAddresses)
+	if err != nil {
+		return aptos.AccountAddress{}, nil, nil, err
+	}
+	return address, tx, Bind(address, client), nil
+}

--- a/bindings/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool/burn_mint_token_pool.go
+++ b/bindings/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool/burn_mint_token_pool.go
@@ -1,0 +1,626 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package module_burn_mint_token_pool
+
+import (
+	"math/big"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/api"
+
+	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	"github.com/smartcontractkit/chainlink-aptos/relayer/codec"
+)
+
+var (
+	_ = aptos.AccountAddress{}
+	_ = api.PendingTransaction{}
+	_ = big.NewInt
+	_ = bind.NewBoundContract
+	_ = codec.DecodeAptosJsonValue
+)
+
+type BurnMintTokenPoolInterface interface {
+	TypeAndVersion(opts *bind.CallOpts) (string, error)
+	GetToken(opts *bind.CallOpts) (aptos.AccountAddress, error)
+	GetRouter(opts *bind.CallOpts) (aptos.AccountAddress, error)
+	GetTokenDecimals(opts *bind.CallOpts) (byte, error)
+	GetRemotePools(opts *bind.CallOpts, remoteChainSelector uint64) ([][]byte, error)
+	IsRemotePool(opts *bind.CallOpts, remoteChainSelector uint64, remotePoolAddress []byte) (bool, error)
+	GetRemoteToken(opts *bind.CallOpts, remoteChainSelector uint64) ([]byte, error)
+	IsSupportedChain(opts *bind.CallOpts, remoteChainSelector uint64) (bool, error)
+	GetSupportedChains(opts *bind.CallOpts) ([]uint64, error)
+	GetAllowlistEnabled(opts *bind.CallOpts) (bool, error)
+	GetAllowlist(opts *bind.CallOpts) ([]aptos.AccountAddress, error)
+	GetStoreAddress(opts *bind.CallOpts) (aptos.AccountAddress, error)
+	Owner(opts *bind.CallOpts) (aptos.AccountAddress, error)
+
+	AddRemotePool(opts *bind.TransactOpts, remoteChainSelector uint64, remotePoolAddress []byte) (*api.PendingTransaction, error)
+	RemoveRemotePool(opts *bind.TransactOpts, remoteChainSelector uint64, remotePoolAddress []byte) (*api.PendingTransaction, error)
+	ApplyChainUpdates(opts *bind.TransactOpts, remoteChainSelectorsToRemove []uint64, remoteChainSelectorsToAdd []uint64, remotePoolAddressesToAdd [][][]byte, remoteTokenAddressesToAdd [][]byte) (*api.PendingTransaction, error)
+	ApplyAllowlistUpdates(opts *bind.TransactOpts, removes []aptos.AccountAddress, adds []aptos.AccountAddress) (*api.PendingTransaction, error)
+	TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
+	AcceptOwnership(opts *bind.TransactOpts) (*api.PendingTransaction, error)
+
+	// Encoder returns the encoder implementation of this module.
+	Encoder() BurnMintTokenPoolEncoder
+}
+
+type BurnMintTokenPoolEncoder interface {
+	TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetToken() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetRouter() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetTokenDecimals() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetRemotePools(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	IsRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetRemoteToken(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	IsSupportedChain(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetSupportedChains() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetAllowlistEnabled() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetAllowlist() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetStoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Owner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AddRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	RemoveRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ApplyChainUpdates(remoteChainSelectorsToRemove []uint64, remoteChainSelectorsToAdd []uint64, remotePoolAddressesToAdd [][][]byte, remoteTokenAddressesToAdd [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ApplyAllowlistUpdates(removes []aptos.AccountAddress, adds []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	StoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AssertCanInitialize(callerAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+}
+
+const FunctionInfo = `[{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"accept_ownership","parameters":null},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"add_remote_pool","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"remote_pool_address","type":"vector\u003cu8\u003e"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"apply_allowlist_updates","parameters":[{"name":"removes","type":"vector\u003caddress\u003e"},{"name":"adds","type":"vector\u003caddress\u003e"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"apply_chain_updates","parameters":[{"name":"remote_chain_selectors_to_remove","type":"vector\u003cu64\u003e"},{"name":"remote_chain_selectors_to_add","type":"vector\u003cu64\u003e"},{"name":"remote_pool_addresses_to_add","type":"vector\u003cvector\u003cvector\u003cu8\u003e\u003e\u003e"},{"name":"remote_token_addresses_to_add","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"assert_can_initialize","parameters":[{"name":"caller_address","type":"address"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"remove_remote_pool","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"remote_pool_address","type":"vector\u003cu8\u003e"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"set_chain_rate_limiter_config","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"outbound_is_enabled","type":"bool"},{"name":"outbound_capacity","type":"u64"},{"name":"outbound_rate","type":"u64"},{"name":"inbound_is_enabled","type":"bool"},{"name":"inbound_capacity","type":"u64"},{"name":"inbound_rate","type":"u64"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"set_chain_rate_limiter_configs","parameters":[{"name":"remote_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"outbound_is_enableds","type":"vector\u003cbool\u003e"},{"name":"outbound_capacities","type":"vector\u003cu64\u003e"},{"name":"outbound_rates","type":"vector\u003cu64\u003e"},{"name":"inbound_is_enableds","type":"vector\u003cbool\u003e"},{"name":"inbound_capacities","type":"vector\u003cu64\u003e"},{"name":"inbound_rates","type":"vector\u003cu64\u003e"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"store_address","parameters":null},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"transfer_ownership","parameters":[{"name":"to","type":"address"}]}]`
+
+func NewBurnMintTokenPool(address aptos.AccountAddress, client aptos.AptosRpcClient) BurnMintTokenPoolInterface {
+	contract := bind.NewBoundContract(address, "burn_mint_token_pool", "burn_mint_token_pool", client)
+	return BurnMintTokenPoolContract{
+		BoundContract:            contract,
+		burnMintTokenPoolEncoder: burnMintTokenPoolEncoder{BoundContract: contract},
+	}
+}
+
+// Structs
+
+type BurnMintTokenPoolDeployment struct {
+}
+
+type BurnMintTokenPool struct {
+	StoreSignerAddress aptos.AccountAddress `move:"address"`
+}
+
+type RemoteChainConfig struct {
+	RemoteTokenAddress []byte   `move:"vector<u8>"`
+	RemotePools        [][]byte `move:"vector<vector<u8>>"`
+}
+
+type CallbackProof struct {
+}
+
+type BurnMintTokenPoolContract struct {
+	*bind.BoundContract
+	burnMintTokenPoolEncoder
+}
+
+var _ BurnMintTokenPoolInterface = BurnMintTokenPoolContract{}
+
+func (c BurnMintTokenPoolContract) Encoder() BurnMintTokenPoolEncoder {
+	return c.burnMintTokenPoolEncoder
+}
+
+// View Functions
+
+func (c BurnMintTokenPoolContract) TypeAndVersion(opts *bind.CallOpts) (string, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.TypeAndVersion()
+	if err != nil {
+		return *new(string), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(string), err
+	}
+
+	var (
+		r0 string
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(string), err
+	}
+	return r0, nil
+}
+
+func (c BurnMintTokenPoolContract) GetToken(opts *bind.CallOpts) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.GetToken()
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	var (
+		r0 aptos.AccountAddress
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+	return r0, nil
+}
+
+func (c BurnMintTokenPoolContract) GetRouter(opts *bind.CallOpts) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.GetRouter()
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	var (
+		r0 aptos.AccountAddress
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+	return r0, nil
+}
+
+func (c BurnMintTokenPoolContract) GetTokenDecimals(opts *bind.CallOpts) (byte, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.GetTokenDecimals()
+	if err != nil {
+		return *new(byte), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(byte), err
+	}
+
+	var (
+		r0 byte
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(byte), err
+	}
+	return r0, nil
+}
+
+func (c BurnMintTokenPoolContract) GetRemotePools(opts *bind.CallOpts, remoteChainSelector uint64) ([][]byte, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.GetRemotePools(remoteChainSelector)
+	if err != nil {
+		return *new([][]byte), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new([][]byte), err
+	}
+
+	var (
+		r0 [][]byte
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new([][]byte), err
+	}
+	return r0, nil
+}
+
+func (c BurnMintTokenPoolContract) IsRemotePool(opts *bind.CallOpts, remoteChainSelector uint64, remotePoolAddress []byte) (bool, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.IsRemotePool(remoteChainSelector, remotePoolAddress)
+	if err != nil {
+		return *new(bool), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(bool), err
+	}
+
+	var (
+		r0 bool
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(bool), err
+	}
+	return r0, nil
+}
+
+func (c BurnMintTokenPoolContract) GetRemoteToken(opts *bind.CallOpts, remoteChainSelector uint64) ([]byte, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.GetRemoteToken(remoteChainSelector)
+	if err != nil {
+		return *new([]byte), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new([]byte), err
+	}
+
+	var (
+		r0 []byte
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new([]byte), err
+	}
+	return r0, nil
+}
+
+func (c BurnMintTokenPoolContract) IsSupportedChain(opts *bind.CallOpts, remoteChainSelector uint64) (bool, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.IsSupportedChain(remoteChainSelector)
+	if err != nil {
+		return *new(bool), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(bool), err
+	}
+
+	var (
+		r0 bool
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(bool), err
+	}
+	return r0, nil
+}
+
+func (c BurnMintTokenPoolContract) GetSupportedChains(opts *bind.CallOpts) ([]uint64, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.GetSupportedChains()
+	if err != nil {
+		return *new([]uint64), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new([]uint64), err
+	}
+
+	var (
+		r0 []uint64
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new([]uint64), err
+	}
+	return r0, nil
+}
+
+func (c BurnMintTokenPoolContract) GetAllowlistEnabled(opts *bind.CallOpts) (bool, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.GetAllowlistEnabled()
+	if err != nil {
+		return *new(bool), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(bool), err
+	}
+
+	var (
+		r0 bool
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(bool), err
+	}
+	return r0, nil
+}
+
+func (c BurnMintTokenPoolContract) GetAllowlist(opts *bind.CallOpts) ([]aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.GetAllowlist()
+	if err != nil {
+		return *new([]aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new([]aptos.AccountAddress), err
+	}
+
+	var (
+		r0 []aptos.AccountAddress
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new([]aptos.AccountAddress), err
+	}
+	return r0, nil
+}
+
+func (c BurnMintTokenPoolContract) GetStoreAddress(opts *bind.CallOpts) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.GetStoreAddress()
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	var (
+		r0 aptos.AccountAddress
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+	return r0, nil
+}
+
+func (c BurnMintTokenPoolContract) Owner(opts *bind.CallOpts) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.Owner()
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	var (
+		r0 aptos.AccountAddress
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+	return r0, nil
+}
+
+// Entry Functions
+
+func (c BurnMintTokenPoolContract) AddRemotePool(opts *bind.TransactOpts, remoteChainSelector uint64, remotePoolAddress []byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.AddRemotePool(remoteChainSelector, remotePoolAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c BurnMintTokenPoolContract) RemoveRemotePool(opts *bind.TransactOpts, remoteChainSelector uint64, remotePoolAddress []byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.RemoveRemotePool(remoteChainSelector, remotePoolAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c BurnMintTokenPoolContract) ApplyChainUpdates(opts *bind.TransactOpts, remoteChainSelectorsToRemove []uint64, remoteChainSelectorsToAdd []uint64, remotePoolAddressesToAdd [][][]byte, remoteTokenAddressesToAdd [][]byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.ApplyChainUpdates(remoteChainSelectorsToRemove, remoteChainSelectorsToAdd, remotePoolAddressesToAdd, remoteTokenAddressesToAdd)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c BurnMintTokenPoolContract) ApplyAllowlistUpdates(opts *bind.TransactOpts, removes []aptos.AccountAddress, adds []aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.ApplyAllowlistUpdates(removes, adds)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c BurnMintTokenPoolContract) TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.TransferOwnership(to)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c BurnMintTokenPoolContract) AcceptOwnership(opts *bind.TransactOpts) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.AcceptOwnership()
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+// Encoder
+type burnMintTokenPoolEncoder struct {
+	*bind.BoundContract
+}
+
+func (c burnMintTokenPoolEncoder) TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
+}
+
+func (c burnMintTokenPoolEncoder) GetToken() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_token", nil, []string{}, []any{})
+}
+
+func (c burnMintTokenPoolEncoder) GetRouter() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_router", nil, []string{}, []any{})
+}
+
+func (c burnMintTokenPoolEncoder) GetTokenDecimals() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_token_decimals", nil, []string{}, []any{})
+}
+
+func (c burnMintTokenPoolEncoder) GetRemotePools(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_remote_pools", nil, []string{
+		"u64",
+	}, []any{
+		remoteChainSelector,
+	})
+}
+
+func (c burnMintTokenPoolEncoder) IsRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("is_remote_pool", nil, []string{
+		"u64",
+		"vector<u8>",
+	}, []any{
+		remoteChainSelector,
+		remotePoolAddress,
+	})
+}
+
+func (c burnMintTokenPoolEncoder) GetRemoteToken(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_remote_token", nil, []string{
+		"u64",
+	}, []any{
+		remoteChainSelector,
+	})
+}
+
+func (c burnMintTokenPoolEncoder) IsSupportedChain(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("is_supported_chain", nil, []string{
+		"u64",
+	}, []any{
+		remoteChainSelector,
+	})
+}
+
+func (c burnMintTokenPoolEncoder) GetSupportedChains() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_supported_chains", nil, []string{}, []any{})
+}
+
+func (c burnMintTokenPoolEncoder) GetAllowlistEnabled() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_allowlist_enabled", nil, []string{}, []any{})
+}
+
+func (c burnMintTokenPoolEncoder) GetAllowlist() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_allowlist", nil, []string{}, []any{})
+}
+
+func (c burnMintTokenPoolEncoder) GetStoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_store_address", nil, []string{}, []any{})
+}
+
+func (c burnMintTokenPoolEncoder) Owner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("owner", nil, []string{}, []any{})
+}
+
+func (c burnMintTokenPoolEncoder) AddRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("add_remote_pool", nil, []string{
+		"u64",
+		"vector<u8>",
+	}, []any{
+		remoteChainSelector,
+		remotePoolAddress,
+	})
+}
+
+func (c burnMintTokenPoolEncoder) RemoveRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("remove_remote_pool", nil, []string{
+		"u64",
+		"vector<u8>",
+	}, []any{
+		remoteChainSelector,
+		remotePoolAddress,
+	})
+}
+
+func (c burnMintTokenPoolEncoder) ApplyChainUpdates(remoteChainSelectorsToRemove []uint64, remoteChainSelectorsToAdd []uint64, remotePoolAddressesToAdd [][][]byte, remoteTokenAddressesToAdd [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("apply_chain_updates", nil, []string{
+		"vector<u64>",
+		"vector<u64>",
+		"vector<vector<vector<u8>>>",
+		"vector<vector<u8>>",
+	}, []any{
+		remoteChainSelectorsToRemove,
+		remoteChainSelectorsToAdd,
+		remotePoolAddressesToAdd,
+		remoteTokenAddressesToAdd,
+	})
+}
+
+func (c burnMintTokenPoolEncoder) ApplyAllowlistUpdates(removes []aptos.AccountAddress, adds []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("apply_allowlist_updates", nil, []string{
+		"vector<address>",
+		"vector<address>",
+	}, []any{
+		removes,
+		adds,
+	})
+}
+
+func (c burnMintTokenPoolEncoder) TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("transfer_ownership", nil, []string{
+		"address",
+	}, []any{
+		to,
+	})
+}
+
+func (c burnMintTokenPoolEncoder) AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("accept_ownership", nil, []string{}, []any{})
+}
+
+func (c burnMintTokenPoolEncoder) SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("set_chain_rate_limiter_configs", nil, []string{
+		"vector<u64>",
+		"vector<bool>",
+		"vector<u64>",
+		"vector<u64>",
+		"vector<bool>",
+		"vector<u64>",
+		"vector<u64>",
+	}, []any{
+		remoteChainSelectors,
+		outboundIsEnableds,
+		outboundCapacities,
+		outboundRates,
+		inboundIsEnableds,
+		inboundCapacities,
+		inboundRates,
+	})
+}
+
+func (c burnMintTokenPoolEncoder) SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("set_chain_rate_limiter_config", nil, []string{
+		"u64",
+		"bool",
+		"u64",
+		"u64",
+		"bool",
+		"u64",
+		"u64",
+	}, []any{
+		remoteChainSelector,
+		outboundIsEnabled,
+		outboundCapacity,
+		outboundRate,
+		inboundIsEnabled,
+		inboundCapacity,
+		inboundRate,
+	})
+}
+
+func (c burnMintTokenPoolEncoder) StoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("store_address", nil, []string{}, []any{})
+}
+
+func (c burnMintTokenPoolEncoder) AssertCanInitialize(callerAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("assert_can_initialize", nil, []string{
+		"address",
+	}, []any{
+		callerAddress,
+	})
+}

--- a/bindings/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool/burn_mint_token_pool.go
+++ b/bindings/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool/burn_mint_token_pool.go
@@ -71,9 +71,10 @@ type BurnMintTokenPoolEncoder interface {
 	SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	StoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	AssertCanInitialize(callerAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	MCMSEntrypoint(Metadata aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
-const FunctionInfo = `[{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"accept_ownership","parameters":null},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"add_remote_pool","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"remote_pool_address","type":"vector\u003cu8\u003e"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"apply_allowlist_updates","parameters":[{"name":"removes","type":"vector\u003caddress\u003e"},{"name":"adds","type":"vector\u003caddress\u003e"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"apply_chain_updates","parameters":[{"name":"remote_chain_selectors_to_remove","type":"vector\u003cu64\u003e"},{"name":"remote_chain_selectors_to_add","type":"vector\u003cu64\u003e"},{"name":"remote_pool_addresses_to_add","type":"vector\u003cvector\u003cvector\u003cu8\u003e\u003e\u003e"},{"name":"remote_token_addresses_to_add","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"assert_can_initialize","parameters":[{"name":"caller_address","type":"address"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"remove_remote_pool","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"remote_pool_address","type":"vector\u003cu8\u003e"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"set_chain_rate_limiter_config","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"outbound_is_enabled","type":"bool"},{"name":"outbound_capacity","type":"u64"},{"name":"outbound_rate","type":"u64"},{"name":"inbound_is_enabled","type":"bool"},{"name":"inbound_capacity","type":"u64"},{"name":"inbound_rate","type":"u64"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"set_chain_rate_limiter_configs","parameters":[{"name":"remote_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"outbound_is_enableds","type":"vector\u003cbool\u003e"},{"name":"outbound_capacities","type":"vector\u003cu64\u003e"},{"name":"outbound_rates","type":"vector\u003cu64\u003e"},{"name":"inbound_is_enableds","type":"vector\u003cbool\u003e"},{"name":"inbound_capacities","type":"vector\u003cu64\u003e"},{"name":"inbound_rates","type":"vector\u003cu64\u003e"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"store_address","parameters":null},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"transfer_ownership","parameters":[{"name":"to","type":"address"}]}]`
+const FunctionInfo = `[{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"accept_ownership","parameters":null},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"add_remote_pool","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"remote_pool_address","type":"vector\u003cu8\u003e"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"apply_allowlist_updates","parameters":[{"name":"removes","type":"vector\u003caddress\u003e"},{"name":"adds","type":"vector\u003caddress\u003e"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"apply_chain_updates","parameters":[{"name":"remote_chain_selectors_to_remove","type":"vector\u003cu64\u003e"},{"name":"remote_chain_selectors_to_add","type":"vector\u003cu64\u003e"},{"name":"remote_pool_addresses_to_add","type":"vector\u003cvector\u003cvector\u003cu8\u003e\u003e\u003e"},{"name":"remote_token_addresses_to_add","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"assert_can_initialize","parameters":[{"name":"caller_address","type":"address"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"mcms_entrypoint","parameters":[{"name":"_metadata","type":"address"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"remove_remote_pool","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"remote_pool_address","type":"vector\u003cu8\u003e"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"set_chain_rate_limiter_config","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"outbound_is_enabled","type":"bool"},{"name":"outbound_capacity","type":"u64"},{"name":"outbound_rate","type":"u64"},{"name":"inbound_is_enabled","type":"bool"},{"name":"inbound_capacity","type":"u64"},{"name":"inbound_rate","type":"u64"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"set_chain_rate_limiter_configs","parameters":[{"name":"remote_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"outbound_is_enableds","type":"vector\u003cbool\u003e"},{"name":"outbound_capacities","type":"vector\u003cu64\u003e"},{"name":"outbound_rates","type":"vector\u003cu64\u003e"},{"name":"inbound_is_enableds","type":"vector\u003cbool\u003e"},{"name":"inbound_capacities","type":"vector\u003cu64\u003e"},{"name":"inbound_rates","type":"vector\u003cu64\u003e"}]},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"store_address","parameters":null},{"package":"burn_mint_token_pool","module":"burn_mint_token_pool","name":"transfer_ownership","parameters":[{"name":"to","type":"address"}]}]`
 
 func NewBurnMintTokenPool(address aptos.AccountAddress, client aptos.AptosRpcClient) BurnMintTokenPoolInterface {
 	contract := bind.NewBoundContract(address, "burn_mint_token_pool", "burn_mint_token_pool", client)
@@ -98,6 +99,9 @@ type RemoteChainConfig struct {
 }
 
 type CallbackProof struct {
+}
+
+type McmsCallback struct {
 }
 
 type BurnMintTokenPoolContract struct {
@@ -622,5 +626,13 @@ func (c burnMintTokenPoolEncoder) AssertCanInitialize(callerAddress aptos.Accoun
 		"address",
 	}, []any{
 		callerAddress,
+	})
+}
+
+func (c burnMintTokenPoolEncoder) MCMSEntrypoint(Metadata aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("mcms_entrypoint", nil, []string{
+		"address",
+	}, []any{
+		Metadata,
 	})
 }

--- a/bindings/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool_test.go
+++ b/bindings/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool_test.go
@@ -1,4 +1,4 @@
-package ccip_router
+package burn_mint_token_pool
 
 import (
 	"testing"
@@ -9,7 +9,7 @@ import (
 
 func TestCompile(t *testing.T) {
 	t.Parallel()
-	output, err := Compile(aptos.AccountOne, aptos.AccountOne, false)
+	output, err := Compile(aptos.AccountOne, aptos.AccountOne, aptos.AccountOne, aptos.AccountOne, aptos.AccountOne, false)
 	require.NoError(t, err)
 	require.NotZero(t, output.Metadata, "Compilation resulted in no metadata")
 	require.NotZero(t, output.Bytecode, "Compilation resulted in no bytecode")

--- a/bindings/ccip_token_pools/lock_release_token_pool/lock_release_token_pool.go
+++ b/bindings/ccip_token_pools/lock_release_token_pool/lock_release_token_pool.go
@@ -1,0 +1,83 @@
+package lock_release_token_pool
+
+import (
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/api"
+
+	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	module_lock_release_token_pool "github.com/smartcontractkit/chainlink-aptos/bindings/ccip_token_pools/lock_release_token_pool/lock_release_token_pool"
+	"github.com/smartcontractkit/chainlink-aptos/bindings/compile"
+	"github.com/smartcontractkit/chainlink-aptos/contracts"
+)
+
+type LockReleaseTokenPool interface {
+	Address() aptos.AccountAddress
+
+	LockReleaseTokenPool() module_lock_release_token_pool.LockReleaseTokenPoolInterface
+}
+
+var _ LockReleaseTokenPool = LockReleaseTokenPoolContract{}
+
+type LockReleaseTokenPoolContract struct {
+	address aptos.AccountAddress
+
+	lockReleaseTokenPool module_lock_release_token_pool.LockReleaseTokenPoolInterface
+}
+
+func (c LockReleaseTokenPoolContract) Address() aptos.AccountAddress {
+	return c.address
+}
+
+func (c LockReleaseTokenPoolContract) LockReleaseTokenPool() module_lock_release_token_pool.LockReleaseTokenPoolInterface {
+	return c.lockReleaseTokenPool
+}
+
+var FunctionInfo = bind.MustParseFunctionInfo(
+	module_lock_release_token_pool.FunctionInfo,
+)
+
+func Compile(address, ccipAddress, mcmsAddress, ccipTokenPoolAddress, localTokenAddress aptos.AccountAddress, registerMCMSEntrypoints bool) (compile.CompiledPackage, error) {
+	namedAddresses := map[string]aptos.AccountAddress{
+		"lock_release_token_pool":   address,
+		"ccip":                      ccipAddress,
+		"ccip_token_pool":           ccipTokenPoolAddress,
+		"local_token":               localTokenAddress,
+		"mcms":                      mcmsAddress,
+		"mcms_register_entrypoints": aptos.AccountZero,
+	}
+	if registerMCMSEntrypoints {
+		namedAddresses["mcms_register_entrypoints"] = ccipAddress
+	}
+	// Compile using CLI
+	return compile.CompilePackage(contracts.CCIPLockReleasePool, namedAddresses)
+}
+
+func Bind(address aptos.AccountAddress, client aptos.AptosRpcClient) LockReleaseTokenPool {
+	return LockReleaseTokenPoolContract{
+		address:              address,
+		lockReleaseTokenPool: module_lock_release_token_pool.NewLockReleaseTokenPool(address, client),
+	}
+}
+
+// DeployToObject deploys the LockReleaseTokenPool to a new named object.
+func DeployToObject(
+	auth aptos.TransactionSigner,
+	client aptos.AptosRpcClient,
+	ccipAddress,
+	mcmsAddress,
+	ccipTokenPoolAddress,
+	localTokenAddress aptos.AccountAddress,
+) (aptos.AccountAddress, *api.PendingTransaction, LockReleaseTokenPool, error) {
+	namedAddresses := map[string]aptos.AccountAddress{
+		"ccip":                      ccipAddress,
+		"ccip_token_pool":           ccipTokenPoolAddress,
+		"local_token":               localTokenAddress,
+		"mcms":                      mcmsAddress,
+		"mcms_register_entrypoints": aptos.AccountZero,
+	}
+	address, tx, err := bind.DeployPackageToObject(auth, client, contracts.CCIPLockReleasePool, namedAddresses)
+	if err != nil {
+		return aptos.AccountAddress{}, nil, nil, err
+	}
+	return address, tx, Bind(address, client), nil
+}

--- a/bindings/ccip_token_pools/lock_release_token_pool/lock_release_token_pool/lock_release_token_pool.go
+++ b/bindings/ccip_token_pools/lock_release_token_pool/lock_release_token_pool/lock_release_token_pool.go
@@ -72,9 +72,10 @@ type LockReleaseTokenPoolEncoder interface {
 	SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	StoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	AssertCanInitialize(callerAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	MCMSEntrypoint(Metadata aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
-const FunctionInfo = `[{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"accept_ownership","parameters":null},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"add_remote_pool","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"remote_pool_address","type":"vector\u003cu8\u003e"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"apply_allowlist_updates","parameters":[{"name":"removes","type":"vector\u003caddress\u003e"},{"name":"adds","type":"vector\u003caddress\u003e"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"apply_chain_updates","parameters":[{"name":"remote_chain_selectors_to_remove","type":"vector\u003cu64\u003e"},{"name":"remote_chain_selectors_to_add","type":"vector\u003cu64\u003e"},{"name":"remote_pool_addresses_to_add","type":"vector\u003cvector\u003cvector\u003cu8\u003e\u003e\u003e"},{"name":"remote_token_addresses_to_add","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"assert_can_initialize","parameters":[{"name":"caller_address","type":"address"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"initialize","parameters":null},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"remove_remote_pool","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"remote_pool_address","type":"vector\u003cu8\u003e"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"set_chain_rate_limiter_config","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"outbound_is_enabled","type":"bool"},{"name":"outbound_capacity","type":"u64"},{"name":"outbound_rate","type":"u64"},{"name":"inbound_is_enabled","type":"bool"},{"name":"inbound_capacity","type":"u64"},{"name":"inbound_rate","type":"u64"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"set_chain_rate_limiter_configs","parameters":[{"name":"remote_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"outbound_is_enableds","type":"vector\u003cbool\u003e"},{"name":"outbound_capacities","type":"vector\u003cu64\u003e"},{"name":"outbound_rates","type":"vector\u003cu64\u003e"},{"name":"inbound_is_enableds","type":"vector\u003cbool\u003e"},{"name":"inbound_capacities","type":"vector\u003cu64\u003e"},{"name":"inbound_rates","type":"vector\u003cu64\u003e"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"store_address","parameters":null},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"transfer_ownership","parameters":[{"name":"to","type":"address"}]}]`
+const FunctionInfo = `[{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"accept_ownership","parameters":null},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"add_remote_pool","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"remote_pool_address","type":"vector\u003cu8\u003e"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"apply_allowlist_updates","parameters":[{"name":"removes","type":"vector\u003caddress\u003e"},{"name":"adds","type":"vector\u003caddress\u003e"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"apply_chain_updates","parameters":[{"name":"remote_chain_selectors_to_remove","type":"vector\u003cu64\u003e"},{"name":"remote_chain_selectors_to_add","type":"vector\u003cu64\u003e"},{"name":"remote_pool_addresses_to_add","type":"vector\u003cvector\u003cvector\u003cu8\u003e\u003e\u003e"},{"name":"remote_token_addresses_to_add","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"assert_can_initialize","parameters":[{"name":"caller_address","type":"address"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"initialize","parameters":null},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"mcms_entrypoint","parameters":[{"name":"_metadata","type":"address"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"remove_remote_pool","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"remote_pool_address","type":"vector\u003cu8\u003e"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"set_chain_rate_limiter_config","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"outbound_is_enabled","type":"bool"},{"name":"outbound_capacity","type":"u64"},{"name":"outbound_rate","type":"u64"},{"name":"inbound_is_enabled","type":"bool"},{"name":"inbound_capacity","type":"u64"},{"name":"inbound_rate","type":"u64"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"set_chain_rate_limiter_configs","parameters":[{"name":"remote_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"outbound_is_enableds","type":"vector\u003cbool\u003e"},{"name":"outbound_capacities","type":"vector\u003cu64\u003e"},{"name":"outbound_rates","type":"vector\u003cu64\u003e"},{"name":"inbound_is_enableds","type":"vector\u003cbool\u003e"},{"name":"inbound_capacities","type":"vector\u003cu64\u003e"},{"name":"inbound_rates","type":"vector\u003cu64\u003e"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"store_address","parameters":null},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"transfer_ownership","parameters":[{"name":"to","type":"address"}]}]`
 
 func NewLockReleaseTokenPool(address aptos.AccountAddress, client aptos.AptosRpcClient) LockReleaseTokenPoolInterface {
 	contract := bind.NewBoundContract(address, "lock_release_token_pool", "lock_release_token_pool", client)
@@ -99,6 +100,9 @@ type RemoteChainConfig struct {
 }
 
 type CallbackProof struct {
+}
+
+type McmsCallback struct {
 }
 
 type LockReleaseTokenPoolContract struct {
@@ -627,5 +631,13 @@ func (c lockReleaseTokenPoolEncoder) AssertCanInitialize(callerAddress aptos.Acc
 		"address",
 	}, []any{
 		callerAddress,
+	})
+}
+
+func (c lockReleaseTokenPoolEncoder) MCMSEntrypoint(Metadata aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("mcms_entrypoint", nil, []string{
+		"address",
+	}, []any{
+		Metadata,
 	})
 }

--- a/bindings/ccip_token_pools/lock_release_token_pool/lock_release_token_pool/lock_release_token_pool.go
+++ b/bindings/ccip_token_pools/lock_release_token_pool/lock_release_token_pool/lock_release_token_pool.go
@@ -1,0 +1,631 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package module_lock_release_token_pool
+
+import (
+	"math/big"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/api"
+
+	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	"github.com/smartcontractkit/chainlink-aptos/relayer/codec"
+)
+
+var (
+	_ = aptos.AccountAddress{}
+	_ = api.PendingTransaction{}
+	_ = big.NewInt
+	_ = bind.NewBoundContract
+	_ = codec.DecodeAptosJsonValue
+)
+
+type LockReleaseTokenPoolInterface interface {
+	TypeAndVersion(opts *bind.CallOpts) (string, error)
+	GetToken(opts *bind.CallOpts) (aptos.AccountAddress, error)
+	GetRouter(opts *bind.CallOpts) (aptos.AccountAddress, error)
+	GetTokenDecimals(opts *bind.CallOpts) (byte, error)
+	GetRemotePools(opts *bind.CallOpts, remoteChainSelector uint64) ([][]byte, error)
+	IsRemotePool(opts *bind.CallOpts, remoteChainSelector uint64, remotePoolAddress []byte) (bool, error)
+	GetRemoteToken(opts *bind.CallOpts, remoteChainSelector uint64) ([]byte, error)
+	IsSupportedChain(opts *bind.CallOpts, remoteChainSelector uint64) (bool, error)
+	GetSupportedChains(opts *bind.CallOpts) ([]uint64, error)
+	GetAllowlistEnabled(opts *bind.CallOpts) (bool, error)
+	GetAllowlist(opts *bind.CallOpts) ([]aptos.AccountAddress, error)
+	GetStoreAddress(opts *bind.CallOpts) (aptos.AccountAddress, error)
+	Owner(opts *bind.CallOpts) (aptos.AccountAddress, error)
+
+	AddRemotePool(opts *bind.TransactOpts, remoteChainSelector uint64, remotePoolAddress []byte) (*api.PendingTransaction, error)
+	RemoveRemotePool(opts *bind.TransactOpts, remoteChainSelector uint64, remotePoolAddress []byte) (*api.PendingTransaction, error)
+	ApplyChainUpdates(opts *bind.TransactOpts, remoteChainSelectorsToRemove []uint64, remoteChainSelectorsToAdd []uint64, remotePoolAddressesToAdd [][][]byte, remoteTokenAddressesToAdd [][]byte) (*api.PendingTransaction, error)
+	ApplyAllowlistUpdates(opts *bind.TransactOpts, removes []aptos.AccountAddress, adds []aptos.AccountAddress) (*api.PendingTransaction, error)
+	TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
+	AcceptOwnership(opts *bind.TransactOpts) (*api.PendingTransaction, error)
+
+	// Encoder returns the encoder implementation of this module.
+	Encoder() LockReleaseTokenPoolEncoder
+}
+
+type LockReleaseTokenPoolEncoder interface {
+	TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetToken() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetRouter() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetTokenDecimals() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetRemotePools(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	IsRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetRemoteToken(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	IsSupportedChain(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetSupportedChains() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetAllowlistEnabled() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetAllowlist() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetStoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Owner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AddRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	RemoveRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ApplyChainUpdates(remoteChainSelectorsToRemove []uint64, remoteChainSelectorsToAdd []uint64, remotePoolAddressesToAdd [][][]byte, remoteTokenAddressesToAdd [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ApplyAllowlistUpdates(removes []aptos.AccountAddress, adds []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Initialize() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	StoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AssertCanInitialize(callerAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+}
+
+const FunctionInfo = `[{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"accept_ownership","parameters":null},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"add_remote_pool","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"remote_pool_address","type":"vector\u003cu8\u003e"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"apply_allowlist_updates","parameters":[{"name":"removes","type":"vector\u003caddress\u003e"},{"name":"adds","type":"vector\u003caddress\u003e"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"apply_chain_updates","parameters":[{"name":"remote_chain_selectors_to_remove","type":"vector\u003cu64\u003e"},{"name":"remote_chain_selectors_to_add","type":"vector\u003cu64\u003e"},{"name":"remote_pool_addresses_to_add","type":"vector\u003cvector\u003cvector\u003cu8\u003e\u003e\u003e"},{"name":"remote_token_addresses_to_add","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"assert_can_initialize","parameters":[{"name":"caller_address","type":"address"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"initialize","parameters":null},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"remove_remote_pool","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"remote_pool_address","type":"vector\u003cu8\u003e"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"set_chain_rate_limiter_config","parameters":[{"name":"remote_chain_selector","type":"u64"},{"name":"outbound_is_enabled","type":"bool"},{"name":"outbound_capacity","type":"u64"},{"name":"outbound_rate","type":"u64"},{"name":"inbound_is_enabled","type":"bool"},{"name":"inbound_capacity","type":"u64"},{"name":"inbound_rate","type":"u64"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"set_chain_rate_limiter_configs","parameters":[{"name":"remote_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"outbound_is_enableds","type":"vector\u003cbool\u003e"},{"name":"outbound_capacities","type":"vector\u003cu64\u003e"},{"name":"outbound_rates","type":"vector\u003cu64\u003e"},{"name":"inbound_is_enableds","type":"vector\u003cbool\u003e"},{"name":"inbound_capacities","type":"vector\u003cu64\u003e"},{"name":"inbound_rates","type":"vector\u003cu64\u003e"}]},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"store_address","parameters":null},{"package":"lock_release_token_pool","module":"lock_release_token_pool","name":"transfer_ownership","parameters":[{"name":"to","type":"address"}]}]`
+
+func NewLockReleaseTokenPool(address aptos.AccountAddress, client aptos.AptosRpcClient) LockReleaseTokenPoolInterface {
+	contract := bind.NewBoundContract(address, "lock_release_token_pool", "lock_release_token_pool", client)
+	return LockReleaseTokenPoolContract{
+		BoundContract:               contract,
+		lockReleaseTokenPoolEncoder: lockReleaseTokenPoolEncoder{BoundContract: contract},
+	}
+}
+
+// Structs
+
+type LockReleaseTokenPoolDeployment struct {
+}
+
+type LockReleaseTokenPool struct {
+	StoreSignerAddress aptos.AccountAddress `move:"address"`
+}
+
+type RemoteChainConfig struct {
+	RemoteTokenAddress []byte   `move:"vector<u8>"`
+	RemotePools        [][]byte `move:"vector<vector<u8>>"`
+}
+
+type CallbackProof struct {
+}
+
+type LockReleaseTokenPoolContract struct {
+	*bind.BoundContract
+	lockReleaseTokenPoolEncoder
+}
+
+var _ LockReleaseTokenPoolInterface = LockReleaseTokenPoolContract{}
+
+func (c LockReleaseTokenPoolContract) Encoder() LockReleaseTokenPoolEncoder {
+	return c.lockReleaseTokenPoolEncoder
+}
+
+// View Functions
+
+func (c LockReleaseTokenPoolContract) TypeAndVersion(opts *bind.CallOpts) (string, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.TypeAndVersion()
+	if err != nil {
+		return *new(string), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(string), err
+	}
+
+	var (
+		r0 string
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(string), err
+	}
+	return r0, nil
+}
+
+func (c LockReleaseTokenPoolContract) GetToken(opts *bind.CallOpts) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.GetToken()
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	var (
+		r0 aptos.AccountAddress
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+	return r0, nil
+}
+
+func (c LockReleaseTokenPoolContract) GetRouter(opts *bind.CallOpts) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.GetRouter()
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	var (
+		r0 aptos.AccountAddress
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+	return r0, nil
+}
+
+func (c LockReleaseTokenPoolContract) GetTokenDecimals(opts *bind.CallOpts) (byte, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.GetTokenDecimals()
+	if err != nil {
+		return *new(byte), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(byte), err
+	}
+
+	var (
+		r0 byte
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(byte), err
+	}
+	return r0, nil
+}
+
+func (c LockReleaseTokenPoolContract) GetRemotePools(opts *bind.CallOpts, remoteChainSelector uint64) ([][]byte, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.GetRemotePools(remoteChainSelector)
+	if err != nil {
+		return *new([][]byte), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new([][]byte), err
+	}
+
+	var (
+		r0 [][]byte
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new([][]byte), err
+	}
+	return r0, nil
+}
+
+func (c LockReleaseTokenPoolContract) IsRemotePool(opts *bind.CallOpts, remoteChainSelector uint64, remotePoolAddress []byte) (bool, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.IsRemotePool(remoteChainSelector, remotePoolAddress)
+	if err != nil {
+		return *new(bool), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(bool), err
+	}
+
+	var (
+		r0 bool
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(bool), err
+	}
+	return r0, nil
+}
+
+func (c LockReleaseTokenPoolContract) GetRemoteToken(opts *bind.CallOpts, remoteChainSelector uint64) ([]byte, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.GetRemoteToken(remoteChainSelector)
+	if err != nil {
+		return *new([]byte), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new([]byte), err
+	}
+
+	var (
+		r0 []byte
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new([]byte), err
+	}
+	return r0, nil
+}
+
+func (c LockReleaseTokenPoolContract) IsSupportedChain(opts *bind.CallOpts, remoteChainSelector uint64) (bool, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.IsSupportedChain(remoteChainSelector)
+	if err != nil {
+		return *new(bool), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(bool), err
+	}
+
+	var (
+		r0 bool
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(bool), err
+	}
+	return r0, nil
+}
+
+func (c LockReleaseTokenPoolContract) GetSupportedChains(opts *bind.CallOpts) ([]uint64, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.GetSupportedChains()
+	if err != nil {
+		return *new([]uint64), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new([]uint64), err
+	}
+
+	var (
+		r0 []uint64
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new([]uint64), err
+	}
+	return r0, nil
+}
+
+func (c LockReleaseTokenPoolContract) GetAllowlistEnabled(opts *bind.CallOpts) (bool, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.GetAllowlistEnabled()
+	if err != nil {
+		return *new(bool), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(bool), err
+	}
+
+	var (
+		r0 bool
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(bool), err
+	}
+	return r0, nil
+}
+
+func (c LockReleaseTokenPoolContract) GetAllowlist(opts *bind.CallOpts) ([]aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.GetAllowlist()
+	if err != nil {
+		return *new([]aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new([]aptos.AccountAddress), err
+	}
+
+	var (
+		r0 []aptos.AccountAddress
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new([]aptos.AccountAddress), err
+	}
+	return r0, nil
+}
+
+func (c LockReleaseTokenPoolContract) GetStoreAddress(opts *bind.CallOpts) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.GetStoreAddress()
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	var (
+		r0 aptos.AccountAddress
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+	return r0, nil
+}
+
+func (c LockReleaseTokenPoolContract) Owner(opts *bind.CallOpts) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.Owner()
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	var (
+		r0 aptos.AccountAddress
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+	return r0, nil
+}
+
+// Entry Functions
+
+func (c LockReleaseTokenPoolContract) AddRemotePool(opts *bind.TransactOpts, remoteChainSelector uint64, remotePoolAddress []byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.AddRemotePool(remoteChainSelector, remotePoolAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c LockReleaseTokenPoolContract) RemoveRemotePool(opts *bind.TransactOpts, remoteChainSelector uint64, remotePoolAddress []byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.RemoveRemotePool(remoteChainSelector, remotePoolAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c LockReleaseTokenPoolContract) ApplyChainUpdates(opts *bind.TransactOpts, remoteChainSelectorsToRemove []uint64, remoteChainSelectorsToAdd []uint64, remotePoolAddressesToAdd [][][]byte, remoteTokenAddressesToAdd [][]byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.ApplyChainUpdates(remoteChainSelectorsToRemove, remoteChainSelectorsToAdd, remotePoolAddressesToAdd, remoteTokenAddressesToAdd)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c LockReleaseTokenPoolContract) ApplyAllowlistUpdates(opts *bind.TransactOpts, removes []aptos.AccountAddress, adds []aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.ApplyAllowlistUpdates(removes, adds)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c LockReleaseTokenPoolContract) TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.TransferOwnership(to)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c LockReleaseTokenPoolContract) AcceptOwnership(opts *bind.TransactOpts) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.AcceptOwnership()
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+// Encoder
+type lockReleaseTokenPoolEncoder struct {
+	*bind.BoundContract
+}
+
+func (c lockReleaseTokenPoolEncoder) TypeAndVersion() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("type_and_version", nil, []string{}, []any{})
+}
+
+func (c lockReleaseTokenPoolEncoder) GetToken() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_token", nil, []string{}, []any{})
+}
+
+func (c lockReleaseTokenPoolEncoder) GetRouter() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_router", nil, []string{}, []any{})
+}
+
+func (c lockReleaseTokenPoolEncoder) GetTokenDecimals() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_token_decimals", nil, []string{}, []any{})
+}
+
+func (c lockReleaseTokenPoolEncoder) GetRemotePools(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_remote_pools", nil, []string{
+		"u64",
+	}, []any{
+		remoteChainSelector,
+	})
+}
+
+func (c lockReleaseTokenPoolEncoder) IsRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("is_remote_pool", nil, []string{
+		"u64",
+		"vector<u8>",
+	}, []any{
+		remoteChainSelector,
+		remotePoolAddress,
+	})
+}
+
+func (c lockReleaseTokenPoolEncoder) GetRemoteToken(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_remote_token", nil, []string{
+		"u64",
+	}, []any{
+		remoteChainSelector,
+	})
+}
+
+func (c lockReleaseTokenPoolEncoder) IsSupportedChain(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("is_supported_chain", nil, []string{
+		"u64",
+	}, []any{
+		remoteChainSelector,
+	})
+}
+
+func (c lockReleaseTokenPoolEncoder) GetSupportedChains() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_supported_chains", nil, []string{}, []any{})
+}
+
+func (c lockReleaseTokenPoolEncoder) GetAllowlistEnabled() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_allowlist_enabled", nil, []string{}, []any{})
+}
+
+func (c lockReleaseTokenPoolEncoder) GetAllowlist() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_allowlist", nil, []string{}, []any{})
+}
+
+func (c lockReleaseTokenPoolEncoder) GetStoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_store_address", nil, []string{}, []any{})
+}
+
+func (c lockReleaseTokenPoolEncoder) Owner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("owner", nil, []string{}, []any{})
+}
+
+func (c lockReleaseTokenPoolEncoder) AddRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("add_remote_pool", nil, []string{
+		"u64",
+		"vector<u8>",
+	}, []any{
+		remoteChainSelector,
+		remotePoolAddress,
+	})
+}
+
+func (c lockReleaseTokenPoolEncoder) RemoveRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("remove_remote_pool", nil, []string{
+		"u64",
+		"vector<u8>",
+	}, []any{
+		remoteChainSelector,
+		remotePoolAddress,
+	})
+}
+
+func (c lockReleaseTokenPoolEncoder) ApplyChainUpdates(remoteChainSelectorsToRemove []uint64, remoteChainSelectorsToAdd []uint64, remotePoolAddressesToAdd [][][]byte, remoteTokenAddressesToAdd [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("apply_chain_updates", nil, []string{
+		"vector<u64>",
+		"vector<u64>",
+		"vector<vector<vector<u8>>>",
+		"vector<vector<u8>>",
+	}, []any{
+		remoteChainSelectorsToRemove,
+		remoteChainSelectorsToAdd,
+		remotePoolAddressesToAdd,
+		remoteTokenAddressesToAdd,
+	})
+}
+
+func (c lockReleaseTokenPoolEncoder) ApplyAllowlistUpdates(removes []aptos.AccountAddress, adds []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("apply_allowlist_updates", nil, []string{
+		"vector<address>",
+		"vector<address>",
+	}, []any{
+		removes,
+		adds,
+	})
+}
+
+func (c lockReleaseTokenPoolEncoder) TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("transfer_ownership", nil, []string{
+		"address",
+	}, []any{
+		to,
+	})
+}
+
+func (c lockReleaseTokenPoolEncoder) AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("accept_ownership", nil, []string{}, []any{})
+}
+
+func (c lockReleaseTokenPoolEncoder) Initialize() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("initialize", nil, []string{}, []any{})
+}
+
+func (c lockReleaseTokenPoolEncoder) SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("set_chain_rate_limiter_configs", nil, []string{
+		"vector<u64>",
+		"vector<bool>",
+		"vector<u64>",
+		"vector<u64>",
+		"vector<bool>",
+		"vector<u64>",
+		"vector<u64>",
+	}, []any{
+		remoteChainSelectors,
+		outboundIsEnableds,
+		outboundCapacities,
+		outboundRates,
+		inboundIsEnableds,
+		inboundCapacities,
+		inboundRates,
+	})
+}
+
+func (c lockReleaseTokenPoolEncoder) SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("set_chain_rate_limiter_config", nil, []string{
+		"u64",
+		"bool",
+		"u64",
+		"u64",
+		"bool",
+		"u64",
+		"u64",
+	}, []any{
+		remoteChainSelector,
+		outboundIsEnabled,
+		outboundCapacity,
+		outboundRate,
+		inboundIsEnabled,
+		inboundCapacity,
+		inboundRate,
+	})
+}
+
+func (c lockReleaseTokenPoolEncoder) StoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("store_address", nil, []string{}, []any{})
+}
+
+func (c lockReleaseTokenPoolEncoder) AssertCanInitialize(callerAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("assert_can_initialize", nil, []string{
+		"address",
+	}, []any{
+		callerAddress,
+	})
+}

--- a/bindings/ccip_token_pools/lock_release_token_pool/lock_release_token_pool_test.go
+++ b/bindings/ccip_token_pools/lock_release_token_pool/lock_release_token_pool_test.go
@@ -1,4 +1,4 @@
-package ccip_router
+package lock_release_token_pool
 
 import (
 	"testing"
@@ -9,7 +9,7 @@ import (
 
 func TestCompile(t *testing.T) {
 	t.Parallel()
-	output, err := Compile(aptos.AccountOne, aptos.AccountOne, false)
+	output, err := Compile(aptos.AccountOne, aptos.AccountOne, aptos.AccountOne, aptos.AccountOne, aptos.AccountOne, false)
 	require.NoError(t, err)
 	require.NotZero(t, output.Metadata, "Compilation resulted in no metadata")
 	require.NotZero(t, output.Bytecode, "Compilation resulted in no bytecode")

--- a/bindings/ccip_token_pools/token_pool/rate_limiter/rate_limiter.go
+++ b/bindings/ccip_token_pools/token_pool/rate_limiter/rate_limiter.go
@@ -1,0 +1,95 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package module_rate_limiter
+
+import (
+	"math/big"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/api"
+
+	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	"github.com/smartcontractkit/chainlink-aptos/relayer/codec"
+)
+
+var (
+	_ = aptos.AccountAddress{}
+	_ = api.PendingTransaction{}
+	_ = big.NewInt
+	_ = bind.NewBoundContract
+	_ = codec.DecodeAptosJsonValue
+)
+
+type RateLimiterInterface interface {
+
+	// Encoder returns the encoder implementation of this module.
+	Encoder() RateLimiterEncoder
+}
+
+type RateLimiterEncoder interface {
+	New(isEnabled bool, capacity uint64, rate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Min(a uint64, b uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+}
+
+const FunctionInfo = `[{"package":"ccip_token_pool","module":"rate_limiter","name":"min","parameters":[{"name":"a","type":"u64"},{"name":"b","type":"u64"}]},{"package":"ccip_token_pool","module":"rate_limiter","name":"new","parameters":[{"name":"is_enabled","type":"bool"},{"name":"capacity","type":"u64"},{"name":"rate","type":"u64"}]}]`
+
+func NewRateLimiter(address aptos.AccountAddress, client aptos.AptosRpcClient) RateLimiterInterface {
+	contract := bind.NewBoundContract(address, "ccip_token_pool", "rate_limiter", client)
+	return RateLimiterContract{
+		BoundContract:      contract,
+		rateLimiterEncoder: rateLimiterEncoder{BoundContract: contract},
+	}
+}
+
+// Structs
+
+type TokenBucket struct {
+	Tokens      uint64 `move:"u64"`
+	LastUpdated uint64 `move:"u64"`
+	IsEnabled   bool   `move:"bool"`
+	Capacity    uint64 `move:"u64"`
+	Rate        uint64 `move:"u64"`
+}
+
+type RateLimiterContract struct {
+	*bind.BoundContract
+	rateLimiterEncoder
+}
+
+var _ RateLimiterInterface = RateLimiterContract{}
+
+func (c RateLimiterContract) Encoder() RateLimiterEncoder {
+	return c.rateLimiterEncoder
+}
+
+// View Functions
+
+// Entry Functions
+
+// Encoder
+type rateLimiterEncoder struct {
+	*bind.BoundContract
+}
+
+func (c rateLimiterEncoder) New(isEnabled bool, capacity uint64, rate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("new", nil, []string{
+		"bool",
+		"u64",
+		"u64",
+	}, []any{
+		isEnabled,
+		capacity,
+		rate,
+	})
+}
+
+func (c rateLimiterEncoder) Min(a uint64, b uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("min", nil, []string{
+		"u64",
+		"u64",
+	}, []any{
+		a,
+		b,
+	})
+}

--- a/bindings/ccip_token_pools/token_pool/token_pool.go
+++ b/bindings/ccip_token_pools/token_pool/token_pool.go
@@ -1,0 +1,92 @@
+package token_pool
+
+import (
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/api"
+
+	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	module_rate_limiter "github.com/smartcontractkit/chainlink-aptos/bindings/ccip_token_pools/token_pool/rate_limiter"
+	module_token_pool "github.com/smartcontractkit/chainlink-aptos/bindings/ccip_token_pools/token_pool/token_pool"
+	module_token_pool_rate_limiter "github.com/smartcontractkit/chainlink-aptos/bindings/ccip_token_pools/token_pool/token_pool_rate_limiter"
+	"github.com/smartcontractkit/chainlink-aptos/bindings/compile"
+	"github.com/smartcontractkit/chainlink-aptos/contracts"
+)
+
+type TokenPool interface {
+	Address() aptos.AccountAddress
+
+	RateLimiter() module_rate_limiter.RateLimiterInterface
+	TokenPool() module_token_pool.TokenPoolInterface
+	TokenPoolRateLimiter() module_token_pool_rate_limiter.TokenPoolRateLimiterInterface
+}
+
+var _ TokenPool = TokenPoolContract{}
+
+type TokenPoolContract struct {
+	address aptos.AccountAddress
+
+	rateLimiter          module_rate_limiter.RateLimiterInterface
+	tokenPool            module_token_pool.TokenPoolInterface
+	tokenPoolRateLimiter module_token_pool_rate_limiter.TokenPoolRateLimiterInterface
+}
+
+func (c TokenPoolContract) Address() aptos.AccountAddress {
+	return c.address
+}
+
+func (c TokenPoolContract) RateLimiter() module_rate_limiter.RateLimiterInterface {
+	return c.rateLimiter
+}
+
+func (c TokenPoolContract) TokenPool() module_token_pool.TokenPoolInterface {
+	return c.tokenPool
+}
+
+func (c TokenPoolContract) TokenPoolRateLimiter() module_token_pool_rate_limiter.TokenPoolRateLimiterInterface {
+	return c.tokenPoolRateLimiter
+}
+
+var FunctionInfo = bind.MustParseFunctionInfo(
+	module_rate_limiter.FunctionInfo,
+	module_token_pool.FunctionInfo,
+	module_rate_limiter.FunctionInfo,
+)
+
+func Compile(address, ccipAddress, mcmsAddress aptos.AccountAddress) (compile.CompiledPackage, error) {
+	namedAddresses := map[string]aptos.AccountAddress{
+		"ccip_token_pool":           address,
+		"ccip":                      ccipAddress,
+		"mcms":                      mcmsAddress,
+		"mcms_register_entrypoints": aptos.AccountZero,
+	}
+	// Compile using CLI
+	return compile.CompilePackage(contracts.CCIPTokenPool, namedAddresses)
+}
+
+func Bind(address aptos.AccountAddress, client aptos.AptosRpcClient) TokenPool {
+	return TokenPoolContract{
+		address:              address,
+		rateLimiter:          module_rate_limiter.NewRateLimiter(address, client),
+		tokenPool:            module_token_pool.NewTokenPool(address, client),
+		tokenPoolRateLimiter: module_token_pool_rate_limiter.NewTokenPoolRateLimiter(address, client),
+	}
+}
+
+// DeployToObject deploys the token_pool package to a new named object.
+func DeployToObject(
+	auth aptos.TransactionSigner,
+	client aptos.AptosRpcClient,
+	ccipAddress,
+	mcmsAddress aptos.AccountAddress,
+) (aptos.AccountAddress, *api.PendingTransaction, TokenPool, error) {
+	namedAddresses := map[string]aptos.AccountAddress{
+		"ccip":                      ccipAddress,
+		"mcms":                      mcmsAddress,
+		"mcms_register_entrypoints": aptos.AccountZero,
+	}
+	address, tx, err := bind.DeployPackageToObject(auth, client, contracts.CCIPTokenPool, namedAddresses)
+	if err != nil {
+		return aptos.AccountAddress{}, nil, nil, err
+	}
+	return address, tx, Bind(address, client), nil
+}

--- a/bindings/ccip_token_pools/token_pool/token_pool/token_pool.go
+++ b/bindings/ccip_token_pools/token_pool/token_pool/token_pool.go
@@ -1,0 +1,273 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package module_token_pool
+
+import (
+	"math/big"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/api"
+
+	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	"github.com/smartcontractkit/chainlink-aptos/relayer/codec"
+)
+
+var (
+	_ = aptos.AccountAddress{}
+	_ = api.PendingTransaction{}
+	_ = big.NewInt
+	_ = bind.NewBoundContract
+	_ = codec.DecodeAptosJsonValue
+)
+
+type TokenPoolInterface interface {
+	GetRouter(opts *bind.CallOpts) (aptos.AccountAddress, error)
+	ParseRemoteDecimals(opts *bind.CallOpts, sourcePoolData []byte, localDecimals byte) (byte, error)
+	CalculateLocalAmount(opts *bind.CallOpts, remoteAmount *big.Int, remoteDecimals byte, localDecimals byte) (uint64, error)
+	CalculateLocalAmountInternal(opts *bind.CallOpts, remoteAmount *big.Int, remoteDecimals byte, localDecimals byte) (*big.Int, error)
+
+	// Encoder returns the encoder implementation of this module.
+	Encoder() TokenPoolEncoder
+}
+
+type TokenPoolEncoder interface {
+	GetRouter() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ParseRemoteDecimals(sourcePoolData []byte, localDecimals byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	CalculateLocalAmount(remoteAmount *big.Int, remoteDecimals byte, localDecimals byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	CalculateLocalAmountInternal(remoteAmount *big.Int, remoteDecimals byte, localDecimals byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Initialize(localToken aptos.AccountAddress, allowlist []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AssertCanInitialize(callerAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	StoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	DestroyTokenPool(state TokenPoolState) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+}
+
+const FunctionInfo = `[{"package":"ccip_token_pool","module":"token_pool","name":"assert_can_initialize","parameters":[{"name":"caller_address","type":"address"}]},{"package":"ccip_token_pool","module":"token_pool","name":"destroy_token_pool","parameters":[{"name":"state","type":"TokenPoolState"}]},{"package":"ccip_token_pool","module":"token_pool","name":"initialize","parameters":[{"name":"local_token","type":"address"},{"name":"allowlist","type":"vector\u003caddress\u003e"}]},{"package":"ccip_token_pool","module":"token_pool","name":"store_address","parameters":null}]`
+
+func NewTokenPool(address aptos.AccountAddress, client aptos.AptosRpcClient) TokenPoolInterface {
+	contract := bind.NewBoundContract(address, "ccip_token_pool", "token_pool", client)
+	return TokenPoolContract{
+		BoundContract:    contract,
+		tokenPoolEncoder: tokenPoolEncoder{BoundContract: contract},
+	}
+}
+
+// Structs
+
+type TokenPoolState struct {
+	FaMetadata bind.StdObject `move:"aptos_framework::object::Object"`
+}
+
+type RemoteChainConfig struct {
+	RemoteTokenAddress []byte   `move:"vector<u8>"`
+	RemotePools        [][]byte `move:"vector<vector<u8>>"`
+}
+
+type CallbackProof struct {
+}
+
+type Locked struct {
+	LocalToken aptos.AccountAddress `move:"address"`
+	Amount     uint64               `move:"u64"`
+}
+
+type Released struct {
+	LocalToken aptos.AccountAddress `move:"address"`
+	Recipient  aptos.AccountAddress `move:"address"`
+	Amount     uint64               `move:"u64"`
+}
+
+type AllowlistRemove struct {
+	Sender aptos.AccountAddress `move:"address"`
+}
+
+type AllowlistAdd struct {
+	Sender aptos.AccountAddress `move:"address"`
+}
+
+type RemotePoolAdded struct {
+	RemoteChainSelector uint64 `move:"u64"`
+	RemotePoolAddress   []byte `move:"vector<u8>"`
+}
+
+type RemotePoolRemoved struct {
+	RemoteChainSelector uint64 `move:"u64"`
+	RemotePoolAddress   []byte `move:"vector<u8>"`
+}
+
+type ChainAdded struct {
+	RemoteChainSelector uint64 `move:"u64"`
+	RemoteTokenAddress  []byte `move:"vector<u8>"`
+}
+
+type TokenPoolContract struct {
+	*bind.BoundContract
+	tokenPoolEncoder
+}
+
+var _ TokenPoolInterface = TokenPoolContract{}
+
+func (c TokenPoolContract) Encoder() TokenPoolEncoder {
+	return c.tokenPoolEncoder
+}
+
+// View Functions
+
+func (c TokenPoolContract) GetRouter(opts *bind.CallOpts) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.tokenPoolEncoder.GetRouter()
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	var (
+		r0 aptos.AccountAddress
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+	return r0, nil
+}
+
+func (c TokenPoolContract) ParseRemoteDecimals(opts *bind.CallOpts, sourcePoolData []byte, localDecimals byte) (byte, error) {
+	module, function, typeTags, args, err := c.tokenPoolEncoder.ParseRemoteDecimals(sourcePoolData, localDecimals)
+	if err != nil {
+		return *new(byte), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(byte), err
+	}
+
+	var (
+		r0 byte
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(byte), err
+	}
+	return r0, nil
+}
+
+func (c TokenPoolContract) CalculateLocalAmount(opts *bind.CallOpts, remoteAmount *big.Int, remoteDecimals byte, localDecimals byte) (uint64, error) {
+	module, function, typeTags, args, err := c.tokenPoolEncoder.CalculateLocalAmount(remoteAmount, remoteDecimals, localDecimals)
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	var (
+		r0 uint64
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(uint64), err
+	}
+	return r0, nil
+}
+
+func (c TokenPoolContract) CalculateLocalAmountInternal(opts *bind.CallOpts, remoteAmount *big.Int, remoteDecimals byte, localDecimals byte) (*big.Int, error) {
+	module, function, typeTags, args, err := c.tokenPoolEncoder.CalculateLocalAmountInternal(remoteAmount, remoteDecimals, localDecimals)
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	var (
+		r0 *big.Int
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(*big.Int), err
+	}
+	return r0, nil
+}
+
+// Entry Functions
+
+// Encoder
+type tokenPoolEncoder struct {
+	*bind.BoundContract
+}
+
+func (c tokenPoolEncoder) GetRouter() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_router", nil, []string{}, []any{})
+}
+
+func (c tokenPoolEncoder) ParseRemoteDecimals(sourcePoolData []byte, localDecimals byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("parse_remote_decimals", nil, []string{
+		"vector<u8>",
+		"u8",
+	}, []any{
+		sourcePoolData,
+		localDecimals,
+	})
+}
+
+func (c tokenPoolEncoder) CalculateLocalAmount(remoteAmount *big.Int, remoteDecimals byte, localDecimals byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("calculate_local_amount", nil, []string{
+		"u256",
+		"u8",
+		"u8",
+	}, []any{
+		remoteAmount,
+		remoteDecimals,
+		localDecimals,
+	})
+}
+
+func (c tokenPoolEncoder) CalculateLocalAmountInternal(remoteAmount *big.Int, remoteDecimals byte, localDecimals byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("calculate_local_amount_internal", nil, []string{
+		"u256",
+		"u8",
+		"u8",
+	}, []any{
+		remoteAmount,
+		remoteDecimals,
+		localDecimals,
+	})
+}
+
+func (c tokenPoolEncoder) Initialize(localToken aptos.AccountAddress, allowlist []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("initialize", nil, []string{
+		"address",
+		"vector<address>",
+	}, []any{
+		localToken,
+		allowlist,
+	})
+}
+
+func (c tokenPoolEncoder) AssertCanInitialize(callerAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("assert_can_initialize", nil, []string{
+		"address",
+	}, []any{
+		callerAddress,
+	})
+}
+
+func (c tokenPoolEncoder) StoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("store_address", nil, []string{}, []any{})
+}
+
+func (c tokenPoolEncoder) DestroyTokenPool(state TokenPoolState) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("destroy_token_pool", nil, []string{
+		"TokenPoolState",
+	}, []any{
+		state,
+	})
+}

--- a/bindings/ccip_token_pools/token_pool/token_pool_rate_limiter/token_pool_rate_limiter.go
+++ b/bindings/ccip_token_pools/token_pool/token_pool_rate_limiter/token_pool_rate_limiter.go
@@ -1,0 +1,95 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package module_token_pool_rate_limiter
+
+import (
+	"math/big"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/api"
+
+	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	"github.com/smartcontractkit/chainlink-aptos/relayer/codec"
+)
+
+var (
+	_ = aptos.AccountAddress{}
+	_ = api.PendingTransaction{}
+	_ = big.NewInt
+	_ = bind.NewBoundContract
+	_ = codec.DecodeAptosJsonValue
+)
+
+type TokenPoolRateLimiterInterface interface {
+
+	// Encoder returns the encoder implementation of this module.
+	Encoder() TokenPoolRateLimiterEncoder
+}
+
+type TokenPoolRateLimiterEncoder interface {
+	New() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	DestroyRateLimiter(state RateLimitState) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+}
+
+const FunctionInfo = `[{"package":"ccip_token_pool","module":"token_pool_rate_limiter","name":"destroy_rate_limiter","parameters":[{"name":"state","type":"RateLimitState"}]},{"package":"ccip_token_pool","module":"token_pool_rate_limiter","name":"new","parameters":null}]`
+
+func NewTokenPoolRateLimiter(address aptos.AccountAddress, client aptos.AptosRpcClient) TokenPoolRateLimiterInterface {
+	contract := bind.NewBoundContract(address, "ccip_token_pool", "token_pool_rate_limiter", client)
+	return TokenPoolRateLimiterContract{
+		BoundContract:               contract,
+		tokenPoolRateLimiterEncoder: tokenPoolRateLimiterEncoder{BoundContract: contract},
+	}
+}
+
+// Structs
+
+type RateLimitState struct {
+}
+
+type TokensConsumed struct {
+	RemoteChainSelector uint64 `move:"u64"`
+	Tokens              uint64 `move:"u64"`
+}
+
+type ConfigChanged struct {
+	RemoteChainSelector uint64 `move:"u64"`
+	OutboundIsEnabled   bool   `move:"bool"`
+	OutboundCapacity    uint64 `move:"u64"`
+	OutboundRate        uint64 `move:"u64"`
+	InboundIsEnabled    bool   `move:"bool"`
+	InboundCapacity     uint64 `move:"u64"`
+	InboundRate         uint64 `move:"u64"`
+}
+
+type TokenPoolRateLimiterContract struct {
+	*bind.BoundContract
+	tokenPoolRateLimiterEncoder
+}
+
+var _ TokenPoolRateLimiterInterface = TokenPoolRateLimiterContract{}
+
+func (c TokenPoolRateLimiterContract) Encoder() TokenPoolRateLimiterEncoder {
+	return c.tokenPoolRateLimiterEncoder
+}
+
+// View Functions
+
+// Entry Functions
+
+// Encoder
+type tokenPoolRateLimiterEncoder struct {
+	*bind.BoundContract
+}
+
+func (c tokenPoolRateLimiterEncoder) New() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("new", nil, []string{}, []any{})
+}
+
+func (c tokenPoolRateLimiterEncoder) DestroyRateLimiter(state RateLimitState) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("destroy_rate_limiter", nil, []string{
+		"RateLimitState",
+	}, []any{
+		state,
+	})
+}

--- a/bindings/ccip_token_pools/token_pool/token_pool_test.go
+++ b/bindings/ccip_token_pools/token_pool/token_pool_test.go
@@ -1,4 +1,4 @@
-package ccip_router
+package token_pool
 
 import (
 	"testing"
@@ -9,7 +9,7 @@ import (
 
 func TestCompile(t *testing.T) {
 	t.Parallel()
-	output, err := Compile(aptos.AccountOne, aptos.AccountOne, false)
+	output, err := Compile(aptos.AccountOne, aptos.AccountOne, aptos.AccountOne)
 	require.NoError(t, err)
 	require.NotZero(t, output.Metadata, "Compilation resulted in no metadata")
 	require.NotZero(t, output.Bytecode, "Compilation resulted in no bytecode")

--- a/bindings/mcms/mcms.go
+++ b/bindings/mcms/mcms.go
@@ -16,11 +16,11 @@ import (
 
 type MCMS interface {
 	Address() aptos.AccountAddress
-	MCMS() module_mcms.MCMS
-	MCMSAccount() module_mcms_account.MCMSAccount
-	MCMSDeployer() module_mcms_deployer.MCMSDeployer
-	MCMSExecutor() module_mcms_executor.MCMSExecutor
-	MCMSRegistry() module_mcms_registry.MCMSRegistry
+	MCMS() module_mcms.MCMSInterface
+	MCMSAccount() module_mcms_account.MCMSAccountInterface
+	MCMSDeployer() module_mcms_deployer.MCMSDeployerInterface
+	MCMSExecutor() module_mcms_executor.MCMSExecutorInterface
+	MCMSRegistry() module_mcms_registry.MCMSRegistryInterface
 }
 
 var _ MCMS = MCMSContract{}
@@ -28,34 +28,34 @@ var _ MCMS = MCMSContract{}
 type MCMSContract struct {
 	address aptos.AccountAddress
 
-	mcms         module_mcms.MCMS
-	mcmsAccount  module_mcms_account.MCMSAccount
-	mcmsDeployer module_mcms_deployer.MCMSDeployer
-	mcmsExecutor module_mcms_executor.MCMSExecutor
-	mcmsRegistry module_mcms_registry.MCMSRegistry
+	mcms         module_mcms.MCMSInterface
+	mcmsAccount  module_mcms_account.MCMSAccountInterface
+	mcmsDeployer module_mcms_deployer.MCMSDeployerInterface
+	mcmsExecutor module_mcms_executor.MCMSExecutorInterface
+	mcmsRegistry module_mcms_registry.MCMSRegistryInterface
 }
 
 func (M MCMSContract) Address() aptos.AccountAddress {
 	return M.address
 }
 
-func (M MCMSContract) MCMS() module_mcms.MCMS {
+func (M MCMSContract) MCMS() module_mcms.MCMSInterface {
 	return M.mcms
 }
 
-func (M MCMSContract) MCMSAccount() module_mcms_account.MCMSAccount {
+func (M MCMSContract) MCMSAccount() module_mcms_account.MCMSAccountInterface {
 	return M.mcmsAccount
 }
 
-func (M MCMSContract) MCMSDeployer() module_mcms_deployer.MCMSDeployer {
+func (M MCMSContract) MCMSDeployer() module_mcms_deployer.MCMSDeployerInterface {
 	return M.mcmsDeployer
 }
 
-func (M MCMSContract) MCMSExecutor() module_mcms_executor.MCMSExecutor {
+func (M MCMSContract) MCMSExecutor() module_mcms_executor.MCMSExecutorInterface {
 	return M.mcmsExecutor
 }
 
-func (M MCMSContract) MCMSRegistry() module_mcms_registry.MCMSRegistry {
+func (M MCMSContract) MCMSRegistry() module_mcms_registry.MCMSRegistryInterface {
 	return M.mcmsRegistry
 }
 

--- a/bindings/mcms/mcms/mcms.go
+++ b/bindings/mcms/mcms/mcms.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type MCMS interface {
+type MCMSInterface interface {
 	GetConfig(opts *bind.CallOpts) (Config, error)
 	GetOpCount(opts *bind.CallOpts) (uint64, error)
 	GetRoot(opts *bind.CallOpts) ([]byte, uint64, error)
@@ -58,7 +58,7 @@ type MCMSEncoder interface {
 
 const FunctionInfo = `[{"package":"mcms","module":"mcms","name":"compute_eth_message_hash","parameters":[{"name":"root","type":"vector\u003cu8\u003e"},{"name":"valid_until","type":"u64"}]},{"package":"mcms","module":"mcms","name":"dispatch","parameters":[{"name":"receiver","type":"address"},{"name":"module_name","type":"0x1::string::String"},{"name":"function_name","type":"0x1::string::String"},{"name":"data","type":"vector\u003cu8\u003e"}]},{"package":"mcms","module":"mcms","name":"dispatch_to_account","parameters":[{"name":"function_name_bytes","type":"vector\u003cu8\u003e"},{"name":"data","type":"vector\u003cu8\u003e"}]},{"package":"mcms","module":"mcms","name":"dispatch_to_deployer","parameters":[{"name":"function_name_bytes","type":"vector\u003cu8\u003e"},{"name":"data","type":"vector\u003cu8\u003e"}]},{"package":"mcms","module":"mcms","name":"dispatch_to_registry","parameters":[{"name":"function_name_bytes","type":"vector\u003cu8\u003e"},{"name":"data","type":"vector\u003cu8\u003e"}]},{"package":"mcms","module":"mcms","name":"dispatch_to_self","parameters":[{"name":"function_name_bytes","type":"vector\u003cu8\u003e"},{"name":"data","type":"vector\u003cu8\u003e"}]},{"package":"mcms","module":"mcms","name":"ecdsa_recover_evm_addr","parameters":[{"name":"eth_signed_message_hash","type":"vector\u003cu8\u003e"},{"name":"signature","type":"vector\u003cu8\u003e"}]},{"package":"mcms","module":"mcms","name":"execute","parameters":[{"name":"chain_id","type":"u256"},{"name":"multisig","type":"address"},{"name":"nonce","type":"u64"},{"name":"to","type":"address"},{"name":"module_name","type":"0x1::string::String"},{"name":"function","type":"0x1::string::String"},{"name":"data","type":"vector\u003cu8\u003e"},{"name":"proof","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"mcms","module":"mcms","name":"hash_metadata_leaf","parameters":[{"name":"metadata","type":"RootMetadata"}]},{"package":"mcms","module":"mcms","name":"hash_op_leaf","parameters":[{"name":"op","type":"Op"}]},{"package":"mcms","module":"mcms","name":"set_config","parameters":[{"name":"signer_addresses","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"signer_groups","type":"vector\u003cu8\u003e"},{"name":"group_quorums","type":"vector\u003cu8\u003e"},{"name":"group_parents","type":"vector\u003cu8\u003e"},{"name":"clear_root","type":"bool"}]},{"package":"mcms","module":"mcms","name":"set_root","parameters":[{"name":"root","type":"vector\u003cu8\u003e"},{"name":"valid_until","type":"u64"},{"name":"chain_id","type":"u256"},{"name":"multisig","type":"address"},{"name":"pre_op_count","type":"u64"},{"name":"post_op_count","type":"u64"},{"name":"override_previous_root","type":"bool"},{"name":"metadata_proof","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"signatures","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"mcms","module":"mcms","name":"test_register_object_owner_for_new_code_object","parameters":null},{"package":"mcms","module":"mcms","name":"verify_merkle_proof","parameters":[{"name":"proof","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"root","type":"vector\u003cu8\u003e"},{"name":"leaf","type":"vector\u003cu8\u003e"}]}]`
 
-func NewMCMS(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMS {
+func NewMCMS(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSInterface {
 	contract := bind.NewBoundContract(address, "mcms", "mcms", client)
 	return MCMSContract{
 		BoundContract: contract,
@@ -136,7 +136,7 @@ type MCMSContract struct {
 	mcmsEncoder
 }
 
-var _ MCMS = MCMSContract{}
+var _ MCMSInterface = MCMSContract{}
 
 func (c MCMSContract) Encoder() MCMSEncoder {
 	return c.mcmsEncoder

--- a/bindings/mcms/mcms_account/mcms_account.go
+++ b/bindings/mcms/mcms_account/mcms_account.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type MCMSAccount interface {
+type MCMSAccountInterface interface {
 	Owner(opts *bind.CallOpts) (aptos.AccountAddress, error)
 	IsSelfOwned(opts *bind.CallOpts) (bool, error)
 
@@ -43,7 +43,7 @@ type MCMSAccountEncoder interface {
 
 const FunctionInfo = `[{"package":"mcms","module":"mcms_account","name":"accept_ownership","parameters":null},{"package":"mcms","module":"mcms_account","name":"assert_is_owner","parameters":null},{"package":"mcms","module":"mcms_account","name":"transfer_ownership","parameters":[{"name":"to","type":"address"}]},{"package":"mcms","module":"mcms_account","name":"transfer_ownership_to_self","parameters":null}]`
 
-func NewMCMSAccount(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSAccount {
+func NewMCMSAccount(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSAccountInterface {
 	contract := bind.NewBoundContract(address, "mcms", "mcms_account", client)
 	return MCMSAccountContract{
 		BoundContract:      contract,
@@ -73,7 +73,7 @@ type MCMSAccountContract struct {
 	mcmsAccountEncoder
 }
 
-var _ MCMSAccount = MCMSAccountContract{}
+var _ MCMSAccountInterface = MCMSAccountContract{}
 
 func (c MCMSAccountContract) Encoder() MCMSAccountEncoder {
 	return c.mcmsAccountEncoder

--- a/bindings/mcms/mcms_deployer/mcms_deployer.go
+++ b/bindings/mcms/mcms_deployer/mcms_deployer.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type MCMSDeployer interface {
+type MCMSDeployerInterface interface {
 	StageCodeChunk(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte) (*api.PendingTransaction, error)
 	StageCodeChunkAndPublishToObject(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, newOwnerSeed []byte) (*api.PendingTransaction, error)
 	StageCodeChunkAndUpgradeObjectCode(opts *bind.TransactOpts, metadataChunk []byte, codeIndices []uint16, codeChunks [][]byte, codeObjectAddress aptos.AccountAddress) (*api.PendingTransaction, error)
@@ -41,7 +41,7 @@ type MCMSDeployerEncoder interface {
 
 const FunctionInfo = `[{"package":"mcms","module":"mcms_deployer","name":"cleanup_staging_area","parameters":null},{"package":"mcms","module":"mcms_deployer","name":"cleanup_staging_area_internal","parameters":null},{"package":"mcms","module":"mcms_deployer","name":"stage_code_chunk","parameters":[{"name":"metadata_chunk","type":"vector\u003cu8\u003e"},{"name":"code_indices","type":"vector\u003cu16\u003e"},{"name":"code_chunks","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"mcms","module":"mcms_deployer","name":"stage_code_chunk_and_publish_to_object","parameters":[{"name":"metadata_chunk","type":"vector\u003cu8\u003e"},{"name":"code_indices","type":"vector\u003cu16\u003e"},{"name":"code_chunks","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"new_owner_seed","type":"vector\u003cu8\u003e"}]},{"package":"mcms","module":"mcms_deployer","name":"stage_code_chunk_and_upgrade_object_code","parameters":[{"name":"metadata_chunk","type":"vector\u003cu8\u003e"},{"name":"code_indices","type":"vector\u003cu16\u003e"},{"name":"code_chunks","type":"vector\u003cvector\u003cu8\u003e\u003e"},{"name":"code_object_address","type":"address"}]}]`
 
-func NewMCMSDeployer(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSDeployer {
+func NewMCMSDeployer(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSDeployerInterface {
 	contract := bind.NewBoundContract(address, "mcms", "mcms_deployer", client)
 	return MCMSDeployerContract{
 		BoundContract:       contract,
@@ -61,7 +61,7 @@ type MCMSDeployerContract struct {
 	mcmsDeployerEncoder
 }
 
-var _ MCMSDeployer = MCMSDeployerContract{}
+var _ MCMSDeployerInterface = MCMSDeployerContract{}
 
 func (c MCMSDeployerContract) Encoder() MCMSDeployerEncoder {
 	return c.mcmsDeployerEncoder

--- a/bindings/mcms/mcms_executor/mcms_executor.go
+++ b/bindings/mcms/mcms_executor/mcms_executor.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type MCMSExecutor interface {
+type MCMSExecutorInterface interface {
 	StageData(opts *bind.TransactOpts, dataChunk []byte, partialProofs [][]byte) (*api.PendingTransaction, error)
 	StageDataAndExecute(opts *bind.TransactOpts, chainId *big.Int, multisig aptos.AccountAddress, nonce uint64, to aptos.AccountAddress, moduleName string, function string, dataChunk []byte, partialProofs [][]byte) (*api.PendingTransaction, error)
 	ClearStagedData(opts *bind.TransactOpts) (*api.PendingTransaction, error)
@@ -38,7 +38,7 @@ type MCMSExecutorEncoder interface {
 
 const FunctionInfo = `[{"package":"mcms","module":"mcms_executor","name":"clear_staged_data","parameters":null},{"package":"mcms","module":"mcms_executor","name":"stage_data","parameters":[{"name":"data_chunk","type":"vector\u003cu8\u003e"},{"name":"partial_proofs","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"mcms","module":"mcms_executor","name":"stage_data_and_execute","parameters":[{"name":"chain_id","type":"u256"},{"name":"multisig","type":"address"},{"name":"nonce","type":"u64"},{"name":"to","type":"address"},{"name":"module_name","type":"0x1::string::String"},{"name":"function","type":"0x1::string::String"},{"name":"data_chunk","type":"vector\u003cu8\u003e"},{"name":"partial_proofs","type":"vector\u003cvector\u003cu8\u003e\u003e"}]}]`
 
-func NewMCMSExecutor(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSExecutor {
+func NewMCMSExecutor(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSExecutorInterface {
 	contract := bind.NewBoundContract(address, "mcms", "mcms_executor", client)
 	return MCMSExecutorContract{
 		BoundContract:       contract,
@@ -58,7 +58,7 @@ type MCMSExecutorContract struct {
 	mcmsExecutorEncoder
 }
 
-var _ MCMSExecutor = MCMSExecutorContract{}
+var _ MCMSExecutorInterface = MCMSExecutorContract{}
 
 func (c MCMSExecutorContract) Encoder() MCMSExecutorEncoder {
 	return c.mcmsExecutorEncoder

--- a/bindings/mcms/mcms_registry/mcms_registry.go
+++ b/bindings/mcms/mcms_registry/mcms_registry.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type MCMSRegistry interface {
+type MCMSRegistryInterface interface {
 	GetNewCodeObjectOwnerAddress(opts *bind.CallOpts, newOwnerSeed []byte) (aptos.AccountAddress, error)
 	GetNewCodeObjectAddress(opts *bind.CallOpts, newOwnerSeed []byte) (aptos.AccountAddress, error)
 	GetPreexistingCodeObjectOwnerAddress(opts *bind.CallOpts, objectAddress aptos.AccountAddress) (aptos.AccountAddress, error)
@@ -53,7 +53,7 @@ type MCMSRegistryEncoder interface {
 
 const FunctionInfo = `[{"package":"mcms","module":"mcms_registry","name":"accept_code_object","parameters":[{"name":"object_address","type":"address"}]},{"package":"mcms","module":"mcms_registry","name":"create_owner_for_preexisting_code_object","parameters":[{"name":"object_address","type":"address"}]},{"package":"mcms","module":"mcms_registry","name":"execute_code_object_transfer","parameters":[{"name":"object_address","type":"address"},{"name":"new_owner_address","type":"address"}]},{"package":"mcms","module":"mcms_registry","name":"finish_dispatch","parameters":[{"name":"callback_address","type":"address"}]},{"package":"mcms","module":"mcms_registry","name":"start_dispatch","parameters":[{"name":"callback_address","type":"address"},{"name":"callback_module_name","type":"0x1::string::String"},{"name":"callback_function","type":"0x1::string::String"},{"name":"data","type":"vector\u003cu8\u003e"}]},{"package":"mcms","module":"mcms_registry","name":"transfer_code_object","parameters":[{"name":"object_address","type":"address"},{"name":"new_owner_address","type":"address"}]}]`
 
-func NewMCMSRegistry(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSRegistry {
+func NewMCMSRegistry(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSRegistryInterface {
 	contract := bind.NewBoundContract(address, "mcms", "mcms_registry", client)
 	return MCMSRegistryContract{
 		BoundContract:       contract,
@@ -132,7 +132,7 @@ type MCMSRegistryContract struct {
 	mcmsRegistryEncoder
 }
 
-var _ MCMSRegistry = MCMSRegistryContract{}
+var _ MCMSRegistryInterface = MCMSRegistryContract{}
 
 func (c MCMSRegistryContract) Encoder() MCMSRegistryEncoder {
 	return c.mcmsRegistryEncoder

--- a/bindings/mcms_test/mcms_user/mcms_user.go
+++ b/bindings/mcms_test/mcms_user/mcms_user.go
@@ -21,7 +21,7 @@ var (
 	_ = codec.DecodeAptosJsonValue
 )
 
-type MCMSUser interface {
+type MCMSUserInterface interface {
 
 	// Encoder returns the encoder implementation of this module.
 	Encoder() MCMSUserEncoder
@@ -35,7 +35,7 @@ type MCMSUserEncoder interface {
 
 const FunctionInfo = `[{"package":"mcms_test","module":"mcms_user","name":"function_one","parameters":[{"name":"arg1","type":"0x1::string::String"},{"name":"arg2","type":"vector\u003cu8\u003e"}]},{"package":"mcms_test","module":"mcms_user","name":"function_two","parameters":[{"name":"arg1","type":"address"},{"name":"arg2","type":"u128"}]},{"package":"mcms_test","module":"mcms_user","name":"mcms_entrypoint","parameters":[{"name":"_metadata","type":"address"}]}]`
 
-func NewMCMSUser(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSUser {
+func NewMCMSUser(address aptos.AccountAddress, client aptos.AptosRpcClient) MCMSUserInterface {
 	contract := bind.NewBoundContract(address, "mcms_test", "mcms_user", client)
 	return MCMSUserContract{
 		BoundContract:   contract,
@@ -61,7 +61,7 @@ type MCMSUserContract struct {
 	mcmsUserEncoder
 }
 
-var _ MCMSUser = MCMSUserContract{}
+var _ MCMSUserInterface = MCMSUserContract{}
 
 func (c MCMSUserContract) Encoder() MCMSUserEncoder {
 	return c.mcmsUserEncoder

--- a/bindings/mcms_test/mcmstest.go
+++ b/bindings/mcms_test/mcmstest.go
@@ -13,7 +13,7 @@ import (
 type MCMSTest interface {
 	Address() aptos.AccountAddress
 
-	MCMSUser() module_mcms_user.MCMSUser
+	MCMSUser() module_mcms_user.MCMSUserInterface
 }
 
 var _ MCMSTest = MCMSTestContract{}
@@ -21,14 +21,14 @@ var _ MCMSTest = MCMSTestContract{}
 type MCMSTestContract struct {
 	address aptos.AccountAddress
 
-	mcmsUser module_mcms_user.MCMSUser
+	mcmsUser module_mcms_user.MCMSUserInterface
 }
 
 func (M MCMSTestContract) Address() aptos.AccountAddress {
 	return M.address
 }
 
-func (M MCMSTestContract) MCMSUser() module_mcms_user.MCMSUser {
+func (M MCMSTestContract) MCMSUser() module_mcms_user.MCMSUserInterface {
 	return M.mcmsUser
 }
 

--- a/cmd/bindgen/main.go
+++ b/cmd/bindgen/main.go
@@ -68,12 +68,12 @@ func main() {
 		log.Fatal(err)
 	}
 
-	pkg, mod, err := parse.PackageModule(fileBytes)
+	pkg, mod, moduleContent, err := parse.PackageModule(fileBytes)
 	if err != nil {
 		panic(err)
 	}
 
-	funcs, err := parse.Functions(fileBytes)
+	funcs, err := parse.Functions([]byte(moduleContent))
 	if err != nil {
 		panic(err)
 	}
@@ -82,7 +82,7 @@ func main() {
 		log.Println(i, viewFunc)
 	}
 	log.Println("----")
-	structs, err := parse.Structs(fileBytes)
+	structs, err := parse.Structs([]byte(moduleContent))
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/bindgen/parse/parse.go
+++ b/cmd/bindgen/parse/parse.go
@@ -37,17 +37,25 @@ type ExternalStruct struct {
 	Name    string
 }
 
-func PackageModule(module []byte) (pkg string, mod string, err error) {
+// PackageModule parses the input file and returns the first module it finds.
+// `#[test_only]` modules will be filtered out
+func PackageModule(module []byte) (pkg string, mod string, moduleContent string, err error) {
 	lang := tree_sitter.NewLanguage(tree_sitter_move_on_aptos.Language())
 	n, err := tree_sitter.ParseCtx(context.Background(), module, lang)
 	if err != nil {
-		return "", "", fmt.Errorf("parsing AST: %w", err)
+		return "", "", "", fmt.Errorf("parsing AST: %w", err)
 	}
 
 	query, err := tree_sitter.NewQuery([]byte(`
-(module
-  path: (identifier) @package
-  name: (identifier) @module
+(source_file
+    (attributes
+    	(attribute) @attr
+    )*
+    (#not-eq? @attr "test_only")
+	(module
+ 		path: (identifier) @packageName
+		name: (identifier) @moduleName
+	) @moduleContent
 )
 	`), lang)
 
@@ -59,14 +67,23 @@ func PackageModule(module []byte) (pkg string, mod string, err error) {
 		if !ok {
 			break
 		}
+
+		m = queryCursor.FilterPredicates(m, module)
+		if len(m.Captures) == 0 {
+			continue
+		}
+
 		for _, capture := range m.Captures {
 			switch capture.Index {
-			case 0:
-				// @package
-				pkg = capture.Node.Content(module)
 			case 1:
-				// @module
+				// @packageName
+				pkg = capture.Node.Content(module)
+			case 2:
+				// @moduleName
 				mod = capture.Node.Content(module)
+			case 3:
+				// @moduleContent
+				moduleContent = capture.Node.Content(module)
 			}
 		}
 	}
@@ -124,7 +141,6 @@ func Functions(module []byte) ([]Func, error) {
 		}
 		m = functionCursor.FilterPredicates(m, module)
 		if len(m.Captures) == 0 {
-			fmt.Println("Filtered out")
 			continue
 		}
 		f := Func{}

--- a/cmd/bindgen/template/go.tmpl
+++ b/cmd/bindgen/template/go.tmpl
@@ -26,7 +26,7 @@ var (
   _ = codec.DecodeAptosJsonValue
 )
 
-type {{toUpperCamel .Module}} interface {
+type {{toUpperCamel .Module}}Interface interface {
   {{- range .ViewFuncs}}
     {{.Name}}(opts *bind.CallOpts, {{range .Params}}{{.Name}} {{.Type.GoType}},{{end}}) ({{range .Returns}}{{.GoType}},{{end}} error)
   {{- end}}
@@ -53,7 +53,7 @@ type {{toUpperCamel .Module}}Encoder interface {
 
 const FunctionInfo = `{{.FunctionInfo}}`
 
-func New{{toUpperCamel .Module}}(address aptos.AccountAddress, client aptos.AptosRpcClient) {{toUpperCamel .Module}} {
+func New{{toUpperCamel .Module}}(address aptos.AccountAddress, client aptos.AptosRpcClient) {{toUpperCamel .Module}}Interface {
   contract := bind.NewBoundContract(address, "{{.Package}}", "{{.Module}}", client)
   return {{toUpperCamel .Module}}Contract {
     BoundContract: contract,
@@ -75,7 +75,7 @@ type {{toUpperCamel .Module}}Contract struct {
   {{toLowerCamel .Module}}Encoder
 }
 
-var _ {{toUpperCamel .Module}} = {{toUpperCamel .Module}}Contract{}
+var _ {{toUpperCamel .Module}}Interface = {{toUpperCamel .Module}}Contract{}
 
 func (c {{toUpperCamel .Module}}Contract) Encoder() {{toUpperCamel .Module}}Encoder {
   return c.{{toLowerCamel .Module}}Encoder

--- a/contracts/ccip/ccip/sources/auth.move
+++ b/contracts/ccip/ccip/sources/auth.move
@@ -44,6 +44,7 @@ module ccip::auth {
 
         move_to(publisher, PendingRouterSignerCapability { signer_capability });
 
+        // Register the entrypoint with mcms
         if (@mcms_register_entrypoints != @0x0) {
             mcms_registry::register_entrypoint(
                 publisher, string::utf8(b"auth"), McmsCallback {}

--- a/contracts/ccip/ccip/sources/fee_quoter.move
+++ b/contracts/ccip/ccip/sources/fee_quoter.move
@@ -222,6 +222,7 @@ module ccip::fee_quoter {
     }
 
     fun init_module(publisher: &signer) {
+        // Register the entrypoint with mcms
         if (@mcms_register_entrypoints != @0x0) {
             mcms_registry::register_entrypoint(
                 publisher, string::utf8(b"fee_quoter"), McmsCallback {}

--- a/contracts/ccip/ccip/sources/offramp.move
+++ b/contracts/ccip/ccip/sources/offramp.move
@@ -232,6 +232,7 @@ module ccip::offramp {
     }
 
     fun init_module(publisher: &signer) {
+        // Register the entrypoint with mcms
         if (@mcms_register_entrypoints != @0x0) {
             mcms_registry::register_entrypoint(
                 publisher, string::utf8(b"offramp"), McmsCallback {}
@@ -1222,7 +1223,7 @@ module ccip::offramp {
         let (caller, function, data) =
             mcms_registry::get_callback_params(@ccip, McmsCallback {});
 
-        let function_bytes = *string::bytes(&function);
+        let function_bytes = *function.bytes();
         let stream = bcs_stream::new(data);
 
         if (function_bytes == b"initialize") {

--- a/contracts/ccip/ccip/sources/onramp.move
+++ b/contracts/ccip/ccip/sources/onramp.move
@@ -147,6 +147,7 @@ module ccip::onramp {
     }
 
     fun init_module(publisher: &signer) {
+        // Register the entrypoint with mcms
         if (@mcms_register_entrypoints != @0x0) {
             mcms_registry::register_entrypoint(
                 publisher, string::utf8(b"onramp"), McmsCallback {}

--- a/contracts/ccip/ccip/sources/rmn_remote.move
+++ b/contracts/ccip/ccip/sources/rmn_remote.move
@@ -109,6 +109,7 @@ module ccip::rmn_remote {
     }
 
     fun init_module(publisher: &signer) {
+        // Register the entrypoint with mcms
         if (@mcms_register_entrypoints != @0x0) {
             mcms_registry::register_entrypoint(
                 publisher, string::utf8(b"rmn_remote"), McmsCallback {}

--- a/contracts/ccip/ccip/sources/token_admin_registry.move
+++ b/contracts/ccip/ccip/sources/token_admin_registry.move
@@ -140,6 +140,7 @@ module ccip::token_admin_registry {
     }
 
     fun init_module(publisher: &signer) {
+        // Register the entrypoint with mcms
         if (@mcms_register_entrypoints != @0x0) {
             mcms_registry::register_entrypoint(
                 publisher, string::utf8(b"token_admin_registry"), McmsCallback {}

--- a/contracts/ccip/ccip_router/sources/router.move
+++ b/contracts/ccip/ccip_router/sources/router.move
@@ -37,6 +37,7 @@ module ccip_router::router {
     }
 
     fun init_module(publisher: &signer) {
+        // Register the entrypoint with mcms
         if (@mcms_register_entrypoints != @0x0) {
             mcms_registry::register_entrypoint(
                 publisher, string::utf8(b"router"), McmsCallback {}

--- a/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
@@ -4,6 +4,7 @@ module burn_mint_token_pool::burn_mint_token_pool {
     use std::fungible_asset::{Self, FungibleAsset, Metadata, TransferRef};
     use std::primary_fungible_store;
     use std::object::{Self, Object, ObjectCore};
+    use std::option;
     use std::signer;
     use std::string::{Self, String};
     use aptos_framework::fungible_asset::{BurnRef, MintRef};
@@ -11,6 +12,9 @@ module burn_mint_token_pool::burn_mint_token_pool {
     use ccip::ownable;
     use ccip::token_admin_registry;
     use ccip_token_pool::token_pool;
+
+    use mcms::mcms_registry;
+    use mcms::bcs_stream;
 
     const STORE_OBJECT_SEED: vector<u8> = b"CcipBurnMintTokenPool";
 
@@ -43,6 +47,7 @@ module burn_mint_token_pool::burn_mint_token_pool {
     const E_INVALID_REMOTE_CHAIN_DECIMALS: u64 = 7;
     const E_INVALID_ENCODED_AMOUNT: u64 = 8;
     const E_INVALID_ARGUMENTS: u64 = 9;
+    const E_UNKNOWN_FUNCTION: u64 = 10;
 
     // ================================================================
     // |                             Init                             |
@@ -62,9 +67,17 @@ module burn_mint_token_pool::burn_mint_token_pool {
         );
         let metadata = object::address_to_object<Metadata>(@local_token);
 
+
         // the name of this module. if incorrect, callbacks will fail to be registered and
         // register_pool will revert.
         let token_pool_module_name = b"burn_mint_token_pool";
+        
+        // Register the entrypoint with mcms
+        if (@mcms_register_entrypoints != @0x0) {
+            mcms_registry::register_entrypoint(
+                publisher, string::utf8(token_pool_module_name), McmsCallback {}
+            );
+        };
 
         token_admin_registry::register_pool(
             publisher,
@@ -470,5 +483,134 @@ module burn_mint_token_pool::burn_mint_token_pool {
     public entry fun accept_ownership(caller: &signer) acquires BurnMintTokenPool {
         let pool = borrow_pool_mut();
         ownable::accept_ownership(signer::address_of(caller), &mut pool.ownable_state)
+    }
+
+    // ================================================================
+    // |                      MCMS entrypoint                         |
+    // ================================================================
+
+    struct McmsCallback has drop {}
+
+    public fun mcms_entrypoint<T: key>(
+        _metadata: object::Object<T>
+    ): option::Option<u128> acquires BurnMintTokenPool {
+        let (caller, function, data) =
+            mcms_registry::get_callback_params(@burn_mint_token_pool, McmsCallback {});
+
+        let function_bytes = *function.bytes();
+        let stream = bcs_stream::new(data);
+
+        if (function_bytes == b"add_remote_pool") {
+            let remote_chain_selector = bcs_stream::deserialize_u64(&mut stream);
+            let remote_pool_address = bcs_stream::deserialize_vector_u8(&mut stream);
+            add_remote_pool(&caller, remote_chain_selector, remote_pool_address);
+        } else if (function_bytes == b"remove_remote_pool") {
+            let remote_chain_selector = bcs_stream::deserialize_u64(&mut stream);
+            let remote_pool_address = bcs_stream::deserialize_vector_u8(&mut stream);
+            remove_remote_pool(&caller, remote_chain_selector, remote_pool_address);
+        } else if (function_bytes == b"apply_chain_updates") {
+            let remote_chain_selectors_to_remove =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u64(stream)
+                );
+            let remote_chain_selectors_to_add =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u64(stream)
+                );
+            let remote_pool_addresses_to_add =
+                bcs_stream::deserialize_vector(
+                    &mut stream,
+                    |stream| bcs_stream::deserialize_vector(
+                        stream, |stream| bcs_stream::deserialize_vector_u8(stream)
+                    )
+                );
+            let remote_token_addresses_to_add =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_vector_u8(stream)
+                );
+            apply_chain_updates(
+                &caller,
+                remote_chain_selectors_to_remove,
+                remote_chain_selectors_to_add,
+                remote_pool_addresses_to_add,
+                remote_token_addresses_to_add
+            );
+        } else if (function_bytes == b"apply_allowlist_updates") {
+            let removes =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_address(stream)
+                );
+            let adds =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_address(stream)
+                );
+            apply_allowlist_updates(&caller, removes, adds);
+        } else if (function_bytes == b"set_chain_rate_limiter_configs") {
+            let remote_chain_selectors =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u64(stream)
+                );
+            let outbound_is_enableds =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_bool(stream)
+                );
+            let outbound_capacities =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u64(stream)
+                );
+            let outbound_rates =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u64(stream)
+                );
+            let inbound_is_enableds =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_bool(stream)
+                );
+            let inbound_capacities =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u64(stream)
+                );
+            let inbound_rates =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u64(stream)
+                );
+            set_chain_rate_limiter_configs(
+                &caller,
+                remote_chain_selectors,
+                outbound_is_enableds,
+                outbound_capacities,
+                outbound_rates,
+                inbound_is_enableds,
+                inbound_capacities,
+                inbound_rates
+            );
+        } else if (function_bytes == b"set_chain_rate_limiter_config") {
+            let remote_chain_selector = bcs_stream::deserialize_u64(&mut stream);
+            let outbound_is_enabled = bcs_stream::deserialize_bool(&mut stream);
+            let outbound_capacity = bcs_stream::deserialize_u64(&mut stream);
+            let outbound_rate = bcs_stream::deserialize_u64(&mut stream);
+            let inbound_is_enabled = bcs_stream::deserialize_bool(&mut stream);
+            let inbound_capacity = bcs_stream::deserialize_u64(&mut stream);
+            let inbound_rate = bcs_stream::deserialize_u64(&mut stream);
+            set_chain_rate_limiter_config(
+                &caller,
+                remote_chain_selector,
+                outbound_is_enabled,
+                outbound_capacity,
+                outbound_rate,
+                inbound_is_enabled,
+                inbound_capacity,
+                inbound_rate
+            );
+        } else if (function_bytes == b"transfer_ownership") {
+            let to = bcs_stream::deserialize_address(&mut stream);
+            transfer_ownership(&caller, to);
+        } else if (function_bytes == b"accept_ownership") {
+            accept_ownership(&caller);
+        } else {
+            abort error::invalid_argument(E_UNKNOWN_FUNCTION)
+        };
+
+        option::none()
     }
 }

--- a/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
@@ -67,11 +67,10 @@ module burn_mint_token_pool::burn_mint_token_pool {
         );
         let metadata = object::address_to_object<Metadata>(@local_token);
 
-
         // the name of this module. if incorrect, callbacks will fail to be registered and
         // register_pool will revert.
         let token_pool_module_name = b"burn_mint_token_pool";
-        
+
         // Register the entrypoint with mcms
         if (@mcms_register_entrypoints != @0x0) {
             mcms_registry::register_entrypoint(

--- a/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
@@ -4,12 +4,16 @@ module lock_release_token_pool::lock_release_token_pool {
     use std::fungible_asset::{Self, FungibleAsset, Metadata, TransferRef};
     use std::primary_fungible_store;
     use std::object::{Self, Object, ObjectCore};
+    use std::option;
     use std::signer;
     use std::string::{Self, String};
 
     use ccip::ownable;
     use ccip::token_admin_registry;
     use ccip_token_pool::token_pool;
+
+    use mcms::mcms_registry;
+    use mcms::bcs_stream;
 
     const STORE_OBJECT_SEED: vector<u8> = b"CcipLockReleaseTokenPool";
 
@@ -40,6 +44,7 @@ module lock_release_token_pool::lock_release_token_pool {
     const E_INVALID_REMOTE_CHAIN_DECIMALS: u64 = 7;
     const E_INVALID_ENCODED_AMOUNT: u64 = 8;
     const E_INVALID_ARGUMENTS: u64 = 9;
+    const E_UNKNOWN_FUNCTION: u64 = 10;
 
     // ================================================================
     // |                             Init                             |
@@ -62,6 +67,13 @@ module lock_release_token_pool::lock_release_token_pool {
         // the name of this module. if incorrect, callbacks will fail to be registered and
         // register_pool will revert.
         let token_pool_module_name = b"lock_release_token_pool";
+
+        // Register the entrypoint with mcms
+        if (@mcms_register_entrypoints != @0x0) {
+            mcms_registry::register_entrypoint(
+                publisher, string::utf8(token_pool_module_name), McmsCallback {}
+            );
+        };
 
         token_admin_registry::register_pool(
             publisher,
@@ -450,5 +462,134 @@ module lock_release_token_pool::lock_release_token_pool {
     public entry fun accept_ownership(caller: &signer) acquires LockReleaseTokenPool {
         let pool = borrow_pool_mut();
         ownable::accept_ownership(signer::address_of(caller), &mut pool.ownable_state)
+    }
+
+    // ================================================================
+    // |                      MCMS entrypoint                         |
+    // ================================================================
+
+    struct McmsCallback has drop {}
+
+    public fun mcms_entrypoint<T: key>(
+        _metadata: object::Object<T>
+    ): option::Option<u128> acquires LockReleaseTokenPool {
+        let (caller, function, data) =
+            mcms_registry::get_callback_params(@lock_release_token_pool, McmsCallback {});
+
+        let function_bytes = *function.bytes();
+        let stream = bcs_stream::new(data);
+
+        if (function_bytes == b"add_remote_pool") {
+            let remote_chain_selector = bcs_stream::deserialize_u64(&mut stream);
+            let remote_pool_address = bcs_stream::deserialize_vector_u8(&mut stream);
+            add_remote_pool(&caller, remote_chain_selector, remote_pool_address);
+        } else if (function_bytes == b"remove_remote_pool") {
+            let remote_chain_selector = bcs_stream::deserialize_u64(&mut stream);
+            let remote_pool_address = bcs_stream::deserialize_vector_u8(&mut stream);
+            remove_remote_pool(&caller, remote_chain_selector, remote_pool_address);
+        } else if (function_bytes == b"apply_chain_updates") {
+            let remote_chain_selectors_to_remove =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u64(stream)
+                );
+            let remote_chain_selectors_to_add =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u64(stream)
+                );
+            let remote_pool_addresses_to_add =
+                bcs_stream::deserialize_vector(
+                    &mut stream,
+                    |stream| bcs_stream::deserialize_vector(
+                        stream, |stream| bcs_stream::deserialize_vector_u8(stream)
+                    )
+                );
+            let remote_token_addresses_to_add =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_vector_u8(stream)
+                );
+            apply_chain_updates(
+                &caller,
+                remote_chain_selectors_to_remove,
+                remote_chain_selectors_to_add,
+                remote_pool_addresses_to_add,
+                remote_token_addresses_to_add
+            );
+        } else if (function_bytes == b"apply_allowlist_updates") {
+            let removes =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_address(stream)
+                );
+            let adds =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_address(stream)
+                );
+            apply_allowlist_updates(&caller, removes, adds);
+        } else if (function_bytes == b"set_chain_rate_limiter_configs") {
+            let remote_chain_selectors =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u64(stream)
+                );
+            let outbound_is_enableds =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_bool(stream)
+                );
+            let outbound_capacities =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u64(stream)
+                );
+            let outbound_rates =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u64(stream)
+                );
+            let inbound_is_enableds =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_bool(stream)
+                );
+            let inbound_capacities =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u64(stream)
+                );
+            let inbound_rates =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u64(stream)
+                );
+            set_chain_rate_limiter_configs(
+                &caller,
+                remote_chain_selectors,
+                outbound_is_enableds,
+                outbound_capacities,
+                outbound_rates,
+                inbound_is_enableds,
+                inbound_capacities,
+                inbound_rates
+            );
+        } else if (function_bytes == b"set_chain_rate_limiter_config") {
+            let remote_chain_selector = bcs_stream::deserialize_u64(&mut stream);
+            let outbound_is_enabled = bcs_stream::deserialize_bool(&mut stream);
+            let outbound_capacity = bcs_stream::deserialize_u64(&mut stream);
+            let outbound_rate = bcs_stream::deserialize_u64(&mut stream);
+            let inbound_is_enabled = bcs_stream::deserialize_bool(&mut stream);
+            let inbound_capacity = bcs_stream::deserialize_u64(&mut stream);
+            let inbound_rate = bcs_stream::deserialize_u64(&mut stream);
+            set_chain_rate_limiter_config(
+                &caller,
+                remote_chain_selector,
+                outbound_is_enabled,
+                outbound_capacity,
+                outbound_rate,
+                inbound_is_enabled,
+                inbound_capacity,
+                inbound_rate
+            );
+        } else if (function_bytes == b"transfer_ownership") {
+            let to = bcs_stream::deserialize_address(&mut stream);
+            transfer_ownership(&caller, to);
+        } else if (function_bytes == b"accept_ownership") {
+            accept_ownership(&caller);
+        } else {
+            abort error::invalid_argument(E_UNKNOWN_FUNCTION)
+        };
+
+        option::none()
     }
 }

--- a/contracts/contracts.go
+++ b/contracts/contracts.go
@@ -13,8 +13,8 @@ type Package string
 const (
 	CCIP                = Package("ccip")
 	CCIPPingPongDemo    = Package("ccip_ping_pong_demo")
-	CCIPBurnMintPool    = Package("ccip_burn_mint_pool")
-	CCIPLockReleasePool = Package("ccip_lock_release_pool")
+	CCIPBurnMintPool    = Package("burn_mint_token_pool")
+	CCIPLockReleasePool = Package("lock_release_token_pool")
 	CCIPTokenPool       = Package("ccip_token_pool")
 	CCIPRouter          = Package("ccip_router")
 	CCIPDummyReceiver   = Package("ccip_dummy_receiver")

--- a/gen.go
+++ b/gen.go
@@ -12,6 +12,13 @@ package aptos
 //go:generate go run ./cmd/bindgen --uppercase CCIP,MCMS --input ./contracts/ccip/ccip_router/sources/router.move --output ./bindings/ccip_router/router
 //go:generate go run ./cmd/bindgen --uppercase CCIP,MCMS --input ./contracts/ccip/ccip_dummy_receiver/sources/dummy_receiver.move --output ./bindings/ccip_dummy_receiver/dummy_receiver
 
+//go:generate go run ./cmd/bindgen --uppercase CCIP,MCMS --input ./contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move --output ./bindings/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool
+//go:generate go run ./cmd/bindgen --uppercase CCIP,MCMS --input ./contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move --output ./bindings/ccip_token_pools/lock_release_token_pool/lock_release_token_pool
+
+//go:generate go run ./cmd/bindgen --uppercase CCIP,MCMS --input ./contracts/ccip/ccip_token_pools/token_pool/sources/rate_limiter.move --output ./bindings/ccip_token_pools/token_pool/rate_limiter
+//go:generate go run ./cmd/bindgen --uppercase CCIP,MCMS --input ./contracts/ccip/ccip_token_pools/token_pool/sources/token_pool.move --output ./bindings/ccip_token_pools/token_pool/token_pool
+//go:generate go run ./cmd/bindgen --uppercase CCIP,MCMS --input ./contracts/ccip/ccip_token_pools/token_pool/sources/token_pool_rate_limiter.move --output ./bindings/ccip_token_pools/token_pool/token_pool_rate_limiter
+
 //go:generate go run ./cmd/bindgen --uppercase CCIP,MCMS --input ./contracts/mcms/mcms/sources/mcms.move --output ./bindings/mcms/mcms
 //go:generate go run ./cmd/bindgen --uppercase CCIP,MCMS --input ./contracts/mcms/mcms/sources/mcms_account.move --output ./bindings/mcms/mcms_account
 //go:generate go run ./cmd/bindgen --uppercase CCIP,MCMS --input ./contracts/mcms/mcms/sources/mcms_deployer.move --output ./bindings/mcms/mcms_deployer


### PR DESCRIPTION
This:
- adds bindings and deploy methods for the burnMint & lockRelease token pools
- adds `mcms_entrypoint` functions to both token pools
- renames the module-level bindings interfaces to include `Interface` as there were collisions
- adjusts the bindgen parsing to not parse `test-only` modules, like present in the `token_pool` package