### PR TITLE
Ownable functions take in signer

### DIFF
--- a/contracts/ccip/ccip/sources/auth.move
+++ b/contracts/ccip/ccip/sources/auth.move
@@ -155,14 +155,12 @@ module ccip::auth {
 
     public entry fun transfer_ownership(caller: &signer, to: address) acquires AuthState {
         let state = borrow_state_mut();
-        ownable::transfer_ownership(
-            signer::address_of(caller), &mut state.ownable_state, to
-        )
+        ownable::transfer_ownership(caller, &mut state.ownable_state, to)
     }
 
     public entry fun accept_ownership(caller: &signer) acquires AuthState {
         let state = borrow_state_mut();
-        ownable::accept_ownership(signer::address_of(caller), &mut state.ownable_state)
+        ownable::accept_ownership(caller, &mut state.ownable_state)
     }
 
     public entry fun execute_ownership_transfer(

--- a/contracts/ccip/ccip/sources/ownable.move
+++ b/contracts/ccip/ccip/sources/ownable.move
@@ -80,28 +80,44 @@ module ccip::ownable {
         owner_internal(state)
     }
 
+    public fun pending_transfer_from(state: &OwnableState): Option<address> {
+        state.pending_transfer.map_ref(|pending_transfer| pending_transfer.from)
+    }
+
+    public fun pending_transfer_to(state: &OwnableState): Option<address> {
+        state.pending_transfer.map_ref(|pending_transfer| pending_transfer.to)
+    }
+
+    public fun pending_transfer_accepted(state: &OwnableState): Option<bool> {
+        state.pending_transfer.map_ref(|pending_transfer| pending_transfer.accepted)
+    }
+
     inline fun owner_internal(state: &OwnableState): address {
         object::owner(state.target_object)
     }
 
     public fun transfer_ownership(
-        caller: address, state: &mut OwnableState, to: address
+        caller: &signer, state: &mut OwnableState, to: address
     ) {
-        assert_only_owner_internal(caller, state);
-        assert!(caller != to, error::invalid_argument(E_CANNOT_TRANSFER_TO_SELF));
+        let caller_address = signer::address_of(caller);
+        assert_only_owner_internal(caller_address, state);
+        assert!(caller_address != to, error::invalid_argument(E_CANNOT_TRANSFER_TO_SELF));
 
         state.pending_transfer = option::some(
-            PendingTransfer { from: caller, to, accepted: false }
+            PendingTransfer { from: caller_address, to, accepted: false }
         );
 
-        event::emit(OwnershipTransferRequested { from: caller, to });
+        event::emit(OwnershipTransferRequested { from: caller_address, to });
         event::emit_event(
             &mut state.ownership_transfer_requested_events,
-            OwnershipTransferRequested { from: caller, to }
+            OwnershipTransferRequested { from: caller_address, to }
         );
     }
 
-    public fun accept_ownership(caller: address, state: &mut OwnableState) {
+    public fun accept_ownership(
+        caller: &signer, state: &mut OwnableState
+    ) {
+        let caller_address = signer::address_of(caller);
         assert!(
             state.pending_transfer.is_some(),
             error::permission_denied(E_NO_PENDING_TRANSFER)
@@ -117,7 +133,7 @@ module ccip::ownable {
             error::permission_denied(E_OWNER_CHANGED)
         );
         assert!(
-            pending_transfer.to == caller,
+            pending_transfer.to == caller_address,
             error::permission_denied(E_MUST_BE_PROPOSED_OWNER)
         );
         assert!(
@@ -127,10 +143,12 @@ module ccip::ownable {
 
         pending_transfer.accepted = true;
 
-        event::emit(OwnershipTransferAccepted { from: pending_transfer.from, to: caller });
+        event::emit(
+            OwnershipTransferAccepted { from: pending_transfer.from, to: caller_address }
+        );
         event::emit_event(
             &mut state.ownership_transfer_accepted_events,
-            OwnershipTransferAccepted { from: pending_transfer.from, to: caller }
+            OwnershipTransferAccepted { from: pending_transfer.from, to: caller_address }
         );
     }
 
@@ -178,5 +196,19 @@ module ccip::ownable {
             caller == owner_internal(state),
             error::permission_denied(E_ONLY_CALLABLE_BY_OWNER)
         );
+    }
+
+    public fun destroy(state: OwnableState) {
+        let OwnableState {
+            target_object: _,
+            pending_transfer: _,
+            ownership_transfer_requested_events,
+            ownership_transfer_accepted_events,
+            ownership_transferred_events
+        } = state;
+
+        event::destroy_handle(ownership_transfer_requested_events);
+        event::destroy_handle(ownership_transfer_accepted_events);
+        event::destroy_handle(ownership_transferred_events);
     }
 }

--- a/contracts/ccip/ccip/tests/ownable_test.move
+++ b/contracts/ccip/ccip/tests/ownable_test.move
@@ -1,0 +1,238 @@
+#[test_only]
+module ccip::ownable_test {
+    use std::signer;
+    use std::object::{Self, Object, ObjectCore};
+    use std::account;
+    use std::option;
+    use std::event;
+
+    use ccip::ownable::{
+        Self,
+        OwnershipTransferRequested,
+        OwnershipTransferAccepted,
+        OwnershipTransferred
+    };
+
+    const OWNER_ADDRESS: address = @0x123;
+    const NEW_OWNER_ADDRESS: address = @0x456;
+
+    fun setup(): (signer, signer, Object<ObjectCore>, ownable::OwnableState) {
+        let owner = account::create_account_for_test(OWNER_ADDRESS);
+        let new_owner = account::create_account_for_test(NEW_OWNER_ADDRESS);
+
+        let constructor_ref = &object::create_named_object(&owner, b"TestObject");
+        let test_object =
+            object::object_from_constructor_ref<ObjectCore>(constructor_ref);
+        let object_address = object::object_address(&test_object);
+
+        let ownable_state = ownable::new(&owner, object_address);
+
+        (owner, new_owner, test_object, ownable_state)
+    }
+
+    #[test]
+    fun test_initialization() {
+        let (owner, _new_owner, _test_object, ownable_state) = setup();
+
+        let initial_owner = ownable::owner(&ownable_state);
+        assert!(initial_owner == signer::address_of(&owner));
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    fun test_transfer_ownership_request() {
+        let (owner, new_owner, _test_object, ownable_state) = setup();
+
+        ownable::transfer_ownership(
+            &owner, &mut ownable_state, signer::address_of(&new_owner)
+        );
+
+        let current_owner = ownable::owner(&ownable_state);
+        assert!(current_owner == signer::address_of(&owner));
+
+        let pending_transfer_from = ownable::pending_transfer_from(&ownable_state);
+        let pending_transfer_to = ownable::pending_transfer_to(&ownable_state);
+        let pending_transfer_accepted =
+            ownable::pending_transfer_accepted(&ownable_state);
+        assert!(pending_transfer_from == option::some(signer::address_of(&owner)));
+        assert!(pending_transfer_to == option::some(signer::address_of(&new_owner)));
+        assert!(pending_transfer_accepted == option::some(false));
+
+        assert!(
+            event::emitted_events<OwnershipTransferRequested>().length() == 1
+        );
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    fun test_accept_ownership() {
+        let (owner, new_owner, _test_object, ownable_state) = setup();
+
+        ownable::transfer_ownership(
+            &owner, &mut ownable_state, signer::address_of(&new_owner)
+        );
+
+        ownable::accept_ownership(&new_owner, &mut ownable_state);
+
+        let current_owner = ownable::owner(&ownable_state);
+        assert!(current_owner == signer::address_of(&owner));
+
+        let pending_transfer_from = ownable::pending_transfer_from(&ownable_state);
+        let pending_transfer_to = ownable::pending_transfer_to(&ownable_state);
+        let pending_transfer_accepted =
+            ownable::pending_transfer_accepted(&ownable_state);
+        assert!(pending_transfer_from == option::some(signer::address_of(&owner)));
+        assert!(pending_transfer_to == option::some(signer::address_of(&new_owner)));
+        assert!(pending_transfer_accepted == option::some(true));
+
+        assert!(
+            event::emitted_events<OwnershipTransferAccepted>().length() == 1
+        );
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    fun test_complete_ownership_transfer() {
+        let (owner, new_owner, _test_object, ownable_state) = setup();
+        let new_owner_addr = signer::address_of(&new_owner);
+
+        ownable::transfer_ownership(&owner, &mut ownable_state, new_owner_addr);
+        ownable::accept_ownership(&new_owner, &mut ownable_state);
+        ownable::execute_ownership_transfer(&owner, &mut ownable_state, new_owner_addr);
+
+        let updated_owner = ownable::owner(&ownable_state);
+        assert!(updated_owner == new_owner_addr);
+
+        let pending_transfer_from = ownable::pending_transfer_from(&ownable_state);
+        let pending_transfer_to = ownable::pending_transfer_to(&ownable_state);
+        let pending_transfer_accepted =
+            ownable::pending_transfer_accepted(&ownable_state);
+        assert!(pending_transfer_from == option::none());
+        assert!(pending_transfer_to == option::none());
+        assert!(pending_transfer_accepted == option::none());
+
+        assert!(
+            event::emitted_events<OwnershipTransferred>().length() == 1
+        );
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 327683, location = ccip::ownable)]
+    // E_ONLY_CALLABLE_BY_OWNER
+    fun test_only_owner_can_transfer() {
+        let (owner, new_owner, _test_object, ownable_state) = setup();
+
+        ownable::transfer_ownership(
+            &new_owner, &mut ownable_state, signer::address_of(&owner)
+        );
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 65538, location = ccip::ownable)]
+    // E_CANNOT_TRANSFER_TO_SELF
+    fun test_cannot_transfer_to_self() {
+        let (owner, _new_owner, _test_object, ownable_state) = setup();
+
+        ownable::transfer_ownership(
+            &owner, &mut ownable_state, signer::address_of(&owner)
+        );
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 327681, location = ccip::ownable)]
+    // E_MUST_BE_PROPOSED_OWNER
+    fun test_only_proposed_can_accept() {
+        let (owner, new_owner, _test_object, ownable_state) = setup();
+
+        let different_owner = @0x789;
+        ownable::transfer_ownership(&owner, &mut ownable_state, different_owner);
+
+        ownable::accept_ownership(&new_owner, &mut ownable_state);
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 327686, location = ccip::ownable)]
+    // E_NO_PENDING_TRANSFER
+    fun test_accept_without_pending_transfer() {
+        let (_owner, new_owner, _test_object, ownable_state) = setup();
+
+        ownable::accept_ownership(&new_owner, &mut ownable_state);
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 196615, location = ccip::ownable)]
+    // E_TRANSFER_NOT_ACCEPTED
+    fun test_execute_without_accept() {
+        let (owner, new_owner, _test_object, ownable_state) = setup();
+        let new_owner_addr = signer::address_of(&new_owner);
+
+        ownable::transfer_ownership(&owner, &mut ownable_state, new_owner_addr);
+
+        ownable::execute_ownership_transfer(&owner, &mut ownable_state, new_owner_addr);
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 327684, location = ccip::ownable)]
+    // E_PROPOSED_OWNER_MISMATCH
+    fun test_execute_with_wrong_address() {
+        let (owner, new_owner, _test_object, ownable_state) = setup();
+        let new_owner_addr = signer::address_of(&new_owner);
+
+        ownable::transfer_ownership(&owner, &mut ownable_state, new_owner_addr);
+        ownable::accept_ownership(&new_owner, &mut ownable_state);
+        ownable::execute_ownership_transfer(&owner, &mut ownable_state, @0x789); // Wrong address
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 196616, location = ccip::ownable)]
+    // E_TRANSFER_ALREADY_ACCEPTED
+    fun test_accept_twice() {
+        let (owner, new_owner, _test_object, ownable_state) = setup();
+
+        ownable::transfer_ownership(
+            &owner, &mut ownable_state, signer::address_of(&new_owner)
+        );
+
+        ownable::accept_ownership(&new_owner, &mut ownable_state);
+
+        ownable::accept_ownership(&new_owner, &mut ownable_state);
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 327685, location = ccip::ownable)]
+    // E_OWNER_CHANGED
+    fun test_owner_changed_directly() {
+        let (owner, new_owner, test_object, ownable_state) = setup();
+        let direct_recipient = account::create_account_for_test(@0x789);
+
+        let proposed_owner = signer::address_of(&new_owner);
+        ownable::transfer_ownership(&owner, &mut ownable_state, proposed_owner);
+
+        // Change owner directly with object::transfer
+        object::transfer(&owner, test_object, signer::address_of(&direct_recipient));
+
+        // Try to accept the ownership - should fail since owner changed directly
+        ownable::accept_ownership(&new_owner, &mut ownable_state);
+
+        ownable::destroy(ownable_state);
+    }
+}

--- a/contracts/ccip/ccip_offramp/sources/ocr3_base.move
+++ b/contracts/ccip/ccip_offramp/sources/ocr3_base.move
@@ -4,6 +4,7 @@ module ccip_offramp::ocr3_base {
     use std::bit_vector;
     use std::chain_id;
     use std::ed25519;
+    use std::signer;
     use std::error;
     use std::event::{Self, EventHandle};
     use std::table::{Self, Table};
@@ -101,7 +102,7 @@ module ccip_offramp::ocr3_base {
     }
 
     public fun set_ocr3_config(
-        caller: address,
+        caller: &signer,
         ocr3_state: &mut OCR3BaseState,
         config_digest: vector<u8>,
         ocr_plugin_type: u8,
@@ -110,7 +111,8 @@ module ccip_offramp::ocr3_base {
         signers: vector<vector<u8>>,
         transmitters: vector<address>
     ) {
-        auth::assert_only_owner(caller);
+        let caller_address = signer::address_of(caller);
+        auth::assert_only_owner(caller_address);
         assert!(big_f != 0, error::invalid_argument(E_BIG_F_MUST_BE_POSITIVE));
 
         let ocr_config =

--- a/contracts/ccip/ccip_offramp/sources/offramp.move
+++ b/contracts/ccip/ccip_offramp/sources/offramp.move
@@ -635,7 +635,9 @@ module ccip_offramp::offramp {
         let merkle_root_values = vector[];
         blessed_merkle_roots.for_each_ref(|merkle_root| {
             let merkle_root: &MerkleRoot = merkle_root;
-            merkle_root_source_chains_selector.push_back(merkle_root.source_chain_selector);
+            merkle_root_source_chains_selector.push_back(
+                merkle_root.source_chain_selector
+            );
             merkle_root_min_seq_nrs.push_back(merkle_root.min_seq_nr);
             merkle_root_max_seq_nrs.push_back(merkle_root.max_seq_nr);
             merkle_root_values.push_back(merkle_root.merkle_root);
@@ -1241,14 +1243,12 @@ module ccip_offramp::offramp {
 
     public entry fun transfer_ownership(caller: &signer, to: address) acquires OffRampState {
         let state = borrow_state_mut();
-        ownable::transfer_ownership(
-            signer::address_of(caller), &mut state.ownable_state, to
-        )
+        ownable::transfer_ownership(caller, &mut state.ownable_state, to)
     }
 
     public entry fun accept_ownership(caller: &signer) acquires OffRampState {
         let state = borrow_state_mut();
-        ownable::accept_ownership(signer::address_of(caller), &mut state.ownable_state)
+        ownable::accept_ownership(caller, &mut state.ownable_state)
     }
 
     public entry fun execute_ownership_transfer(
@@ -1273,7 +1273,7 @@ module ccip_offramp::offramp {
     ) acquires OffRampState {
         let state = borrow_state_mut();
         ocr3_base::set_ocr3_config(
-            signer::address_of(caller),
+            caller,
             &mut state.ocr3_base_state,
             config_digest,
             ocr_plugin_type,

--- a/contracts/ccip/ccip_onramp/sources/onramp.move
+++ b/contracts/ccip/ccip_onramp/sources/onramp.move
@@ -935,14 +935,12 @@ module ccip_onramp::onramp {
 
     public entry fun transfer_ownership(caller: &signer, to: address) acquires OnRampState {
         let state = borrow_state_mut();
-        ownable::transfer_ownership(
-            signer::address_of(caller), &mut state.ownable_state, to
-        )
+        ownable::transfer_ownership(caller, &mut state.ownable_state, to)
     }
 
     public entry fun accept_ownership(caller: &signer) acquires OnRampState {
         let state = borrow_state_mut();
-        ownable::accept_ownership(signer::address_of(caller), &mut state.ownable_state)
+        ownable::accept_ownership(caller, &mut state.ownable_state)
     }
 
     public entry fun execute_ownership_transfer(

--- a/contracts/ccip/ccip_ping_pong_demo/sources/ping_pong_demo.move
+++ b/contracts/ccip/ccip_ping_pong_demo/sources/ping_pong_demo.move
@@ -251,13 +251,11 @@ module ccip_ping_pong_demo::ping_pong_demo {
 
     public entry fun transfer_ownership(caller: &signer, to: address) acquires PingPongDemo {
         let state = borrow_state_mut();
-        ownable::transfer_ownership(
-            signer::address_of(caller), &mut state.ownable_state, to
-        )
+        ownable::transfer_ownership(caller, &mut state.ownable_state, to)
     }
 
     public entry fun accept_ownership(caller: &signer) acquires PingPongDemo {
         let state = borrow_state_mut();
-        ownable::accept_ownership(signer::address_of(caller), &mut state.ownable_state)
+        ownable::accept_ownership(caller, &mut state.ownable_state)
     }
 }

--- a/contracts/ccip/ccip_router/sources/router.move
+++ b/contracts/ccip/ccip_router/sources/router.move
@@ -299,14 +299,12 @@ module ccip_router::router {
 
     public entry fun transfer_ownership(caller: &signer, to: address) acquires RouterState {
         let state = borrow_state_mut();
-        ownable::transfer_ownership(
-            signer::address_of(caller), &mut state.ownable_state, to
-        )
+        ownable::transfer_ownership(caller, &mut state.ownable_state, to)
     }
 
     public entry fun accept_ownership(caller: &signer) acquires RouterState {
         let state = borrow_state_mut();
-        ownable::accept_ownership(signer::address_of(caller), &mut state.ownable_state)
+        ownable::accept_ownership(caller, &mut state.ownable_state)
     }
 
     public entry fun execute_ownership_transfer(

--- a/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
@@ -461,14 +461,12 @@ module burn_mint_token_pool::burn_mint_token_pool {
 
     public entry fun transfer_ownership(caller: &signer, to: address) acquires BurnMintTokenPoolState {
         let pool = borrow_pool_mut();
-        ownable::transfer_ownership(
-            signer::address_of(caller), &mut pool.ownable_state, to
-        )
+        ownable::transfer_ownership(caller, &mut pool.ownable_state, to)
     }
 
     public entry fun accept_ownership(caller: &signer) acquires BurnMintTokenPoolState {
         let pool = borrow_pool_mut();
-        ownable::accept_ownership(signer::address_of(caller), &mut pool.ownable_state)
+        ownable::accept_ownership(caller, &mut pool.ownable_state)
     }
 
     // ================================================================

--- a/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
@@ -468,14 +468,12 @@ module lock_release_token_pool::lock_release_token_pool {
         caller: &signer, to: address
     ) acquires LockReleaseTokenPoolState {
         let pool = borrow_pool_mut();
-        ownable::transfer_ownership(
-            signer::address_of(caller), &mut pool.ownable_state, to
-        )
+        ownable::transfer_ownership(caller, &mut pool.ownable_state, to)
     }
 
     public entry fun accept_ownership(caller: &signer) acquires LockReleaseTokenPoolState {
         let pool = borrow_pool_mut();
-        ownable::accept_ownership(signer::address_of(caller), &mut pool.ownable_state)
+        ownable::accept_ownership(caller, &mut pool.ownable_state)
     }
 
     // ================================================================

--- a/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
@@ -660,14 +660,12 @@ module usdc_token_pool::usdc_token_pool {
 
     public entry fun transfer_ownership(caller: &signer, to: address) acquires USDCTokenPoolState {
         let pool = borrow_pool_mut();
-        ownable::transfer_ownership(
-            signer::address_of(caller), &mut pool.ownable_state, to
-        )
+        ownable::transfer_ownership(caller, &mut pool.ownable_state, to)
     }
 
     public entry fun accept_ownership(caller: &signer) acquires USDCTokenPoolState {
         let pool = borrow_pool_mut();
-        ownable::accept_ownership(signer::address_of(caller), &mut pool.ownable_state)
+        ownable::accept_ownership(caller, &mut pool.ownable_state)
     }
 
     // ================================================================

--- a/contracts/link-token/sources/link_token.move
+++ b/contracts/link-token/sources/link_token.move
@@ -348,7 +348,7 @@ module link::link_token {
     /// So we only extract the ownable state from the token state
     public entry fun transfer_ownership(caller: &signer, to: address) acquires TokenState {
         ownable::transfer_ownership(
-            signer::address_of(caller),
+            caller,
             &mut TokenState[token_state_address_internal()].ownable_state,
             to
         )
@@ -358,7 +358,7 @@ module link::link_token {
     /// that the caller is the pending owner
     public entry fun accept_ownership(caller: &signer) acquires TokenState {
         ownable::accept_ownership(
-            signer::address_of(caller),
+            caller,
             &mut TokenState[token_state_address_internal()].ownable_state
         )
     }

--- a/contracts/link-token/sources/ownable.move
+++ b/contracts/link-token/sources/ownable.move
@@ -80,28 +80,44 @@ module link::ownable {
         owner_internal(state)
     }
 
+    public fun pending_transfer_from(state: &OwnableState): Option<address> {
+        state.pending_transfer.map_ref(|pending_transfer| pending_transfer.from)
+    }
+
+    public fun pending_transfer_to(state: &OwnableState): Option<address> {
+        state.pending_transfer.map_ref(|pending_transfer| pending_transfer.to)
+    }
+
+    public fun pending_transfer_accepted(state: &OwnableState): Option<bool> {
+        state.pending_transfer.map_ref(|pending_transfer| pending_transfer.accepted)
+    }
+
     inline fun owner_internal(state: &OwnableState): address {
         object::owner(state.target_object)
     }
 
     public fun transfer_ownership(
-        caller: address, state: &mut OwnableState, to: address
+        caller: &signer, state: &mut OwnableState, to: address
     ) {
-        assert_only_owner_internal(caller, state);
-        assert!(caller != to, error::invalid_argument(E_CANNOT_TRANSFER_TO_SELF));
+        let caller_address = signer::address_of(caller);
+        assert_only_owner_internal(caller_address, state);
+        assert!(caller_address != to, error::invalid_argument(E_CANNOT_TRANSFER_TO_SELF));
 
         state.pending_transfer = option::some(
-            PendingTransfer { from: caller, to, accepted: false }
+            PendingTransfer { from: caller_address, to, accepted: false }
         );
 
-        event::emit(OwnershipTransferRequested { from: caller, to });
+        event::emit(OwnershipTransferRequested { from: caller_address, to });
         event::emit_event(
             &mut state.ownership_transfer_requested_events,
-            OwnershipTransferRequested { from: caller, to }
+            OwnershipTransferRequested { from: caller_address, to }
         );
     }
 
-    public fun accept_ownership(caller: address, state: &mut OwnableState) {
+    public fun accept_ownership(
+        caller: &signer, state: &mut OwnableState
+    ) {
+        let caller_address = signer::address_of(caller);
         assert!(
             state.pending_transfer.is_some(),
             error::permission_denied(E_NO_PENDING_TRANSFER)
@@ -117,7 +133,7 @@ module link::ownable {
             error::permission_denied(E_OWNER_CHANGED)
         );
         assert!(
-            pending_transfer.to == caller,
+            pending_transfer.to == caller_address,
             error::permission_denied(E_MUST_BE_PROPOSED_OWNER)
         );
         assert!(
@@ -127,10 +143,12 @@ module link::ownable {
 
         pending_transfer.accepted = true;
 
-        event::emit(OwnershipTransferAccepted { from: pending_transfer.from, to: caller });
+        event::emit(
+            OwnershipTransferAccepted { from: pending_transfer.from, to: caller_address }
+        );
         event::emit_event(
             &mut state.ownership_transfer_accepted_events,
-            OwnershipTransferAccepted { from: pending_transfer.from, to: caller }
+            OwnershipTransferAccepted { from: pending_transfer.from, to: caller_address }
         );
     }
 
@@ -178,5 +196,19 @@ module link::ownable {
             caller == owner_internal(state),
             error::permission_denied(E_ONLY_CALLABLE_BY_OWNER)
         );
+    }
+
+    public fun destroy(state: OwnableState) {
+        let OwnableState {
+            target_object: _,
+            pending_transfer: _,
+            ownership_transfer_requested_events,
+            ownership_transfer_accepted_events,
+            ownership_transferred_events
+        } = state;
+
+        event::destroy_handle(ownership_transfer_requested_events);
+        event::destroy_handle(ownership_transfer_accepted_events);
+        event::destroy_handle(ownership_transferred_events);
     }
 }

--- a/contracts/link-token/tests/ownable_test.move
+++ b/contracts/link-token/tests/ownable_test.move
@@ -1,0 +1,238 @@
+#[test_only]
+module link::ownable_test {
+    use std::signer;
+    use std::object::{Self, Object, ObjectCore};
+    use std::account;
+    use std::option;
+    use std::event;
+
+    use link::ownable::{
+        Self,
+        OwnershipTransferRequested,
+        OwnershipTransferAccepted,
+        OwnershipTransferred
+    };
+
+    const OWNER_ADDRESS: address = @0x123;
+    const NEW_OWNER_ADDRESS: address = @0x456;
+
+    fun setup(): (signer, signer, Object<ObjectCore>, ownable::OwnableState) {
+        let owner = account::create_account_for_test(OWNER_ADDRESS);
+        let new_owner = account::create_account_for_test(NEW_OWNER_ADDRESS);
+
+        let constructor_ref = &object::create_named_object(&owner, b"TestObject");
+        let test_object =
+            object::object_from_constructor_ref<ObjectCore>(constructor_ref);
+        let object_address = object::object_address(&test_object);
+
+        let ownable_state = ownable::new(&owner, object_address);
+
+        (owner, new_owner, test_object, ownable_state)
+    }
+
+    #[test]
+    fun test_initialization() {
+        let (owner, _new_owner, _test_object, ownable_state) = setup();
+
+        let initial_owner = ownable::owner(&ownable_state);
+        assert!(initial_owner == signer::address_of(&owner));
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    fun test_transfer_ownership_request() {
+        let (owner, new_owner, _test_object, ownable_state) = setup();
+
+        ownable::transfer_ownership(
+            &owner, &mut ownable_state, signer::address_of(&new_owner)
+        );
+
+        let current_owner = ownable::owner(&ownable_state);
+        assert!(current_owner == signer::address_of(&owner));
+
+        let pending_transfer_from = ownable::pending_transfer_from(&ownable_state);
+        let pending_transfer_to = ownable::pending_transfer_to(&ownable_state);
+        let pending_transfer_accepted =
+            ownable::pending_transfer_accepted(&ownable_state);
+        assert!(pending_transfer_from == option::some(signer::address_of(&owner)));
+        assert!(pending_transfer_to == option::some(signer::address_of(&new_owner)));
+        assert!(pending_transfer_accepted == option::some(false));
+
+        assert!(
+            event::emitted_events<OwnershipTransferRequested>().length() == 1
+        );
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    fun test_accept_ownership() {
+        let (owner, new_owner, _test_object, ownable_state) = setup();
+
+        ownable::transfer_ownership(
+            &owner, &mut ownable_state, signer::address_of(&new_owner)
+        );
+
+        ownable::accept_ownership(&new_owner, &mut ownable_state);
+
+        let current_owner = ownable::owner(&ownable_state);
+        assert!(current_owner == signer::address_of(&owner));
+
+        let pending_transfer_from = ownable::pending_transfer_from(&ownable_state);
+        let pending_transfer_to = ownable::pending_transfer_to(&ownable_state);
+        let pending_transfer_accepted =
+            ownable::pending_transfer_accepted(&ownable_state);
+        assert!(pending_transfer_from == option::some(signer::address_of(&owner)));
+        assert!(pending_transfer_to == option::some(signer::address_of(&new_owner)));
+        assert!(pending_transfer_accepted == option::some(true));
+
+        assert!(
+            event::emitted_events<OwnershipTransferAccepted>().length() == 1
+        );
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    fun test_complete_ownership_transfer() {
+        let (owner, new_owner, _test_object, ownable_state) = setup();
+        let new_owner_addr = signer::address_of(&new_owner);
+
+        ownable::transfer_ownership(&owner, &mut ownable_state, new_owner_addr);
+        ownable::accept_ownership(&new_owner, &mut ownable_state);
+        ownable::execute_ownership_transfer(&owner, &mut ownable_state, new_owner_addr);
+
+        let updated_owner = ownable::owner(&ownable_state);
+        assert!(updated_owner == new_owner_addr);
+
+        let pending_transfer_from = ownable::pending_transfer_from(&ownable_state);
+        let pending_transfer_to = ownable::pending_transfer_to(&ownable_state);
+        let pending_transfer_accepted =
+            ownable::pending_transfer_accepted(&ownable_state);
+        assert!(pending_transfer_from == option::none());
+        assert!(pending_transfer_to == option::none());
+        assert!(pending_transfer_accepted == option::none());
+
+        assert!(
+            event::emitted_events<OwnershipTransferred>().length() == 1
+        );
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 327683, location = link::ownable)]
+    // E_ONLY_CALLABLE_BY_OWNER
+    fun test_only_owner_can_transfer() {
+        let (owner, new_owner, _test_object, ownable_state) = setup();
+
+        ownable::transfer_ownership(
+            &new_owner, &mut ownable_state, signer::address_of(&owner)
+        );
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 65538, location = link::ownable)]
+    // E_CANNOT_TRANSFER_TO_SELF
+    fun test_cannot_transfer_to_self() {
+        let (owner, _new_owner, _test_object, ownable_state) = setup();
+
+        ownable::transfer_ownership(
+            &owner, &mut ownable_state, signer::address_of(&owner)
+        );
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 327681, location = link::ownable)]
+    // E_MUST_BE_PROPOSED_OWNER
+    fun test_only_proposed_can_accept() {
+        let (owner, new_owner, _test_object, ownable_state) = setup();
+
+        let different_owner = @0x789;
+        ownable::transfer_ownership(&owner, &mut ownable_state, different_owner);
+
+        ownable::accept_ownership(&new_owner, &mut ownable_state);
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 327686, location = link::ownable)]
+    // E_NO_PENDING_TRANSFER
+    fun test_accept_without_pending_transfer() {
+        let (_owner, new_owner, _test_object, ownable_state) = setup();
+
+        ownable::accept_ownership(&new_owner, &mut ownable_state);
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 196615, location = link::ownable)]
+    // E_TRANSFER_NOT_ACCEPTED
+    fun test_execute_without_accept() {
+        let (owner, new_owner, _test_object, ownable_state) = setup();
+        let new_owner_addr = signer::address_of(&new_owner);
+
+        ownable::transfer_ownership(&owner, &mut ownable_state, new_owner_addr);
+
+        ownable::execute_ownership_transfer(&owner, &mut ownable_state, new_owner_addr);
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 327684, location = link::ownable)]
+    // E_PROPOSED_OWNER_MISMATCH
+    fun test_execute_with_wrong_address() {
+        let (owner, new_owner, _test_object, ownable_state) = setup();
+        let new_owner_addr = signer::address_of(&new_owner);
+
+        ownable::transfer_ownership(&owner, &mut ownable_state, new_owner_addr);
+        ownable::accept_ownership(&new_owner, &mut ownable_state);
+        ownable::execute_ownership_transfer(&owner, &mut ownable_state, @0x789); // Wrong address
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 196616, location = link::ownable)]
+    // E_TRANSFER_ALREADY_ACCEPTED
+    fun test_accept_twice() {
+        let (owner, new_owner, _test_object, ownable_state) = setup();
+
+        ownable::transfer_ownership(
+            &owner, &mut ownable_state, signer::address_of(&new_owner)
+        );
+
+        ownable::accept_ownership(&new_owner, &mut ownable_state);
+
+        ownable::accept_ownership(&new_owner, &mut ownable_state);
+
+        ownable::destroy(ownable_state);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 327685, location = link::ownable)]
+    // E_OWNER_CHANGED
+    fun test_owner_changed_directly() {
+        let (owner, new_owner, test_object, ownable_state) = setup();
+        let direct_recipient = account::create_account_for_test(@0x789);
+
+        let proposed_owner = signer::address_of(&new_owner);
+        ownable::transfer_ownership(&owner, &mut ownable_state, proposed_owner);
+
+        // Change owner directly with object::transfer
+        object::transfer(&owner, test_object, signer::address_of(&direct_recipient));
+
+        // Try to accept the ownership - should fail since owner changed directly
+        ownable::accept_ownership(&new_owner, &mut ownable_state);
+
+        ownable::destroy(ownable_state);
+    }
+}


### PR DESCRIPTION
## Description
Ownable functions take in signer

Changed link token usage of ownable to.

## CCIP package Tests

```
Module 0000000000000000000000000000000000000000000000000000000000001000::allowlist
>>> % Module coverage: 97.21
Module 0000000000000000000000000000000000000000000000000000000000001000::ownable
>>> % Module coverage: 89.96
```

## Link token tests
```
| Move Coverage Summary   |
+-------------------------+
Module ec027d053a48066c79c442d3215e1b775c47f832ac18f8e0539bbd6667f76e85::allowlist
>>> % Module coverage: 96.22
Module ec027d053a48066c79c442d3215e1b775c47f832ac18f8e0539bbd6667f76e85::ownable
>>> % Module coverage: 97.19
Module ec027d053a48066c79c442d3215e1b775c47f832ac18f8e0539bbd6667f76e85::link_token
>>> % Module coverage: 85.29
+-------------------------+
| % Move Coverage: 91.26  |
+-------------------------+
```
