### PR TITLE
contracts/ccip/ccip_router: fix router, remove auth signer cap handling

### DIFF
--- a/bindings/ccip/auth/auth.go
+++ b/bindings/ccip/auth/auth.go
@@ -68,10 +68,6 @@ func NewAuth(address aptos.AccountAddress, client aptos.AptosRpcClient) AuthInte
 // Structs
 
 type AuthState struct {
-	RouterAddress aptos.AccountAddress `move:"address"`
-}
-
-type PendingRouterSignerCapability struct {
 }
 
 type McmsCallback struct {

--- a/bindings/ccip_router/router/router.go
+++ b/bindings/ccip_router/router/router.go
@@ -26,8 +26,13 @@ type RouterInterface interface {
 	GetStateAddress(opts *bind.CallOpts) (aptos.AccountAddress, error)
 	IsChainSupported(opts *bind.CallOpts, destChainSelector uint64) (bool, error)
 	GetFee(opts *bind.CallOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (uint64, error)
+	GetOnRampVersions(opts *bind.CallOpts, destChainSelectors []uint64) ([][]byte, error)
+	Owner(opts *bind.CallOpts) (aptos.AccountAddress, error)
 
 	CCIPSend(opts *bind.TransactOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (*api.PendingTransaction, error)
+	SetOnRampVersions(opts *bind.TransactOpts, destChainSelectors []uint64, onRampVersions [][]byte) (*api.PendingTransaction, error)
+	TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
+	AcceptOwnership(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 
 	// Encoder returns the encoder implementation of this module.
 	Encoder() RouterEncoder
@@ -38,14 +43,18 @@ type RouterEncoder interface {
 	GetStateAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	IsChainSupported(destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetFee(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
-	CCIPSend(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
-	CCIPSendWithMessageId(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetOnRampVersions(destChainSelectors []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Owner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	CCIPSend(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	SetOnRampVersions(destChainSelectors []uint64, onRampVersions [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	CCIPSendWithMessageId(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetStateAddressInternal() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	MCMSEntrypoint(Metadata aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
-const FunctionInfo = `[{"package":"ccip_router","module":"router","name":"ccip_send","parameters":[{"name":"dest_chain_selector","type":"u64"},{"name":"receiver","type":"vector\u003cu8\u003e"},{"name":"data","type":"vector\u003cu8\u003e"},{"name":"token_addresses","type":"vector\u003caddress\u003e"},{"name":"token_amounts","type":"vector\u003cu64\u003e"},{"name":"token_store_addresses","type":"vector\u003caddress\u003e"},{"name":"fee_token","type":"address"},{"name":"fee_token_store","type":"address"},{"name":"extra_args","type":"vector\u003cu8\u003e"}]},{"package":"ccip_router","module":"router","name":"ccip_send_with_message_id","parameters":[{"name":"dest_chain_selector","type":"u64"},{"name":"receiver","type":"vector\u003cu8\u003e"},{"name":"data","type":"vector\u003cu8\u003e"},{"name":"token_addresses","type":"vector\u003caddress\u003e"},{"name":"token_amounts","type":"vector\u003cu64\u003e"},{"name":"token_store_addresses","type":"vector\u003caddress\u003e"},{"name":"fee_token","type":"address"},{"name":"fee_token_store","type":"address"},{"name":"extra_args","type":"vector\u003cu8\u003e"}]},{"package":"ccip_router","module":"router","name":"get_on_ramp_versions","parameters":[{"name":"dest_chain_selectors","type":"vector\u003cu64\u003e"}]},{"package":"ccip_router","module":"router","name":"mcms_entrypoint","parameters":[{"name":"_metadata","type":"address"}]},{"package":"ccip_router","module":"router","name":"set_on_ramp_versions","parameters":[{"name":"dest_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"on_ramp_versions","type":"vector\u003cvector\u003cu8\u003e\u003e"}]}]`
+const FunctionInfo = `[{"package":"ccip_router","module":"router","name":"accept_ownership","parameters":null},{"package":"ccip_router","module":"router","name":"ccip_send","parameters":[{"name":"dest_chain_selector","type":"u64"},{"name":"receiver","type":"vector\u003cu8\u003e"},{"name":"data","type":"vector\u003cu8\u003e"},{"name":"token_addresses","type":"vector\u003caddress\u003e"},{"name":"token_amounts","type":"vector\u003cu64\u003e"},{"name":"token_store_addresses","type":"vector\u003caddress\u003e"},{"name":"fee_token","type":"address"},{"name":"fee_token_store","type":"address"},{"name":"extra_args","type":"vector\u003cu8\u003e"}]},{"package":"ccip_router","module":"router","name":"ccip_send_with_message_id","parameters":[{"name":"dest_chain_selector","type":"u64"},{"name":"receiver","type":"vector\u003cu8\u003e"},{"name":"data","type":"vector\u003cu8\u003e"},{"name":"token_addresses","type":"vector\u003caddress\u003e"},{"name":"token_amounts","type":"vector\u003cu64\u003e"},{"name":"token_store_addresses","type":"vector\u003caddress\u003e"},{"name":"fee_token","type":"address"},{"name":"fee_token_store","type":"address"},{"name":"extra_args","type":"vector\u003cu8\u003e"}]},{"package":"ccip_router","module":"router","name":"get_state_address_internal","parameters":null},{"package":"ccip_router","module":"router","name":"mcms_entrypoint","parameters":[{"name":"_metadata","type":"address"}]},{"package":"ccip_router","module":"router","name":"set_on_ramp_versions","parameters":[{"name":"dest_chain_selectors","type":"vector\u003cu64\u003e"},{"name":"on_ramp_versions","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"ccip_router","module":"router","name":"transfer_ownership","parameters":[{"name":"to","type":"address"}]}]`
 
 func NewRouter(address aptos.AccountAddress, client aptos.AptosRpcClient) RouterInterface {
 	contract := bind.NewBoundContract(address, "ccip_router", "router", client)
@@ -165,10 +174,79 @@ func (c RouterContract) GetFee(opts *bind.CallOpts, destChainSelector uint64, re
 	return r0, nil
 }
 
+func (c RouterContract) GetOnRampVersions(opts *bind.CallOpts, destChainSelectors []uint64) ([][]byte, error) {
+	module, function, typeTags, args, err := c.routerEncoder.GetOnRampVersions(destChainSelectors)
+	if err != nil {
+		return *new([][]byte), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new([][]byte), err
+	}
+
+	var (
+		r0 [][]byte
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new([][]byte), err
+	}
+	return r0, nil
+}
+
+func (c RouterContract) Owner(opts *bind.CallOpts) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.routerEncoder.Owner()
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	var (
+		r0 aptos.AccountAddress
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+	return r0, nil
+}
+
 // Entry Functions
 
 func (c RouterContract) CCIPSend(opts *bind.TransactOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (*api.PendingTransaction, error) {
 	module, function, typeTags, args, err := c.routerEncoder.CCIPSend(destChainSelector, receiver, data, tokenAddresses, tokenAmounts, tokenStoreAddresses, feeToken, feeTokenStore, extraArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c RouterContract) SetOnRampVersions(opts *bind.TransactOpts, destChainSelectors []uint64, onRampVersions [][]byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.routerEncoder.SetOnRampVersions(destChainSelectors, onRampVersions)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c RouterContract) TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.routerEncoder.TransferOwnership(to)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c RouterContract) AcceptOwnership(opts *bind.TransactOpts) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.routerEncoder.AcceptOwnership()
 	if err != nil {
 		return nil, err
 	}
@@ -221,6 +299,18 @@ func (c routerEncoder) GetFee(destChainSelector uint64, receiver []byte, data []
 	})
 }
 
+func (c routerEncoder) GetOnRampVersions(destChainSelectors []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_on_ramp_versions", nil, []string{
+		"vector<u64>",
+	}, []any{
+		destChainSelectors,
+	})
+}
+
+func (c routerEncoder) Owner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("owner", nil, []string{}, []any{})
+}
+
 func (c routerEncoder) CCIPSend(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("ccip_send", nil, []string{
 		"u64",
@@ -243,6 +333,28 @@ func (c routerEncoder) CCIPSend(destChainSelector uint64, receiver []byte, data 
 		feeTokenStore,
 		extraArgs,
 	})
+}
+
+func (c routerEncoder) SetOnRampVersions(destChainSelectors []uint64, onRampVersions [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("set_on_ramp_versions", nil, []string{
+		"vector<u64>",
+		"vector<vector<u8>>",
+	}, []any{
+		destChainSelectors,
+		onRampVersions,
+	})
+}
+
+func (c routerEncoder) TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("transfer_ownership", nil, []string{
+		"address",
+	}, []any{
+		to,
+	})
+}
+
+func (c routerEncoder) AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("accept_ownership", nil, []string{}, []any{})
 }
 
 func (c routerEncoder) CCIPSendWithMessageId(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
@@ -269,22 +381,8 @@ func (c routerEncoder) CCIPSendWithMessageId(destChainSelector uint64, receiver 
 	})
 }
 
-func (c routerEncoder) GetOnRampVersions(destChainSelectors []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("get_on_ramp_versions", nil, []string{
-		"vector<u64>",
-	}, []any{
-		destChainSelectors,
-	})
-}
-
-func (c routerEncoder) SetOnRampVersions(destChainSelectors []uint64, onRampVersions [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("set_on_ramp_versions", nil, []string{
-		"vector<u64>",
-		"vector<vector<u8>>",
-	}, []any{
-		destChainSelectors,
-		onRampVersions,
-	})
+func (c routerEncoder) GetStateAddressInternal() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_state_address_internal", nil, []string{}, []any{})
 }
 
 func (c routerEncoder) MCMSEntrypoint(Metadata aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {

--- a/contracts/ccip/ccip/sources/auth.move
+++ b/contracts/ccip/ccip/sources/auth.move
@@ -1,5 +1,4 @@
 module ccip::auth {
-    use std::account::{Self, SignerCapability};
     use std::error;
     use std::object;
     use std::option;
@@ -15,13 +14,8 @@ module ccip::auth {
 
     struct AuthState has key {
         ownable_state: ownable::OwnableState,
-        router_address: address,
         allowed_onramps: allowlist::AllowlistState,
         allowed_offramps: allowlist::AllowlistState
-    }
-
-    struct PendingRouterSignerCapability has key {
-        signer_capability: SignerCapability
     }
 
     const E_UNKNOWN_FUNCTION: u64 = 1;
@@ -33,11 +27,6 @@ module ccip::auth {
 
     fun init_module(publisher: &signer) {
         let state_object_signer = &state_object::object_signer();
-
-        let (router_signer, signer_capability) =
-            account::create_resource_account(
-                state_object_signer, b"CHAINLINK_CCIP_ROUTER"
-            );
 
         let allowed_onramps =
             allowlist::new_with_name(publisher, vector[], string::utf8(b"onramps"));
@@ -55,13 +44,10 @@ module ccip::auth {
             state_object_signer,
             AuthState {
                 ownable_state: ownable::new(state_object_signer, @ccip),
-                router_address: signer::address_of(&router_signer),
                 allowed_onramps,
                 allowed_offramps
             }
         );
-
-        move_to(publisher, PendingRouterSignerCapability { signer_capability });
 
         // Register the entrypoint with mcms
         if (@mcms_register_entrypoints != @0x0) {
@@ -69,22 +55,6 @@ module ccip::auth {
                 publisher, string::utf8(b"auth"), McmsCallback {}
             );
         };
-    }
-
-    public fun retrieve_router_signer_cap(
-        caller: &signer
-    ): SignerCapability acquires PendingRouterSignerCapability {
-        assert!(
-            signer::address_of(caller) == @ccip, error::permission_denied(E_NOT_CCIP)
-        );
-        assert!(
-            exists<PendingRouterSignerCapability>(@ccip),
-            error::not_found(E_SIGNER_CAP_NOT_FOUND)
-        );
-
-        let PendingRouterSignerCapability { signer_capability } =
-            move_from<PendingRouterSignerCapability>(@ccip);
-        signer_capability
     }
 
     #[view]

--- a/contracts/ccip/ccip/sources/auth.move
+++ b/contracts/ccip/ccip/sources/auth.move
@@ -29,6 +29,7 @@ module ccip::auth {
     const E_SIGNER_CAP_NOT_FOUND: u64 = 3;
     const E_NOT_ALLOWED_ONRAMP: u64 = 4;
     const E_NOT_ALLOWED_OFFRAMP: u64 = 5;
+    const E_NOT_OWNER_OR_CCIP: u64 = 6;
 
     fun init_module(publisher: &signer) {
         let state_object_signer = &state_object::object_signer();
@@ -112,7 +113,8 @@ module ccip::auth {
         onramps_to_remove: vector<address>
     ) acquires AuthState {
         let state = borrow_state_mut();
-        ownable::assert_only_owner(signer::address_of(caller), &state.ownable_state);
+
+        assert_is_owner_or_ccip(signer::address_of(caller), &state.ownable_state);
 
         allowlist::apply_allowlist_updates(
             &mut state.allowed_onramps,
@@ -127,7 +129,8 @@ module ccip::auth {
         offramps_to_remove: vector<address>
     ) acquires AuthState {
         let state = borrow_state_mut();
-        ownable::assert_only_owner(signer::address_of(caller), &state.ownable_state);
+
+        assert_is_owner_or_ccip(signer::address_of(caller), &state.ownable_state);
 
         allowlist::apply_allowlist_updates(
             &mut state.allowed_offramps,
@@ -142,6 +145,15 @@ module ccip::auth {
 
     inline fun borrow_state_mut(): &mut AuthState {
         borrow_global_mut<AuthState>(state_object::object_address())
+    }
+
+    inline fun assert_is_owner_or_ccip(
+        caller: address, ownable_state: &ownable::OwnableState
+    ) {
+        assert!(
+            caller == @ccip || caller == ownable::owner(ownable_state),
+            error::permission_denied(E_NOT_OWNER_OR_CCIP)
+        );
     }
 
     public fun assert_is_allowed_onramp(caller: address) acquires AuthState {

--- a/contracts/ccip/ccip_offramp/sources/offramp.move
+++ b/contracts/ccip/ccip_offramp/sources/offramp.move
@@ -13,6 +13,7 @@ module ccip_offramp::offramp {
     use std::timestamp;
     use std::vector;
 
+    use ccip::auth;
     use ccip::client;
     use ccip::eth_abi;
     use ccip::fee_quoter;
@@ -250,7 +251,7 @@ module ccip_offramp::offramp {
     }
 
     fun init_module(publisher: &signer) {
-        let (_, state_signer_cap) =
+        let (state_signer, state_signer_cap) =
             account::create_resource_account(publisher, STATE_SEED);
 
         move_to(
@@ -268,6 +269,15 @@ module ccip_offramp::offramp {
                 skipped_report_execution_events: account::new_event_handle(publisher)
             }
         );
+
+        if (@ccip_offramp == @ccip) {
+            // if we're deployed on the same code object, self-register as an allowed offramp.
+            auth::apply_allowed_offramp_updates(
+                publisher,
+                vector[signer::address_of(&state_signer)],
+                vector[]
+            );
+        };
 
         // Register the entrypoint with mcms
         if (@mcms_register_entrypoints != @0x0) {

--- a/contracts/ccip/ccip_onramp/sources/onramp.move
+++ b/contracts/ccip/ccip_onramp/sources/onramp.move
@@ -13,6 +13,7 @@ module ccip_onramp::onramp {
     use std::smart_table::{Self, SmartTable};
     use std::vector;
 
+    use ccip::auth;
     use ccip::eth_abi;
     use ccip::fee_quoter;
     use ccip::internal;
@@ -167,7 +168,7 @@ module ccip_onramp::onramp {
     }
 
     fun init_module(publisher: &signer) {
-        let (_, state_signer_cap) =
+        let (state_signer, state_signer_cap) =
             account::create_resource_account(publisher, STATE_SEED);
 
         move_to(
@@ -183,6 +184,15 @@ module ccip_onramp::onramp {
                 fee_token_withdrawn_events: account::new_event_handle(publisher)
             }
         );
+
+        if (@ccip_onramp == @ccip) {
+            // if we're deployed on the same code object, self-register as an allowed onramp.
+            auth::apply_allowed_onramp_updates(
+                publisher,
+                vector[signer::address_of(&state_signer)],
+                vector[]
+            );
+        };
 
         // Register the entrypoint with mcms
         if (@mcms_register_entrypoints != @0x0) {

--- a/contracts/ccip/ccip_router/sources/router.move
+++ b/contracts/ccip/ccip_router/sources/router.move
@@ -1,6 +1,7 @@
 module ccip_router::router {
     use std::account::{Self, SignerCapability};
     use std::error;
+    use std::event;
     use std::object;
     use std::option::{Self, Option};
     use std::signer;
@@ -8,14 +9,17 @@ module ccip_router::router {
     use std::smart_table::{Self, SmartTable};
     use std::event::EventHandle;
 
-    use ccip::auth;
+    use ccip::ownable;
     use ccip_onramp::onramp;
 
     use mcms::mcms_registry;
     use mcms::bcs_stream;
 
+    const STATE_SEED: vector<u8> = b"CHAINLINK_CCIP_ROUTER";
+
     struct RouterState has key {
-        signer_capability: SignerCapability,
+        state_signer_cap: SignerCapability,
+        ownable_state: ownable::OwnableState,
         on_ramp_versions: SmartTable<u64, vector<u8>>,
         on_ramp_set_events: EventHandle<OnRampSet>
     }
@@ -37,28 +41,30 @@ module ccip_router::router {
     }
 
     fun init_module(publisher: &signer) {
+        let (state_signer, state_signer_cap) =
+            account::create_resource_account(publisher, STATE_SEED);
+
+        move_to(
+            &state_signer,
+            RouterState {
+                state_signer_cap,
+                ownable_state: ownable::new(publisher, @ccip_router),
+                on_ramp_versions: smart_table::new(),
+                on_ramp_set_events: account::new_event_handle(publisher)
+            }
+        );
+
         // Register the entrypoint with mcms
         if (@mcms_register_entrypoints != @0x0) {
             mcms_registry::register_entrypoint(
                 publisher, string::utf8(b"router"), McmsCallback {}
             );
         };
-
-        let signer_capability = auth::retrieve_router_signer_cap(publisher);
-
-        move_to(
-            publisher,
-            RouterState {
-                signer_capability,
-                on_ramp_versions: smart_table::new(),
-                on_ramp_set_events: account::new_event_handle(publisher)
-            }
-        );
     }
 
     #[view]
-    public fun get_state_address(): address acquires RouterState {
-        signer::address_of(&get_signer())
+    public fun get_state_address(): address {
+        get_state_address_internal()
     }
 
     #[view]
@@ -130,15 +136,20 @@ module ccip_router::router {
         extra_args: vector<u8>
     ): vector<u8> acquires RouterState {
         let state = borrow_state();
-        if (!state.on_ramp_versions.contains(dest_chain_selector)) {
-            abort error::invalid_argument(E_UNKNOWN_CHAIN)
-        };
+
+        assert!(
+            state.on_ramp_versions.contains(dest_chain_selector),
+            error::invalid_argument(E_UNKNOWN_CHAIN)
+        );
 
         let on_ramp_version = *state.on_ramp_versions.borrow(dest_chain_selector);
 
+        let state_signer =
+            account::create_signer_with_capability(&state.state_signer_cap);
+
         if (on_ramp_version == vector[1, 6, 0]) {
             onramp::ccip_send(
-                &get_signer(),
+                &state_signer,
                 caller,
                 dest_chain_selector,
                 receiver,
@@ -155,22 +166,23 @@ module ccip_router::router {
         }
     }
 
-    inline fun get_signer(): signer {
-        account::create_signer_with_capability(&borrow_state().signer_capability)
+    inline fun get_state_address_internal(): address {
+        account::create_resource_address(&@ccip_router, STATE_SEED)
     }
 
     inline fun borrow_state(): &RouterState {
-        borrow_global<RouterState>(@ccip_router)
+        borrow_global<RouterState>(get_state_address_internal())
     }
 
     inline fun borrow_state_mut(): &mut RouterState {
-        borrow_global_mut<RouterState>(@ccip)
+        borrow_global_mut<RouterState>(get_state_address_internal())
     }
 
     // ================================================================
     // |                       OnRamp Routing                         |
     // ================================================================
 
+    #[view]
     public fun get_on_ramp_versions(
         dest_chain_selectors: vector<u64>
     ): vector<vector<u8>> acquires RouterState {
@@ -180,26 +192,59 @@ module ccip_router::router {
         }))
     }
 
-    public fun set_on_ramp_versions(
+    public entry fun set_on_ramp_versions(
         caller: &signer,
         dest_chain_selectors: vector<u64>,
         on_ramp_versions: vector<vector<u8>>
     ) acquires RouterState {
-        auth::assert_only_owner(signer::address_of(caller));
-
         let state = borrow_state_mut();
+
+        ownable::assert_only_owner(signer::address_of(caller), &state.ownable_state);
 
         dest_chain_selectors.zip(
             on_ramp_versions,
             |dest_chain_selector, on_ramp_version| {
-                assert!(
-                    on_ramp_version.length() == 3,
-                    error::invalid_argument(E_INVALID_ON_RAMP_VERSION)
-                );
+                let version_len = on_ramp_version.length();
+                if (version_len == 0) {
+                    if (state.on_ramp_versions.contains(dest_chain_selector)) {
+                        state.on_ramp_versions.remove(dest_chain_selector);
+                    };
+                } else {
+                    assert!(
+                        version_len == 3,
+                        error::invalid_argument(E_INVALID_ON_RAMP_VERSION)
+                    );
+                    state.on_ramp_versions.upsert(dest_chain_selector, on_ramp_version);
+                };
 
-                state.on_ramp_versions.upsert(dest_chain_selector, on_ramp_version);
+                event::emit_event(
+                    &mut state.on_ramp_set_events,
+                    OnRampSet { dest_chain_selector, on_ramp_version }
+                );
+                event::emit(OnRampSet { dest_chain_selector, on_ramp_version });
             }
         );
+    }
+
+    //
+    // ccip::ownable functions
+    //
+
+    #[view]
+    public fun owner(): address acquires RouterState {
+        ownable::owner(&borrow_state().ownable_state)
+    }
+
+    public entry fun transfer_ownership(caller: &signer, to: address) acquires RouterState {
+        let state = borrow_state_mut();
+        ownable::transfer_ownership(
+            signer::address_of(caller), &mut state.ownable_state, to
+        )
+    }
+
+    public entry fun accept_ownership(caller: &signer) acquires RouterState {
+        let state = borrow_state_mut();
+        ownable::accept_ownership(signer::address_of(caller), &mut state.ownable_state)
     }
 
     // ================================================================


### PR DESCRIPTION
- automatically register onramp/offramp if deployed on the same object as ccip
- make setting onramps an entry function
- actually emit the defined event
- don't use ccip::auth which wouldn't work for test router, check the actual code object for ownership
- create signer cap independently
