### PR TITLE
PLEX-1438 Allow adding custom tags to WT ID

### DIFF
--- a/relayer/write_target/aptos/write_target.go
+++ b/relayer/write_target/aptos/write_target.go
@@ -28,7 +28,7 @@ func NewAptosWriteTarget(ctx context.Context, chain chain.Chain, lggr logger.Log
 	// chainName, err := chainselectors.NameFromChainId(chain.ID().Uint64())
 
 	// Construct the ID for the WT (e.g., "write_aptos-localnet@1.0.0")
-	id, err := write_target.NewWriteTargetID(aptosconfig.ChainFamilyName, config.NetworkName, config.ChainID, version)
+	id, err := write_target.NewWriteTargetID(aptosconfig.ChainFamilyName, config.NetworkName, config.ChainID, config.WriteTargetCap.Tag, version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create write target ID: %+w", err)
 	}

--- a/relayer/write_target/config.go
+++ b/relayer/write_target/config.go
@@ -8,6 +8,7 @@ import (
 
 // Config defines the write target component configuration.
 type Config struct {
+	Tag                 string // allows modifying WT ID e.g. write_aptos-testnet:{{.Tag}}@1.0.3
 	ConfirmerPollPeriod config.Duration
 	ConfirmerTimeout    config.Duration
 }

--- a/relayer/write_target/write_target.go
+++ b/relayer/write_target/write_target.go
@@ -111,7 +111,7 @@ type TransmissionState struct {
 }
 
 // NewWriteTargetID returns the capability ID for the write target
-func NewWriteTargetID(chainFamilyName, networkName, chainID, version string) (string, error) {
+func NewWriteTargetID(chainFamilyName, networkName, chainID, tag, version string) (string, error) {
 	// Input args should not be empty
 	if chainFamilyName == "" || version == "" {
 		return "", fmt.Errorf("invalid input: chainFamilyName, and version must not be empty")
@@ -126,7 +126,12 @@ func NewWriteTargetID(chainFamilyName, networkName, chainID, version string) (st
 		networkID = chainID
 	}
 
-	return fmt.Sprintf("%s_%s-%s@%s", CapabilityName, chainFamilyName, networkID, version), nil
+	id := fmt.Sprintf("%s_%s-%s", CapabilityName, chainFamilyName, networkID)
+	if tag != "" {
+		id += ":" + tag
+	}
+
+	return id + "@" + version, nil
 }
 
 // TODO: opts.Config input is not validated for sanity

--- a/relayer/write_target/write_target_test.go
+++ b/relayer/write_target/write_target_test.go
@@ -33,6 +33,7 @@ func TestNewWriteTargetID(t *testing.T) {
 		networkName     string
 		chainID         string
 		version         string
+		tag             string
 		expected        string
 		expectError     bool
 	}{
@@ -99,17 +100,40 @@ func TestNewWriteTargetID(t *testing.T) {
 			expected:        "write_aptos-testnet@1.0.3",
 			expectError:     false,
 		},
+		{
+			name:            "Valid input with unknown network name and tag",
+			chainFamilyName: "aptos",
+			networkName:     "unknown",
+			chainID:         "1",
+			tag:             "region-b",
+			version:         "2.0.1",
+			expected:        "write_aptos-1:region-b@2.0.1",
+			expectError:     false,
+		},
+		{
+			name:            "Valid input with network name (testnet)",
+			chainFamilyName: "aptos",
+			networkName:     "testnet",
+			chainID:         "2",
+			tag:             "region-b",
+			version:         "1.0.3",
+			expected:        "write_aptos-testnet:region-b@1.0.3",
+			expectError:     false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result, err := NewWriteTargetID(tt.chainFamilyName, tt.networkName, tt.chainID, tt.version)
+			result, err := NewWriteTargetID(tt.chainFamilyName, tt.networkName, tt.chainID, tt.tag, tt.version)
 			if tt.expectError {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.expected, result)
+				// ensure we meet capabilities requirements for the ID
+				_, err := capabilities.NewCapabilityInfo(result, capabilities.CapabilityTypeTarget, CapabilityName)
+				require.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
In the current implementation, the WT ID is programmatically generated from the chain ID and version, and there is no way to change it via configuration.

To test active-active, we need to enable two writer DONs with the same capability.  Unfortunately, this requires two separate capabilities registries used by two workflow DONs.  

Deploying a new capabilities registry and migrating the Workflow DON requires effort similar to making the WT ID taggable (e.g. write_aptos-testnet:region_a@1.0.3), but making it taggable gives us more flexibility. 