### PR TITLE
MCMS entrypoint: fee_quoter::update_prices

### DIFF
--- a/bindings/ccip_onramp/ccip_onramp.go
+++ b/bindings/ccip_onramp/ccip_onramp.go
@@ -39,7 +39,7 @@ var FunctionInfo = bind.MustParseFunctionInfo(
 func Compile(ccipAddress, mcmsAddress aptos.AccountAddress, registerMCMSEntrypoints bool) (compile.CompiledPackage, error) {
 	namedAddresses := map[string]aptos.AccountAddress{
 		"ccip":                      ccipAddress,
-		"ccip_onramp":              ccipAddress,
+		"ccip_onramp":               ccipAddress,
 		"mcms":                      mcmsAddress,
 		"mcms_register_entrypoints": aptos.AccountZero,
 	}
@@ -53,7 +53,7 @@ func Compile(ccipAddress, mcmsAddress aptos.AccountAddress, registerMCMSEntrypoi
 func Bind(address aptos.AccountAddress, client aptos.AptosRpcClient) CCIPOnramp {
 	return CCIPOnrampContract{
 		address: address,
-		onramp: module_onramp.NewOnramp(address, client),
+		onramp:  module_onramp.NewOnramp(address, client),
 	}
 }
 

--- a/contracts/ccip/ccip/sources/fee_quoter.move
+++ b/contracts/ccip/ccip/sources/fee_quoter.move
@@ -1438,6 +1438,31 @@ module ccip::fee_quoter {
                 add_is_enabled,
                 remove_tokens
             )
+        } else if (function_bytes == b"update_prices") {
+            let source_tokens =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_address(stream)
+                );
+            let source_usd_per_token =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u256(stream)
+                );
+            let gas_dest_chain_selectors =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u64(stream)
+                );
+            let gas_usd_per_unit_gas =
+                bcs_stream::deserialize_vector(
+                    &mut stream, |stream| bcs_stream::deserialize_u256(stream)
+                );
+            bcs_stream::assert_is_consumed(&stream);
+            update_prices(
+                &caller,
+                source_tokens,
+                source_usd_per_token,
+                gas_dest_chain_selectors,
+                gas_usd_per_unit_gas
+            )
         } else if (function_bytes == b"apply_premium_multiplier_wei_per_eth_updates") {
             let tokens =
                 bcs_stream::deserialize_vector(


### PR DESCRIPTION
Adding `fee_quoter::update_prices` to the methods allowed to be called via MCMS.

MCMS needs to be set as an allowed offramp using `auth::apply_allowed_offramp_updates` before being able to call it.