### PR TITLE
Offramp and ocr3 tests

### DIFF
--- a/contracts/ccip/ccip_offramp/Move.toml
+++ b/contracts/ccip/ccip_offramp/Move.toml
@@ -10,13 +10,21 @@ mcms = "_"
 mcms_register_entrypoints = "_"
 
 [dev-addresses]
-ccip_offramp = "0x1001"
-ccip = "0x1000"
+ccip_offramp = "0xc6bcb7d2c22391db9b56fc98d6ef142e7d8f7035dc75fae2bfc469daa1b0d0ba"
+ccip = "0x85d5520ea6a8b1501502651040c6f61238b281142ccbafdc205d40258f0bec10"
 mcms = "0x4000"
 mcms_register_entrypoints = "0x4001"
+
+ccip_token_pool = "0x8d62e11f76e6e92563c59e7a5e842a540f8c6c3a4ed8a32f40a5ad3425b55f86"
+burn_mint_token_pool = "0x8e03eb21315649c06acb9a860a72c2b8cef5bd36775402008b89af397756dad7"
+lock_release_token_pool = "0x2e1f4cc8fbc2c7ccd2c67ff453e00526919098304d70708ef504af944d6fede8"
+burn_mint_local_token = "0x15c084d10b071a4b180c8d050e421a533bd07d13f9d9386335709da567183768"
+lock_release_local_token = "0x6d1c246126d36fea774b12486de0a3737997f1b9b23806c67ca5ce72859ff5fa"
 
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "837d04bd9bd0dd7156da4252bcfc1d080ed591ec", subdir = "aptos-move/framework/aptos-framework" }
 ChainlinkCCIP = { local = "../ccip" }
 
 [dev-dependencies]
+BurnMintTokenPool = { local = "../ccip_token_pools/burn_mint_token_pool", addr_subst = { 'token_pool_administrator' = '0x0' } }
+LockReleaseTokenPool = { local = "../ccip_token_pools/lock_release_token_pool", addr_subst = { 'token_pool_administrator' = '0x0' } }

--- a/contracts/ccip/ccip_offramp/sources/ocr3_base.move
+++ b/contracts/ccip/ccip_offramp/sources/ocr3_base.move
@@ -373,11 +373,39 @@ module ccip_offramp::ocr3_base {
         found
     }
 
+    public fun config_signers(ocr_config: &OCRConfig): vector<vector<u8>> {
+        ocr_config.signers
+    }
+
+    public fun config_transmitters(ocr_config: &OCRConfig): vector<address> {
+        ocr_config.transmitters
+    }
+
     #[test]
     fun deserialize_sequence_number() {
         let report_context_one =
             x"0000000000000000000000000000000000000000000000000000000000000009";
         let ocr_sequence_number = deserialize_sequence_bytes(report_context_one);
         assert!(ocr_sequence_number == 9);
+    }
+
+    // ===================== Test functions =====================
+
+    #[test_only]
+    public fun destroy_ocr3_state(ocr3_state: OCR3BaseState) {
+        let OCR3BaseState {
+            chain_id: _,
+            ocr3_configs,
+            signer_oracles,
+            transmitter_oracles,
+            config_set_events,
+            transmitted_events
+        } = ocr3_state;
+
+        table::drop_unchecked(ocr3_configs);
+        table::drop_unchecked(signer_oracles);
+        table::drop_unchecked(transmitter_oracles);
+        event::destroy_handle(config_set_events);
+        event::destroy_handle(transmitted_events);
     }
 }

--- a/contracts/ccip/ccip_offramp/sources/offramp.move
+++ b/contracts/ccip/ccip_offramp/sources/offramp.move
@@ -1438,122 +1438,194 @@ module ccip_offramp::offramp {
         option::none()
     }
 
-    #[test]
-    fun test_calculate_message_hash() {
-        let expected_hash =
-            x"c8d6cf666864a60dd6ecd89e5c294734c53b3218d3f83d2d19a3c3f9e200e00d";
+    // ======================= Getters ==========================
 
-        let message_id =
-            x"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
-
-        let message = Any2AptosRampMessage {
-            header: RampMessageHeader {
-                message_id,
-                source_chain_selector: 1,
-                dest_chain_selector: 2,
-                sequence_number: 42,
-                nonce: 123
-            },
-            sender: x"8765432109fedcba8765432109fedcba87654321",
-            data: b"sample message data",
-            receiver: @0x1234,
-            gas_limit: 500000,
-            token_amounts: vector[
-                Any2AptosTokenTransfer {
-                    source_pool_address: x"abcdef1234567890abcdef1234567890abcdef12",
-                    dest_token_address: @0x5678,
-                    dest_gas_amount: 10000,
-                    extra_data: x"00112233",
-                    amount: 1000000
-                },
-                Any2AptosTokenTransfer {
-                    source_pool_address: x"123456789abcdef123456789abcdef123456789a",
-                    dest_token_address: @0x9abc,
-                    dest_gas_amount: 20000,
-                    extra_data: x"ffeeddcc",
-                    amount: 5000000
-                }
-            ]
-        };
-        let metadata_hash =
-            x"aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899";
-
-        let message_hash = calculate_message_hash(&message, metadata_hash);
-        assert!(message_hash == expected_hash);
+    public fun message(report: &ExecutionReport): &Any2AptosRampMessage {
+        &report.message
     }
 
-    #[test]
-    fun test_calculate_metadata_hash() {
-        let expected_hash =
-            x"812acb01df318f85be452cf6664891cf5481a69dac01e0df67102a295218dd17";
-        let expected_hash_alternate =
-            x"6caf8756ae02ee4f12b83b38e0f21b5e43e90d203bd06729486fd4a0fc8bcc5e";
-
-        let source_chain_selector = 123456789;
-        let dest_chain_selector = 987654321;
-        let on_ramp = b"source-onramp-address";
-
-        let metadata_hash =
-            calculate_metadata_hash(source_chain_selector, dest_chain_selector, on_ramp);
-        let metadata_hash_alternate =
-            calculate_metadata_hash(
-                source_chain_selector + 1, dest_chain_selector, on_ramp
-            );
-
-        assert!(metadata_hash == expected_hash);
-        assert!(metadata_hash_alternate == expected_hash_alternate);
+    public fun sender(message: &Any2AptosRampMessage): vector<u8> {
+        message.sender
     }
 
-    #[test]
-    fun test_deserialize_execution_report() {
-        let expected_sender = x"d87929a32cf0cbdc9e2d07ffc7c33344079de727";
-        let expected_data = x"68656c6c6f20434349505265636569766572";
-        let expected_receiver =
-            @0xbd8a1fb0af25dc8700d2d302cfbae718c3b2c3c61cfe47f58a45b1126c006490;
-        let expected_gas_limit = 100000;
-        let expected_message_id =
-            x"20865dcacbd6afb6a2288daa164caf75517009a289fa3135281fb1e4800b11bc";
-        let expected_source_chain_selector = 909606746561742123;
-        let expected_dest_chain_selector = 743186221051783445;
-        let expected_sequence_number = 1;
-        let expected_nonce = 0;
-        let expected_leaf_bytes =
-            x"258dc7f9ec033388ee50bf3e0debfc841a278054f5b2ce41728f7459267c719e";
+    public fun data(message: &Any2AptosRampMessage): vector<u8> {
+        message.data
+    }
 
-        let report_bytes =
-            x"2b851c4684929f0c20865dcacbd6afb6a2288daa164caf75517009a289fa3135281fb1e4800b11bc2b851c4684929f0c15a9c133ee53500a0100000000000000000000000000000014d87929a32cf0cbdc9e2d07ffc7c33344079de7271268656c6c6f20434349505265636569766572bd8a1fb0af25dc8700d2d302cfbae718c3b2c3c61cfe47f58a45b1126c006490a086010000000000000000000000000000000000000000000000000000000000000000";
-        let onramp = x"47a1f0a819457f01153f35c6b6b0d42e2e16e91e";
-        let execution_report = deserialize_execution_report(report_bytes);
-        std::debug::print(&execution_report);
+    public fun receiver(message: &Any2AptosRampMessage): address {
+        message.receiver
+    }
 
-        assert!(execution_report.message.sender == expected_sender);
-        assert!(execution_report.message.data == expected_data);
-        assert!(execution_report.message.receiver == expected_receiver);
-        assert!(execution_report.message.gas_limit == expected_gas_limit);
-        assert!(execution_report.message.header.message_id == expected_message_id);
-        assert!(
-            execution_report.message.header.source_chain_selector
-                == expected_source_chain_selector
-        );
-        assert!(
-            execution_report.message.header.dest_chain_selector
-                == expected_dest_chain_selector
-        );
-        assert!(
-            execution_report.message.header.sequence_number == expected_sequence_number
-        );
-        assert!(execution_report.message.header.nonce == expected_nonce);
+    public fun gas_limit(message: &Any2AptosRampMessage): u256 {
+        message.gas_limit
+    }
 
-        let metadata_hash =
-            calculate_metadata_hash(
-                execution_report.source_chain_selector,
-                execution_report.message.header.dest_chain_selector,
-                onramp
-            );
-        let hashed_leaf = calculate_message_hash(
-            &execution_report.message, metadata_hash
-        );
+    public fun header(message: &Any2AptosRampMessage): &RampMessageHeader {
+        &message.header
+    }
 
-        assert!(expected_leaf_bytes == hashed_leaf);
+    public fun header_source_chain_selector(header: &RampMessageHeader): u64 {
+        header.source_chain_selector
+    }
+
+    public fun header_dest_chain_selector(header: &RampMessageHeader): u64 {
+        header.dest_chain_selector
+    }
+
+    public fun header_message_id(header: &RampMessageHeader): vector<u8> {
+        header.message_id
+    }
+
+    public fun sequence_number(header: &RampMessageHeader): u64 {
+        header.sequence_number
+    }
+
+    public fun nonce(header: &RampMessageHeader): u64 {
+        header.nonce
+    }
+
+    public fun token_amounts(message: &Any2AptosRampMessage): &vector<Any2AptosTokenTransfer> {
+        &message.token_amounts
+    }
+
+    public fun chain_selector(config: &StaticConfig): u64 {
+        config.chain_selector
+    }
+
+    public fun permissionless_execution_threshold_seconds(
+        config: &DynamicConfig
+    ): u32 {
+        config.permissionless_execution_threshold_seconds
+    }
+
+    public fun is_enabled(config: &SourceChainConfig): bool {
+        config.is_enabled
+    }
+
+    public fun is_rmn_verification_disabled(config: &SourceChainConfig): bool {
+        config.is_rmn_verification_disabled
+    }
+
+    // ========================== Test Functions ========================== //
+
+    #[test_only]
+    public fun test_init_module(publisher: &signer) {
+        init_module(publisher);
+    }
+
+    #[test_only]
+    public fun test_register_mcms_entrypoint(publisher: &signer) {
+        mcms_registry::register_entrypoint(
+            publisher, string::utf8(b"offramp"), McmsCallback {}
+        );
+    }
+
+    #[test_only]
+    public fun test_execute_single_report(report: ExecutionReport) acquires OffRampState {
+        execute_single_report(
+            borrow_global_mut<OffRampState>(get_state_address_internal()),
+            report,
+            false
+        );
+    }
+
+    #[test_only]
+    public fun test_create_execution_report(
+        source_chain_selector: u64,
+        message: Any2AptosRampMessage,
+        offchain_token_data: vector<vector<u8>>,
+        proofs: vector<vector<u8>>
+    ): ExecutionReport {
+        ExecutionReport { source_chain_selector, message, offchain_token_data, proofs }
+    }
+
+    #[test_only]
+    public fun test_add_root(root: vector<u8>, timestamp: u64) acquires OffRampState {
+        let state = borrow_global_mut<OffRampState>(get_state_address_internal());
+        state.roots.add(root, timestamp);
+    }
+
+    #[test_only]
+    public fun test_deserialize_execution_report(
+        report_bytes: vector<u8>
+    ): ExecutionReport {
+        deserialize_execution_report(report_bytes)
+    }
+
+    #[test_only]
+    public fun test_calculate_metadata_hash(
+        source_chain_selector: u64, dest_chain_selector: u64, onramp: vector<u8>
+    ): vector<u8> {
+        calculate_metadata_hash(source_chain_selector, dest_chain_selector, onramp)
+    }
+
+    #[test_only]
+    public fun test_calculate_message_hash(
+        message: &Any2AptosRampMessage, metadata_hash: vector<u8>
+    ): vector<u8> {
+        calculate_message_hash(message, metadata_hash)
+    }
+
+    #[test_only]
+    public fun test_create_any2aptos_ramp_message(
+        header: RampMessageHeader,
+        sender: vector<u8>,
+        data: vector<u8>,
+        receiver: address,
+        gas_limit: u256,
+        token_amounts: vector<Any2AptosTokenTransfer>
+    ): Any2AptosRampMessage {
+        Any2AptosRampMessage { header, sender, data, receiver, gas_limit, token_amounts }
+    }
+
+    #[test_only]
+    public fun test_create_any2aptos_token_transfer(
+        source_pool_address: vector<u8>,
+        dest_token_address: address,
+        dest_gas_amount: u32,
+        extra_data: vector<u8>,
+        amount: u256
+    ): Any2AptosTokenTransfer {
+        Any2AptosTokenTransfer {
+            source_pool_address,
+            dest_token_address,
+            dest_gas_amount,
+            extra_data,
+            amount
+        }
+    }
+
+    #[test_only]
+    public fun test_create_ramp_message_header(
+        message_id: vector<u8>,
+        source_chain_selector: u64,
+        dest_chain_selector: u64,
+        sequence_number: u64,
+        nonce: u64
+    ): RampMessageHeader {
+        RampMessageHeader {
+            message_id,
+            source_chain_selector,
+            dest_chain_selector,
+            sequence_number,
+            nonce
+        }
+    }
+
+    #[test_only]
+    public fun test_create_merkle_root(
+        source_chain_selector: u64,
+        on_ramp_address: vector<u8>,
+        min_seq_nr: u64,
+        max_seq_nr: u64,
+        merkle_root: vector<u8>
+    ): MerkleRoot {
+        MerkleRoot {
+            source_chain_selector,
+            on_ramp_address,
+            min_seq_nr,
+            max_seq_nr,
+            merkle_root
+        }
     }
 }

--- a/contracts/ccip/ccip_offramp/tests/ocr3_base_test.move
+++ b/contracts/ccip/ccip_offramp/tests/ocr3_base_test.move
@@ -1,0 +1,348 @@
+#[test_only]
+module ccip_offramp::ocr3_base_test {
+    use std::signer;
+    use std::chain_id;
+    use std::account;
+    use std::object;
+
+    use ccip::state_object;
+    use ccip_offramp::ocr3_base;
+    use ccip::auth;
+
+    const CHAIN_ID: u8 = 100;
+    const OCR_PLUGIN_TYPE_COMMIT: u8 = 0;
+    const OCR_PLUGIN_TYPE_EXECUTION: u8 = 1;
+
+    const OWNER: address = @0x1234;
+    const TRANSMITTER1: address = @0x5678;
+    const TRANSMITTER2: address = @0x9ABC;
+    const TRANSMITTER3: address = @0xDEF0;
+    const TRANSMITTER4: address = @0x1111;
+
+    const SIGNER1: vector<u8> = x"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const SIGNER2: vector<u8> = x"fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+    const SIGNER3: vector<u8> = x"1122334455667788990011223344556677889900112233445566778899001122";
+    const SIGNER4: vector<u8> = x"aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899";
+
+    fun setup(aptos_framework: &signer, owner: &signer, ccip: &signer):
+        ocr3_base::OCR3BaseState {
+        account::create_account_for_test(signer::address_of(owner));
+        account::create_account_for_test(signer::address_of(ccip));
+        chain_id::initialize_for_test(aptos_framework, CHAIN_ID);
+
+        // Create object for @ccip
+        let _constructor_ref = object::create_named_object(owner, b"ccip");
+
+        state_object::init_module_for_testing(ccip);
+
+        // Initialize auth module for testing
+        auth::test_init_module(owner);
+
+        // Create new OCR3BaseState
+        ocr3_base::new(owner)
+    }
+
+    #[test(aptos_framework = @aptos_framework, owner = @0x100, ccip = @ccip)]
+    fun test_ocr_plugin_types(
+        aptos_framework: &signer, owner: &signer, ccip: &signer
+    ) {
+        let state = setup(aptos_framework, owner, ccip);
+
+        // Verify plugin types match expected values
+        assert!(ocr3_base::ocr_plugin_type_commit() == OCR_PLUGIN_TYPE_COMMIT, 0);
+        assert!(ocr3_base::ocr_plugin_type_execution() == OCR_PLUGIN_TYPE_EXECUTION, 0);
+
+        ocr3_base::destroy_ocr3_state(state);
+    }
+
+    #[test(aptos_framework = @aptos_framework, owner = @0x100, ccip = @ccip)]
+    fun test_set_ocr3_config(
+        aptos_framework: &signer, owner: &signer, ccip: &signer
+    ) {
+        let state = setup(aptos_framework, owner, ccip);
+
+        let config_digest =
+            x"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let ocr_plugin_type = ocr3_base::ocr_plugin_type_commit();
+        let big_f = 1;
+        let is_signature_verification_enabled = true;
+
+        let signers = vector[SIGNER1, SIGNER2, SIGNER3, SIGNER4];
+        let transmitters = vector[TRANSMITTER1, TRANSMITTER2, TRANSMITTER3, TRANSMITTER4];
+
+        ocr3_base::set_ocr3_config(
+            owner,
+            &mut state,
+            config_digest,
+            ocr_plugin_type,
+            big_f,
+            is_signature_verification_enabled,
+            signers,
+            transmitters
+        );
+
+        let ocr_plugin_type = ocr3_base::ocr_plugin_type_execution();
+        let is_signature_verification_enabled = true;
+
+        ocr3_base::set_ocr3_config(
+            owner,
+            &mut state,
+            config_digest,
+            ocr_plugin_type,
+            big_f,
+            is_signature_verification_enabled,
+            signers,
+            transmitters
+        );
+
+        // Verify execution plugin config was set correctly
+        let config = ocr3_base::latest_config_details(&state, ocr_plugin_type);
+        assert!(ocr3_base::config_signers(&config) == signers);
+        assert!(ocr3_base::config_transmitters(&config) == transmitters);
+
+        ocr3_base::destroy_ocr3_state(state);
+    }
+
+    #[test(aptos_framework = @aptos_framework, owner = @0x100, ccip = @ccip)]
+    fun test_deserialize_sequence_bytes(
+        aptos_framework: &signer, owner: &signer, ccip: &signer
+    ) {
+        let state = setup(aptos_framework, owner, ccip);
+
+        // Test with sequence number 9
+        let sequence_bytes =
+            x"0000000000000000000000000000000000000000000000000000000000000009";
+        let sequence_number = ocr3_base::deserialize_sequence_bytes(sequence_bytes);
+        assert!(sequence_number == 9, 0);
+
+        // Test with sequence number 12345
+        let sequence_bytes =
+            x"0000000000000000000000000000000000000000000000000000000000003039";
+        let sequence_number = ocr3_base::deserialize_sequence_bytes(sequence_bytes);
+        assert!(sequence_number == 12345, 0);
+
+        // Test with max u64 value
+        let sequence_bytes =
+            x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        let sequence_number = ocr3_base::deserialize_sequence_bytes(sequence_bytes);
+        assert!(sequence_number == 18446744073709551615, 0); // max u64 value
+
+        ocr3_base::destroy_ocr3_state(state);
+    }
+
+    #[test(aptos_framework = @aptos_framework, owner = @0x100, ccip = @ccip)]
+    #[expected_failure(abort_code = 65539, location = ccip_offramp::ocr3_base)]
+    fun test_set_ocr3_config_too_many_signers(
+        aptos_framework: &signer, owner: &signer, ccip: &signer
+    ) {
+        let state = setup(aptos_framework, owner, ccip);
+
+        // Create more than MAX_NUM_ORACLES signers
+        let signers = vector[];
+        let i = 0;
+        while (i < 257) { // MAX_NUM_ORACLES is 256
+            signers.push_back(SIGNER1);
+            i = i + 1;
+        };
+
+        let transmitters = vector[TRANSMITTER1];
+
+        // This should fail with E_TOO_MANY_SIGNERS
+        ocr3_base::set_ocr3_config(
+            owner,
+            &mut state,
+            x"00",
+            ocr3_base::ocr_plugin_type_commit(),
+            1,
+            true,
+            signers,
+            transmitters
+        );
+
+        ocr3_base::destroy_ocr3_state(state);
+    }
+
+    #[test(aptos_framework = @aptos_framework, owner = @0x100, ccip = @ccip)]
+    #[expected_failure(abort_code = 65541, location = ccip_offramp::ocr3_base)]
+    fun test_set_ocr3_config_too_many_transmitters(
+        aptos_framework: &signer, owner: &signer, ccip: &signer
+    ) {
+        let state = setup(aptos_framework, owner, ccip);
+
+        // Create more than MAX_NUM_ORACLES transmitters
+        let transmitters = vector[];
+        let i = 0;
+        while (i < 257) { // MAX_NUM_ORACLES is 256
+            transmitters.push_back(TRANSMITTER1);
+            i = i + 1;
+        };
+
+        let signers = vector[SIGNER1, SIGNER2, SIGNER3, SIGNER4];
+
+        // This should fail with MAX_NUM_ORACLES
+        ocr3_base::set_ocr3_config(
+            owner,
+            &mut state,
+            x"00",
+            ocr3_base::ocr_plugin_type_commit(),
+            1,
+            true,
+            signers,
+            transmitters
+        );
+
+        ocr3_base::destroy_ocr3_state(state);
+    }
+
+    #[test(aptos_framework = @aptos_framework, owner = @0x100, ccip = @ccip)]
+    #[expected_failure(abort_code = 65542, location = ccip_offramp::ocr3_base)]
+    fun test_set_ocr3_config_no_transmitters(
+        aptos_framework: &signer, owner: &signer, ccip: &signer
+    ) {
+        let state = setup(aptos_framework, owner, ccip);
+
+        let signers = vector[SIGNER1, SIGNER2, SIGNER3, SIGNER4];
+        let transmitters = vector[];
+
+        // This should fail with E_NO_TRANSMITTERS
+        ocr3_base::set_ocr3_config(
+            owner,
+            &mut state,
+            x"00",
+            ocr3_base::ocr_plugin_type_commit(),
+            1,
+            true,
+            signers,
+            transmitters
+        );
+
+        ocr3_base::destroy_ocr3_state(state);
+    }
+
+    #[test(aptos_framework = @aptos_framework, owner = @0x100, ccip = @ccip)]
+    #[expected_failure(abort_code = 65537, location = ccip_offramp::ocr3_base)]
+    fun test_set_ocr3_config_zero_big_f(
+        aptos_framework: &signer, owner: &signer, ccip: &signer
+    ) {
+        let state = setup(aptos_framework, owner, ccip);
+
+        let signers = vector[SIGNER1, SIGNER2, SIGNER3, SIGNER4];
+        let transmitters = vector[TRANSMITTER1, TRANSMITTER2, TRANSMITTER3, TRANSMITTER4];
+
+        // This should fail with E_BIG_F_MUST_BE_POSITIVE
+        ocr3_base::set_ocr3_config(
+            owner,
+            &mut state,
+            x"00",
+            ocr3_base::ocr_plugin_type_commit(),
+            0, // big_f = 0
+            true,
+            signers,
+            transmitters
+        );
+
+        ocr3_base::destroy_ocr3_state(state);
+    }
+
+    #[test(aptos_framework = @aptos_framework, owner = @0x100, ccip = @ccip)]
+    #[expected_failure(abort_code = 65540, location = ccip_offramp::ocr3_base)]
+    fun test_set_ocr3_config_big_f_too_high(
+        aptos_framework: &signer, owner: &signer, ccip: &signer
+    ) {
+        let state = setup(aptos_framework, owner, ccip);
+
+        let signers = vector[SIGNER1]; // Only 1 signer
+        let transmitters = vector[TRANSMITTER1];
+
+        // This should fail with E_BIG_F_TOO_HIGH because signers.length() must be > 3 * big_f
+        ocr3_base::set_ocr3_config(
+            owner,
+            &mut state,
+            x"00",
+            ocr3_base::ocr_plugin_type_commit(),
+            1, // big_f = 1, so need at least 4 signers
+            true,
+            signers,
+            transmitters
+        );
+
+        ocr3_base::destroy_ocr3_state(state);
+    }
+
+    #[test(aptos_framework = @aptos_framework, owner = @0x100, ccip = @ccip)]
+    #[expected_failure(abort_code = 65543, location = ccip_offramp::ocr3_base)]
+    fun test_set_ocr3_config_repeated_signers(
+        aptos_framework: &signer, owner: &signer, ccip: &signer
+    ) {
+        let state = setup(aptos_framework, owner, ccip);
+
+        // Create signers with duplicates
+        let signers = vector[SIGNER1, SIGNER1, SIGNER2, SIGNER3];
+        let transmitters = vector[TRANSMITTER1, TRANSMITTER2, TRANSMITTER3, TRANSMITTER4];
+
+        // This should fail with E_REPEATED_SIGNERS
+        ocr3_base::set_ocr3_config(
+            owner,
+            &mut state,
+            x"00",
+            ocr3_base::ocr_plugin_type_commit(),
+            1,
+            true,
+            signers,
+            transmitters
+        );
+
+        ocr3_base::destroy_ocr3_state(state);
+    }
+
+    #[test(aptos_framework = @aptos_framework, owner = @0x100, ccip = @ccip)]
+    #[expected_failure(abort_code = 65544, location = ccip_offramp::ocr3_base)]
+    fun test_set_ocr3_config_repeated_transmitters(
+        aptos_framework: &signer, owner: &signer, ccip: &signer
+    ) {
+        let state = setup(aptos_framework, owner, ccip);
+
+        let signers = vector[SIGNER1, SIGNER2, SIGNER3, SIGNER4];
+        // Create transmitters with duplicates
+        let transmitters = vector[TRANSMITTER1, TRANSMITTER1, TRANSMITTER2, TRANSMITTER3];
+
+        // This should fail with E_REPEATED_TRANSMITTERS
+        ocr3_base::set_ocr3_config(
+            owner,
+            &mut state,
+            x"00",
+            ocr3_base::ocr_plugin_type_commit(),
+            1,
+            true,
+            signers,
+            transmitters
+        );
+
+        ocr3_base::destroy_ocr3_state(state);
+    }
+
+    #[test(aptos_framework = @aptos_framework, owner = @0x100, ccip = @ccip)]
+    #[expected_failure(abort_code = 65540, location = ccip_offramp::ocr3_base)]
+    fun test_set_ocr3_config_transmitters_exceed_signers(
+        aptos_framework: &signer, owner: &signer, ccip: &signer
+    ) {
+        let state = setup(aptos_framework, owner, ccip);
+
+        let signers = vector[SIGNER1, SIGNER2, SIGNER3]; // 3 signers
+        let transmitters = vector[TRANSMITTER1, TRANSMITTER2, TRANSMITTER3, TRANSMITTER4]; // 4 transmitters
+
+        // E_BIG_F_TOO_HIGH - too many signers
+        ocr3_base::set_ocr3_config(
+            owner,
+            &mut state,
+            x"00",
+            ocr3_base::ocr_plugin_type_commit(),
+            1,
+            true,
+            signers,
+            transmitters
+        );
+
+        ocr3_base::destroy_ocr3_state(state);
+    }
+}

--- a/contracts/ccip/ccip_offramp/tests/offramp_test.move
+++ b/contracts/ccip/ccip_offramp/tests/offramp_test.move
@@ -1,0 +1,1223 @@
+#[test_only]
+module ccip_offramp::offramp_test {
+    use std::signer;
+    use std::string;
+    use std::option;
+    use std::chain_id;
+    use std::account;
+    use std::object::{Self, Object, ExtendRef, ObjectCore};
+    use aptos_framework::fungible_asset::{Self, Metadata, MintRef, BurnRef, TransferRef};
+    use aptos_framework::primary_fungible_store;
+    use aptos_framework::timestamp;
+    use ccip_offramp::bcs_helper;
+
+    use ccip::merkle_proof;
+    use ccip::token_admin_registry;
+    use ccip::rmn_remote;
+    use ccip::nonce_manager;
+    use ccip::auth;
+    use ccip::state_object;
+    use ccip::fee_quoter;
+    use ccip_offramp::offramp;
+    use ccip_offramp::ocr3_base;
+
+    use burn_mint_token_pool::burn_mint_token_pool;
+    use lock_release_token_pool::lock_release_token_pool;
+
+    const CHAIN_ID: u8 = 100;
+    const EVM_SOURCE_CHAIN_SELECTOR: u64 = 909606746561742123;
+    const DEST_CHAIN_SELECTOR: u64 = 743186221051783445;
+    const TOKEN_AMOUNT: u64 = 5000;
+
+    const INBOUND_CAPACITY: u64 = 1000000000000000000;
+    const INBOUND_RATE: u64 = 1000000000000000000;
+    const OUTBOUND_CAPACITY: u64 = 1000000000000000000;
+    const OUTBOUND_RATE: u64 = 1000000000000000000;
+
+    const OWNER: address = @0x100;
+    const SENDER: address = @0x200;
+    const ROUTER: address = @0x300;
+    const PERMISSIONLESS_EXECUTION_THRESHOLD_SECONDS: u32 = 3600; // 1 hour
+
+    const BURN_MINT_TOKEN_POOL: u8 = 0;
+    const LOCK_RELEASE_TOKEN_POOL: u8 = 1;
+
+    const BURN_MINT_TOKEN_SEED: vector<u8> = b"TestToken";
+    const LOCK_RELEASE_TOKEN_SEED: vector<u8> = b"LockReleaseToken";
+
+    const MOCK_EVM_ADDRESS: address = @0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97;
+    const MOCK_EVM_ADDRESS_VECTOR: vector<u8> = x"4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97";
+
+    struct TestToken has key, store {
+        metadata: Object<Metadata>,
+        extend_ref: ExtendRef,
+        mint_ref: MintRef,
+        burn_ref: BurnRef,
+        transfer_ref: TransferRef
+    }
+
+    fun init_timestamp(aptos_framework: &signer, timestamp_seconds: u64) {
+        timestamp::set_time_has_started_for_testing(aptos_framework);
+        timestamp::update_global_time_for_test_secs(timestamp_seconds);
+    }
+
+    fun setup(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_offramp: &signer,
+        owner: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer,
+        pool_type: u8,
+        seed: vector<u8>
+    ): (address, Object<Metadata>) {
+        let owner_addr = signer::address_of(owner);
+        account::create_account_for_test(signer::address_of(burn_mint_token_pool));
+        account::create_account_for_test(signer::address_of(lock_release_token_pool));
+        init_timestamp(aptos_framework, 100000);
+
+        chain_id::initialize_for_test(aptos_framework, CHAIN_ID);
+
+        // Create object for @ccip_offramp
+        let _constructor_ref = object::create_named_object(owner, b"ccip_offramp");
+
+        // Create object for @ccip
+        let _constructor_ref = object::create_named_object(owner, b"ccip");
+
+        // Create objects for token pools similar to onramp_test
+        let constructor_ref = object::create_named_object(
+            owner, b"burn_mint_token_pool"
+        );
+        let burn_mint_token_pool_obj_signer = &object::generate_signer(&constructor_ref);
+
+        let constructor_ref =
+            object::create_named_object(owner, b"lock_release_token_pool");
+        let lock_release_token_pool_obj_signer =
+            &object::generate_signer(&constructor_ref);
+
+        // Create token pool object
+        let constructor_ref =
+            object::create_named_object(
+                burn_mint_token_pool_obj_signer,
+                b"ccip_token_pool"
+            );
+        let ccip_token_pool_obj =
+            object::object_from_constructor_ref<ObjectCore>(&constructor_ref);
+
+        // Transfer ownership if needed for lock_release pool
+        if (pool_type == LOCK_RELEASE_TOKEN_POOL) {
+            object::transfer(
+                burn_mint_token_pool_obj_signer,
+                ccip_token_pool_obj,
+                signer::address_of(lock_release_token_pool_obj_signer)
+            );
+        };
+
+        state_object::init_module_for_testing(ccip);
+        auth::test_init_module(owner);
+        rmn_remote::initialize(owner, EVM_SOURCE_CHAIN_SELECTOR);
+
+        token_admin_registry::init_module_for_testing(ccip);
+        offramp::test_init_module(ccip_offramp);
+        nonce_manager::test_init_module(ccip);
+
+        let (token_obj, token_addr) =
+            create_test_token_and_pool(
+                owner,
+                burn_mint_token_pool,
+                lock_release_token_pool,
+                pool_type,
+                seed
+            );
+
+        // Initialize fee quoter
+        fee_quoter::initialize(
+            owner,
+            20000000000000,
+            token_addr,
+            12400,
+            vector[token_addr]
+        );
+
+        // Initialize offramp
+        initialize_offramp(owner);
+
+        // Configure fees
+        setup_fee_quoter(owner, ccip_offramp, token_addr);
+
+        // Delay to allow token bucket to refill
+        timestamp::update_global_time_for_test_secs(timestamp::now_seconds() + 10);
+
+        (owner_addr, token_obj)
+    }
+
+    fun create_test_token_and_pool(
+        owner: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer,
+        pool_type: u8,
+        seed: vector<u8>
+    ): (Object<Metadata>, address) {
+        let constructor_ref = object::create_named_object(owner, seed);
+
+        primary_fungible_store::create_primary_store_enabled_fungible_asset(
+            &constructor_ref,
+            option::none(),
+            string::utf8(seed),
+            string::utf8(seed),
+            0,
+            string::utf8(b"http://www.example.com/favicon.ico"),
+            string::utf8(b"http://www.example.com")
+        );
+
+        let metadata = object::object_from_constructor_ref(&constructor_ref);
+
+        let obj_signer = object::generate_signer(&constructor_ref);
+        let extend_ref = object::generate_extend_ref(&constructor_ref);
+        let mint_ref = fungible_asset::generate_mint_ref(&constructor_ref);
+        let burn_ref = fungible_asset::generate_burn_ref(&constructor_ref);
+        let transfer_ref = fungible_asset::generate_transfer_ref(&constructor_ref);
+
+        let token_addr = object::object_address(&metadata);
+
+        if (pool_type == BURN_MINT_TOKEN_POOL) {
+            burn_mint_token_pool::test_init_module(burn_mint_token_pool);
+            burn_mint_token_pool::initialize(burn_mint_token_pool, burn_ref, mint_ref);
+            burn_mint_token_pool::apply_chain_updates(
+                owner,
+                vector[],
+                vector[EVM_SOURCE_CHAIN_SELECTOR],
+                vector[vector[MOCK_EVM_ADDRESS_VECTOR]],
+                vector[MOCK_EVM_ADDRESS_VECTOR]
+            );
+            burn_mint_token_pool::set_chain_rate_limiter_config(
+                owner,
+                EVM_SOURCE_CHAIN_SELECTOR,
+                true,
+                OUTBOUND_CAPACITY,
+                OUTBOUND_RATE,
+                true,
+                INBOUND_CAPACITY,
+                INBOUND_RATE
+            );
+        } else {
+            lock_release_token_pool::test_init_module(lock_release_token_pool);
+            lock_release_token_pool::initialize(
+                lock_release_token_pool, option::some(transfer_ref)
+            );
+            lock_release_token_pool::apply_chain_updates(
+                owner,
+                vector[],
+                vector[EVM_SOURCE_CHAIN_SELECTOR],
+                vector[vector[MOCK_EVM_ADDRESS_VECTOR]],
+                vector[MOCK_EVM_ADDRESS_VECTOR]
+            );
+            lock_release_token_pool::set_chain_rate_limiter_config(
+                owner,
+                EVM_SOURCE_CHAIN_SELECTOR,
+                true,
+                OUTBOUND_CAPACITY,
+                OUTBOUND_RATE,
+                true,
+                INBOUND_CAPACITY,
+                INBOUND_RATE
+            );
+        };
+
+        let mint_ref = fungible_asset::generate_mint_ref(&constructor_ref);
+        let burn_ref = fungible_asset::generate_burn_ref(&constructor_ref);
+        let transfer_ref = fungible_asset::generate_transfer_ref(&constructor_ref);
+
+        // Fund lock/release token pool
+        primary_fungible_store::mint(
+            &mint_ref,
+            lock_release_token_pool::get_store_address(),
+            1000
+        );
+
+        move_to(
+            &obj_signer,
+            TestToken { metadata, extend_ref, mint_ref, burn_ref, transfer_ref }
+        );
+
+        (metadata, token_addr)
+    }
+
+    fun initialize_offramp(owner: &signer): address {
+        offramp::initialize(
+            owner,
+            DEST_CHAIN_SELECTOR,
+            PERMISSIONLESS_EXECUTION_THRESHOLD_SECONDS,
+            vector[EVM_SOURCE_CHAIN_SELECTOR],
+            vector[true], // is_enabled
+            vector[false], // is_rmn_verification_disabled
+            vector[x"47a1f0a819457f01153f35c6b6b0d42e2e16e91e"] // on_ramp address
+        );
+
+        offramp::get_state_address()
+    }
+
+    fun setup_fee_quoter(
+        owner: &signer, ccip_offramp: &signer, token_addr: address
+    ) {
+        fee_quoter::apply_fee_token_updates(owner, vector[], vector[token_addr]);
+        fee_quoter::apply_token_transfer_fee_config_updates(
+            owner,
+            EVM_SOURCE_CHAIN_SELECTOR,
+            vector[token_addr],
+            vector[1], // add_min_fee_usd_cents
+            vector[1], // add_max_fee_usd_cents
+            vector[0], // add_deci_bps
+            vector[1000], // add_dest_gas_overhead - needs to be non-zero
+            vector[1], // add_dest_bytes_overhead
+            vector[true], // add_is_enabled
+            vector[] // remove_tokens
+        );
+
+        fee_quoter::apply_dest_chain_config_updates(
+            owner,
+            EVM_SOURCE_CHAIN_SELECTOR,
+            true, // is_enabled
+            1, // max_number_of_tokens_per_msg
+            10000, // max_data_bytes
+            7000000, // max_per_msg_gas_limit
+            1000, // dest_gas_overhead
+            0, // dest_gas_per_payload_byte_base
+            0, // dest_gas_per_payload_byte_high
+            0, // dest_gas_per_payload_byte_threshold
+            0, // dest_data_availability_overhead_gas
+            0, // dest_gas_per_data_availability_byte
+            0, // dest_data_availability_multiplier_bps
+            x"ac77ffec", // chain_family_selector_aptos
+            false, // enforce_out_of_order
+            0, // default_token_fee_usd_cents
+            1000, // default_token_dest_gas_overhead - needs to be non-zero
+            1000000, // default_tx_gas_limit
+            0, // gas_multiplier_wei_per_eth
+            10000000, // gas_price_staleness_threshold
+            0 // network_fee_usd_cents
+        );
+
+        fee_quoter::apply_premium_multiplier_wei_per_eth_updates(
+            owner, vector[token_addr], vector[1]
+        );
+
+        // Register permissions
+        auth::apply_allowed_offramp_updates(
+            owner,
+            vector[],
+            vector[signer::address_of(ccip_offramp)]
+        );
+
+        auth::apply_allowed_offramp_updates(
+            owner,
+            vector[],
+            vector[offramp::get_state_address()]
+        );
+
+        // Update prices
+        fee_quoter::update_prices(
+            ccip_offramp,
+            vector[token_addr],
+            vector[1000],
+            vector[EVM_SOURCE_CHAIN_SELECTOR],
+            vector[100]
+        );
+    }
+
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            ccip = @ccip,
+            ccip_offramp = @ccip_offramp,
+            owner = @0x100,
+            burn_mint_token_pool = @burn_mint_token_pool,
+            lock_release_token_pool = @lock_release_token_pool
+        )
+    ]
+    fun test_initialize(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_offramp: &signer,
+        owner: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer
+    ) {
+        setup(
+            aptos_framework,
+            ccip,
+            ccip_offramp,
+            owner,
+            burn_mint_token_pool,
+            lock_release_token_pool,
+            BURN_MINT_TOKEN_POOL,
+            BURN_MINT_TOKEN_SEED
+        );
+
+        // Verify initialization was successful
+        let static_config = offramp::get_static_config();
+        assert!(offramp::chain_selector(&static_config) == DEST_CHAIN_SELECTOR);
+
+        let dynamic_config = offramp::get_dynamic_config();
+        assert!(
+            offramp::permissionless_execution_threshold_seconds(&dynamic_config)
+                == PERMISSIONLESS_EXECUTION_THRESHOLD_SECONDS
+        );
+
+        let source_chain_config =
+            offramp::get_source_chain_config(EVM_SOURCE_CHAIN_SELECTOR);
+        assert!(offramp::is_enabled(&source_chain_config));
+        assert!(!offramp::is_rmn_verification_disabled(&source_chain_config));
+
+        assert!(offramp::owner() == signer::address_of(owner));
+    }
+
+    #[test]
+    fun test_calculate_message_hash() {
+        let expected_hash =
+            x"c8d6cf666864a60dd6ecd89e5c294734c53b3218d3f83d2d19a3c3f9e200e00d";
+
+        let message_id =
+            x"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+
+        let source_chain_selector = 123456789;
+        let dest_chain_selector = 987654321;
+        let sequence_number = 42;
+        let nonce = 123;
+
+        let message =
+            offramp::test_create_any2aptos_ramp_message(
+                offramp::test_create_ramp_message_header(
+                    message_id,
+                    source_chain_selector,
+                    dest_chain_selector,
+                    sequence_number,
+                    nonce
+                ),
+                x"8765432109fedcba8765432109fedcba87654321",
+                b"sample message data",
+                @0x1234,
+                500000,
+                vector[
+                    offramp::test_create_any2aptos_token_transfer(
+                        x"abcdef1234567890abcdef1234567890abcdef12",
+                        @0x5678,
+                        10000,
+                        x"00112233",
+                        1000000
+                    ),
+                    offramp::test_create_any2aptos_token_transfer(
+                        x"123456789abcdef123456789abcdef123456789a",
+                        @0x9abc,
+                        20000,
+                        x"ffeeddcc",
+                        5000000
+                    )
+                ]
+            );
+
+        let metadata_hash =
+            x"aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899";
+
+        let message_hash = offramp::test_calculate_message_hash(&message, metadata_hash);
+        assert!(message_hash == expected_hash);
+    }
+
+    #[test]
+    fun test_calculate_metadata_hash() {
+        let expected_hash =
+            x"812acb01df318f85be452cf6664891cf5481a69dac01e0df67102a295218dd17";
+        let expected_hash_alternate =
+            x"6caf8756ae02ee4f12b83b38e0f21b5e43e90d203bd06729486fd4a0fc8bcc5e";
+
+        let source_chain_selector = 123456789;
+        let dest_chain_selector = 987654321;
+        let on_ramp = b"source-onramp-address";
+
+        let metadata_hash =
+            offramp::test_calculate_metadata_hash(
+                source_chain_selector, dest_chain_selector, on_ramp
+            );
+        let metadata_hash_alternate =
+            offramp::test_calculate_metadata_hash(
+                source_chain_selector + 1, dest_chain_selector, on_ramp
+            );
+
+        assert!(metadata_hash == expected_hash);
+        assert!(metadata_hash_alternate == expected_hash_alternate);
+    }
+
+    #[test]
+    fun test_deserialize_execution_report() {
+        let expected_sender = x"d87929a32cf0cbdc9e2d07ffc7c33344079de727";
+        let expected_data = x"68656c6c6f20434349505265636569766572";
+        let expected_receiver =
+            @0xbd8a1fb0af25dc8700d2d302cfbae718c3b2c3c61cfe47f58a45b1126c006490;
+        let expected_gas_limit = 100000;
+        let expected_message_id =
+            x"20865dcacbd6afb6a2288daa164caf75517009a289fa3135281fb1e4800b11bc";
+        let expected_EVM_SOURCE_CHAIN_SELECTOR = 909606746561742123;
+        let expected_dest_chain_selector = 743186221051783445;
+        let expected_sequence_number = 1;
+        let expected_nonce = 0;
+        let expected_leaf_bytes =
+            x"258dc7f9ec033388ee50bf3e0debfc841a278054f5b2ce41728f7459267c719e";
+
+        let report_bytes =
+            x"2b851c4684929f0c20865dcacbd6afb6a2288daa164caf75517009a289fa3135281fb1e4800b11bc2b851c4684929f0c15a9c133ee53500a0100000000000000000000000000000014d87929a32cf0cbdc9e2d07ffc7c33344079de7271268656c6c6f20434349505265636569766572bd8a1fb0af25dc8700d2d302cfbae718c3b2c3c61cfe47f58a45b1126c006490a086010000000000000000000000000000000000000000000000000000000000000000";
+        let onramp = x"47a1f0a819457f01153f35c6b6b0d42e2e16e91e";
+        let execution_report = offramp::test_deserialize_execution_report(report_bytes);
+
+        assert!(offramp::sender(offramp::message(&execution_report)) == expected_sender);
+        assert!(offramp::data(offramp::message(&execution_report)) == expected_data);
+        assert!(
+            offramp::receiver(offramp::message(&execution_report)) == expected_receiver
+        );
+        assert!(
+            offramp::gas_limit(offramp::message(&execution_report))
+                == expected_gas_limit
+        );
+        assert!(
+            offramp::header_message_id(
+                offramp::header(offramp::message(&execution_report))
+            ) == expected_message_id
+        );
+        assert!(
+            offramp::header_source_chain_selector(
+                offramp::header(offramp::message(&execution_report))
+            ) == expected_EVM_SOURCE_CHAIN_SELECTOR
+        );
+        assert!(
+            offramp::header_dest_chain_selector(
+                offramp::header(offramp::message(&execution_report))
+            ) == expected_dest_chain_selector
+        );
+        assert!(
+            offramp::sequence_number(offramp::header(offramp::message(&execution_report))) ==
+            expected_sequence_number
+        );
+        assert!(
+            offramp::nonce(offramp::header(offramp::message(&execution_report)))
+                == expected_nonce
+        );
+
+        let metadata_hash =
+            offramp::test_calculate_metadata_hash(
+                offramp::header_source_chain_selector(
+                    offramp::header(offramp::message(&execution_report))
+                ),
+                offramp::header_dest_chain_selector(
+                    offramp::header(offramp::message(&execution_report))
+                ),
+                onramp
+            );
+        let hashed_leaf =
+            offramp::test_calculate_message_hash(
+                offramp::message(&execution_report), metadata_hash
+            );
+
+        assert!(expected_leaf_bytes == hashed_leaf);
+    }
+
+    #[test(aptos_framework = @aptos_framework)]
+    fun test_create_serialized_execution_report(
+        aptos_framework: &signer
+    ) {
+        timestamp::set_time_has_started_for_testing(aptos_framework);
+
+        // Message ID (from JSON)
+        let message_id =
+            x"f3514a995f0ed287f1000a115447dd188f8714cf6187874aa2e9cd89af8d31da";
+
+        // Destination chain selector (from JSON)
+        let dest_chain_selector: u64 = 743186221051783445;
+
+        // Sequence number (from JSON)
+        let sequence_number: u64 = 6;
+
+        // Sender (from JSON)
+        let sender = x"e30b40bfb1baeed9e4c62f145be85eb3d19ae932";
+
+        // Data (from JSON)
+        let data = x"4920616d206120746573742063636970206d657373616765"; // "I am a test ccip message"
+
+        // ccip_offramp address
+        let receiver =
+            @0xc6bcb7d2c22391db9b56fc98d6ef142e7d8f7035dc75fae2bfc469daa1b0d0ba;
+
+        // Token amounts (empty array from JSON)
+        let token_amounts: vector<offramp::Any2AptosTokenTransfer> = vector[];
+
+        // Gas limit (from JSON)
+        let gas_limit: u256 = 0;
+
+        // Offchain token data (empty array from JSON but nested)
+        let empty_vector: vector<u8> = vector[];
+        let offchain_token_data: vector<vector<u8>> = vector[empty_vector];
+
+        // Proofs from the JSON
+        let proofs = vector[
+            x"3a68ff2c8091476723b8312418da36c358cc4ff7e64b4bcc633a96548ee85394",
+            x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            x"07ee4ff5528128e49067a01b99835e09746052bb4c6dd2ad1d4297843efa0bec"
+        ];
+        // vector::append(&mut proofs, bcs::to_bytes(&empty_vector));
+
+        // Use the helper function to create the report bytes with CORRECT serialization
+        let nonce: u64 = 0; // nonce must be 0 for out-of-order execution
+        let report_bytes =
+            bcs_helper::create_execution_report_bytes(
+                EVM_SOURCE_CHAIN_SELECTOR,
+                message_id,
+                dest_chain_selector,
+                sequence_number,
+                nonce,
+                sender,
+                data,
+                receiver,
+                gas_limit,
+                token_amounts,
+                offchain_token_data,
+                proofs
+            );
+
+        let deserialized_report =
+            offramp::test_deserialize_execution_report(report_bytes);
+        let header = offramp::header(offramp::message(&deserialized_report));
+        assert!(
+            offramp::header_source_chain_selector(header) == EVM_SOURCE_CHAIN_SELECTOR
+        );
+
+        let deserialized_message = offramp::message(&deserialized_report);
+        let deserialized_header = offramp::header(deserialized_message);
+
+        assert!(
+            offramp::header_source_chain_selector(deserialized_header)
+                == EVM_SOURCE_CHAIN_SELECTOR
+        );
+        assert!(
+            offramp::header_dest_chain_selector(deserialized_header)
+                == dest_chain_selector
+        );
+
+        let header_sequence_number = offramp::sequence_number(deserialized_header);
+        assert!(header_sequence_number == sequence_number);
+    }
+
+    #[test(aptos_framework = @aptos_framework)]
+    fun test_proper_serialization(aptos_framework: &signer) {
+        timestamp::set_time_has_started_for_testing(aptos_framework);
+
+        let message_id =
+            x"f3514a995f0ed287f1000a115447dd188f8714cf6187874aa2e9cd89af8d31da";
+        let dest_chain_selector: u64 = 743186221051783445;
+        let sequence_number: u64 = 6;
+        let sender = x"e30b40bfb1baeed9e4c62f145be85eb3d19ae932";
+        let data = x"4920616d206120746573742063636970206d657373616765";
+        let receiver =
+            @0x096c526aee8e07742b943d8c947344eacca7af4fbaec1c7c3e4c56114534de73;
+        let token_amounts: vector<offramp::Any2AptosTokenTransfer> = vector[];
+        let gas_limit: u256 = 0;
+        let offchain_token_data: vector<vector<u8>> = vector[vector[]];
+        let proofs = vector[
+            x"3a68ff2c8091476723b8312418da36c358cc4ff7e64b4bcc633a96548ee85394",
+            x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            x"07ee4ff5528128e49067a01b99835e09746052bb4c6dd2ad1d4297843efa0bec"
+        ];
+
+        // Use the helper function to create the report bytes with CORRECT serialization
+        let nonce: u64 = 0; // nonce must be 0 for out-of-order execution
+        let report_bytes =
+            bcs_helper::create_execution_report_bytes(
+                EVM_SOURCE_CHAIN_SELECTOR,
+                message_id,
+                dest_chain_selector,
+                sequence_number,
+                nonce,
+                sender,
+                data,
+                receiver,
+                gas_limit,
+                token_amounts,
+                offchain_token_data,
+                proofs
+            );
+
+        let deserialized_report =
+            offramp::test_deserialize_execution_report(report_bytes);
+
+        let header = offramp::header(offramp::message(&deserialized_report));
+
+        assert!(
+            offramp::header_source_chain_selector(header) == EVM_SOURCE_CHAIN_SELECTOR
+        );
+
+        let deserialized_message = offramp::message(&deserialized_report);
+        let deserialized_header = offramp::header(deserialized_message);
+
+        assert!(
+            offramp::header_source_chain_selector(deserialized_header)
+                == EVM_SOURCE_CHAIN_SELECTOR
+        );
+        assert!(
+            offramp::header_dest_chain_selector(deserialized_header)
+                == dest_chain_selector
+        );
+
+        let header_sequence_number = offramp::sequence_number(deserialized_header);
+        assert!(header_sequence_number == sequence_number);
+    }
+
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            ccip = @ccip,
+            ccip_offramp = @ccip_offramp,
+            owner = @0x100,
+            burn_mint_token_pool = @burn_mint_token_pool,
+            lock_release_token_pool = @lock_release_token_pool
+        )
+    ]
+    fun test_commit_and_execute(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_offramp: &signer,
+        owner: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer
+    ) {
+        setup(
+            aptos_framework,
+            ccip,
+            ccip_offramp,
+            owner,
+            burn_mint_token_pool,
+            lock_release_token_pool,
+            BURN_MINT_TOKEN_POOL,
+            BURN_MINT_TOKEN_SEED
+        );
+        let config_digest =
+            x"000aed76a87f048dab766bc14ecdbb966f4253e309d742585062a75abfc16c38";
+        let sequence_bytes =
+            x"0000000000000000000000000000000000000000000000000000000000000005";
+        let onramp_address = x"47a1f0a819457f01153f35c6b6b0d42e2e16e91e";
+
+        offramp::apply_source_chain_config_updates(
+            owner,
+            vector[EVM_SOURCE_CHAIN_SELECTOR],
+            vector[true], // is_enabled
+            vector[true], // is_rmn_verification_disabled
+            vector[onramp_address]
+        );
+
+        // https://explorer.aptoslabs.com/txn/6668426643/payload?network=testnet
+        let signers = vector[
+            x"23f7c3895726904020bf79ed45e294e9e8f675b3c8ac4ccb6f0365d46ea8f948",
+            x"d95f678f5dd5b715f809fc8c7a7848c9e122d9ba04b1480b41ae04eb36d118cb",
+            x"61ec5f4bbb6a5f2c4262d3a4aa9dd33b4da6e29a069254d0e0e188a84c31ade7",
+            x"326ca02220991762549f59b7d5fc727787d546f5d42fa7a9f4f1f62bec267d2c"
+        ];
+
+        let transmitters = vector[signer::address_of(ccip_offramp), signer::address_of(
+            owner
+        )];
+        let f = 1; // BigF value for OCR config
+
+        // Set up OCR3 config for commit plugin with the exact configuration
+        // https://explorer.aptoslabs.com/txn/6668426643/payload?network=testnet
+        offramp::set_ocr3_config(
+            owner,
+            config_digest, // config_digest
+            ocr3_base::ocr_plugin_type_commit(),
+            f,
+            true, // is_signature_verification_enabled - must be true for commit plugin
+            signers,
+            transmitters
+        );
+
+        let config = offramp::latest_config_details(ocr3_base::ocr_plugin_type_commit());
+        assert!(ocr3_base::config_signers(&config) == signers);
+        assert!(ocr3_base::config_transmitters(&config) == transmitters);
+
+        // ===== Build the commit report with exact transaction data =====
+
+        // Create the report context - this is what the transmitters would sign
+        let report_context = vector[config_digest, sequence_bytes];
+
+        // https://explorer.aptoslabs.com/txn/6668426995/userTxnOverview?network=testnet
+
+        // Deserialized commit report
+
+        // 0xc6bcb7d2c22391db9b56fc98d6ef142e7d8f7035dc75fae2bfc469daa1b0d0ba::offramp::CommitReport {
+        //   price_updates: 0xc6bcb7d2c22391db9b56fc98d6ef142e7d8f7035dc75fae2bfc469daa1b0d0ba::offramp::PriceUpdates {
+        //     token_price_updates: [
+        //       0xc6bcb7d2c22391db9b56fc98d6ef142e7d8f7035dc75fae2bfc469daa1b0d0ba::offramp::TokenPriceUpdate {
+        //         source_token: @0xa,
+        //         usd_per_token: 500000000000000000000
+        //       }
+        //     ],
+        //     gas_price_updates: []
+        //   },
+        //   blessed_merkle_roots: [],
+        //   unblessed_merkle_roots: [
+        //     0xc6bcb7d2c22391db9b56fc98d6ef142e7d8f7035dc75fae2bfc469daa1b0d0ba::offramp::MerkleRoot {
+        //       EVM_SOURCE_CHAIN_SELECTOR: 909606746561742123,
+        //       on_ramp_address: 0x47a1f0a819457f01153f35c6b6b0d42e2e16e91e,
+        //       min_seq_nr: 1,
+        //       max_seq_nr: 1,
+        //       merkle_root: 0x258dc7f9ec033388ee50bf3e0debfc841a278054f5b2ce41728f7459267c719e
+        //     }
+        //   ],
+        //   rmn_signatures: []
+        // }
+
+        // Create the commit report
+        let commit_report_bytes =
+            x"01000000000000000000000000000000000000000000000000000000000000000a000050efe2d6e41a1b00000000000000000000000000000000000000000000000000012b851c4684929f0c1447a1f0a819457f01153f35c6b6b0d42e2e16e91e01000000000000000100000000000000258dc7f9ec033388ee50bf3e0debfc841a278054f5b2ce41728f7459267c719e00";
+        offramp::commit(
+            ccip_offramp,
+            report_context,
+            commit_report_bytes,
+            vector[
+                x"23f7c3895726904020bf79ed45e294e9e8f675b3c8ac4ccb6f0365d46ea8f948581f47bda72115bed3bc50bba6ddbc56601592524c0527206b035574add85f5258be225f913f08817615854459891e1ccbab3f730a5c3a5caa0cfd742e625c00",
+                x"d95f678f5dd5b715f809fc8c7a7848c9e122d9ba04b1480b41ae04eb36d118cb7f8850db30e12a6807f8eefeae6bba136669235602529f993da0139d4895f184444a88510ae7a8247d5d683bb7a5ff5ac26cebdc7b0f88eb1b09f4632160cb08"
+            ]
+        );
+
+        // ====== Execute ======
+
+        // Set up OCR3 config for commit plugin with the exact configuration
+        // https://explorer.aptoslabs.com/txn/6668426658/payload?network=testnet
+
+        let config_digest =
+            x"000a616fac87d8b5406dc2f3149e501a3952f3a3af404f8ce58e80875b524819";
+        let f = 1; // BigF value for OCR config
+        let signers = vector[
+            x"23f7c3895726904020bf79ed45e294e9e8f675b3c8ac4ccb6f0365d46ea8f948",
+            x"d95f678f5dd5b715f809fc8c7a7848c9e122d9ba04b1480b41ae04eb36d118cb",
+            x"61ec5f4bbb6a5f2c4262d3a4aa9dd33b4da6e29a069254d0e0e188a84c31ade7",
+            x"326ca02220991762549f59b7d5fc727787d546f5d42fa7a9f4f1f62bec267d2c"
+        ];
+        let transmitters = vector[signer::address_of(ccip_offramp), signer::address_of(
+            owner
+        )];
+
+        offramp::set_ocr3_config(
+            owner,
+            config_digest, // config_digest
+            ocr3_base::ocr_plugin_type_execution(),
+            f,
+            false, // is_signature_verification_enabled
+            signers,
+            transmitters
+        );
+
+        // https://explorer.aptoslabs.com/txn/6668427121/userTxnOverview?network=testnet
+
+        let report_context = vector[
+            x"000a616fac87d8b5406dc2f3149e501a3952f3a3af404f8ce58e80875b524819", // config_digest
+            x"0000000000000000000000000000000000000000000000000000000000000009" // sequence_number
+        ];
+        let report =
+            x"2b851c4684929f0c20865dcacbd6afb6a2288daa164caf75517009a289fa3135281fb1e4800b11bc2b851c4684929f0c15a9c133ee53500a0100000000000000000000000000000014d87929a32cf0cbdc9e2d07ffc7c33344079de7271268656c6c6f20434349505265636569766572bd8a1fb0af25dc8700d2d302cfbae718c3b2c3c61cfe47f58a45b1126c006490a086010000000000000000000000000000000000000000000000000000000000000000";
+
+        // Deserialized execute report
+
+        // 0xc6bcb7d2c22391db9b56fc98d6ef142e7d8f7035dc75fae2bfc469daa1b0d0ba::offramp::ExecutionReport {
+        //   EVM_SOURCE_CHAIN_SELECTOR: 909606746561742123,
+        //   message: 0xc6bcb7d2c22391db9b56fc98d6ef142e7d8f7035dc75fae2bfc469daa1b0d0ba::offramp::Any2AptosRampMessage {
+        //     header: 0xc6bcb7d2c22391db9b56fc98d6ef142e7d8f7035dc75fae2bfc469daa1b0d0ba::offramp::RampMessageHeader {
+        //       message_id: 0x20865dcacbd6afb6a2288daa164caf75517009a289fa3135281fb1e4800b11bc,
+        //       EVM_SOURCE_CHAIN_SELECTOR: 909606746561742123,
+        //       dest_chain_selector: 743186221051783445,
+        //       sequence_number: 1,
+        //       nonce: 0
+        //     },
+        //     sender: 0xd87929a32cf0cbdc9e2d07ffc7c33344079de727,
+        //     data: 0x68656c6c6f20434349505265636569766572,
+        //     receiver: @0xbd8a1fb0af25dc8700d2d302cfbae718c3b2c3c61cfe47f58a45b1126c006490,
+        //     gas_limit: 100000,
+        //     token_amounts: []
+        //   },
+        //   offchain_token_data: [],
+        //   proofs: []
+        //  }
+
+        offramp::execute(ccip_offramp, report_context, report);
+
+        let execution_state = offramp::get_execution_state(EVM_SOURCE_CHAIN_SELECTOR, 1); // sequence_number is 1
+        assert!(execution_state == 2); // EXECUTION_STATE_SUCCESS is 2
+    }
+
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            ccip = @ccip,
+            ccip_offramp = @ccip_offramp,
+            owner = @0x100,
+            burn_mint_token_pool = @burn_mint_token_pool,
+            lock_release_token_pool = @lock_release_token_pool
+        )
+    ]
+    fun test_manually_execute(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_offramp: &signer,
+        owner: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer
+    ) {
+        setup(
+            aptos_framework,
+            ccip,
+            ccip_offramp,
+            owner,
+            burn_mint_token_pool,
+            lock_release_token_pool,
+            BURN_MINT_TOKEN_POOL,
+            BURN_MINT_TOKEN_SEED
+        );
+
+        let merkle_root =
+            x"258dc7f9ec033388ee50bf3e0debfc841a278054f5b2ce41728f7459267c719e";
+        offramp::test_add_root(merkle_root, timestamp::now_seconds() - 3700);
+
+        let report =
+            x"2b851c4684929f0c20865dcacbd6afb6a2288daa164caf75517009a289fa3135281fb1e4800b11bc2b851c4684929f0c15a9c133ee53500a0100000000000000000000000000000014d87929a32cf0cbdc9e2d07ffc7c33344079de7271268656c6c6f20434349505265636569766572bd8a1fb0af25dc8700d2d302cfbae718c3b2c3c61cfe47f58a45b1126c006490a086010000000000000000000000000000000000000000000000000000000000000000";
+        offramp::manually_execute(report);
+
+        let execution_state = offramp::get_execution_state(EVM_SOURCE_CHAIN_SELECTOR, 1); // sequence_number is 1
+        assert!(execution_state == 2); // EXECUTION_STATE_SUCCESS is 2
+    }
+
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            ccip = @ccip,
+            ccip_offramp = @ccip_offramp,
+            owner = @0x100,
+            burn_mint_token_pool = @burn_mint_token_pool,
+            lock_release_token_pool = @lock_release_token_pool,
+            receiver = @0xbed8
+        )
+    ]
+    fun test_burn_mint_pool_execute_single_report_with_token_transfer(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_offramp: &signer,
+        owner: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer,
+        receiver: &signer
+    ) {
+        test_execute_single_report_with_token_transfer(
+            aptos_framework,
+            ccip,
+            ccip_offramp,
+            owner,
+            burn_mint_token_pool,
+            lock_release_token_pool,
+            receiver,
+            BURN_MINT_TOKEN_POOL,
+            BURN_MINT_TOKEN_SEED
+        )
+    }
+
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            ccip = @ccip,
+            ccip_offramp = @ccip_offramp,
+            owner = @0x100,
+            burn_mint_token_pool = @burn_mint_token_pool,
+            lock_release_token_pool = @lock_release_token_pool,
+            receiver = @0xbed8
+        )
+    ]
+    fun test_lock_release_pool_execute_single_report_with_token_transfer(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_offramp: &signer,
+        owner: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer,
+        receiver: &signer
+    ) {
+        test_execute_single_report_with_token_transfer(
+            aptos_framework,
+            ccip,
+            ccip_offramp,
+            owner,
+            burn_mint_token_pool,
+            lock_release_token_pool,
+            receiver,
+            LOCK_RELEASE_TOKEN_POOL,
+            LOCK_RELEASE_TOKEN_SEED
+        )
+    }
+
+    // Helper function to test execute single report with token transfer
+    // Specifying pool type (burn/mint or lock/release)
+    fun test_execute_single_report_with_token_transfer(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_offramp: &signer,
+        owner: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer,
+        receiver: &signer,
+        pool_type: u8,
+        token_seed: vector<u8>
+    ) {
+        let (_owner_addr, token_obj) =
+            setup(
+                aptos_framework,
+                ccip,
+                ccip_offramp,
+                owner,
+                burn_mint_token_pool,
+                lock_release_token_pool,
+                pool_type,
+                token_seed
+            );
+
+        let token_addr = object::object_address(&token_obj);
+        let receiver_addr = signer::address_of(receiver);
+        account::create_account_for_test(receiver_addr);
+
+        let onramp_address = x"47a1f0a819457f01153f35c6b6b0d42e2e16e91e";
+
+        offramp::apply_source_chain_config_updates(
+            owner,
+            vector[EVM_SOURCE_CHAIN_SELECTOR],
+            vector[true], // is_enabled
+            vector[true], // is_rmn_verification_disabled
+            vector[onramp_address]
+        );
+
+        // Check initial balance (should be 0)
+        let initial_balance = primary_fungible_store::balance(receiver_addr, token_obj);
+        assert!(initial_balance == 0);
+
+        // Create token transfer with amount
+        let token_amount: u256 = 1000;
+        let token_transfer =
+            offramp::test_create_any2aptos_token_transfer(
+                MOCK_EVM_ADDRESS_VECTOR, // source_pool_address
+                token_addr, // dest_token_address
+                0, // dest_gas_amount
+                vector[], // extra_data
+                token_amount // amount to transfer
+            );
+
+        let token_transfers = vector[token_transfer];
+        let message_id =
+            x"20865dcacbd6afb6a2288daa164caf75517009a289fa3135281fb1e4800b11bc";
+        let dest_chain_selector: u64 = 743186221051783445;
+        let sequence_number: u64 = 1;
+        let nonce: u64 = 0;
+        let sender = x"d87929a32cf0cbdc9e2d07ffc7c33344079de727";
+        let data = x"68656c6c6f20434349505265636569766572";
+        let gas_limit: u256 = 100000;
+
+        let header =
+            offramp::test_create_ramp_message_header(
+                message_id,
+                EVM_SOURCE_CHAIN_SELECTOR,
+                dest_chain_selector,
+                sequence_number,
+                nonce
+            );
+        let message =
+            offramp::test_create_any2aptos_ramp_message(
+                header,
+                sender,
+                data,
+                receiver_addr,
+                gas_limit,
+                token_transfers
+            );
+        let metadata_hash =
+            offramp::test_calculate_metadata_hash(
+                EVM_SOURCE_CHAIN_SELECTOR,
+                dest_chain_selector,
+                onramp_address
+            );
+        let hashed_leaf = offramp::test_calculate_message_hash(&message, metadata_hash);
+
+        let proofs = vector[];
+        let root = merkle_proof::merkle_root(hashed_leaf, proofs);
+
+        // Simply commit by adding root to
+        offramp::test_add_root(root, timestamp::now_seconds() - 3700);
+
+        // Create offchain token data (needed for token transfers)
+        let offchain_token_data: vector<vector<u8>> = vector[vector[]];
+
+        // Create execution report using helper function
+        let execution_report =
+            offramp::test_create_execution_report(
+                EVM_SOURCE_CHAIN_SELECTOR,
+                message,
+                offchain_token_data,
+                vector[] // empty proofs for simplicity
+            );
+
+        offramp::test_execute_single_report(execution_report);
+
+        let final_balance = primary_fungible_store::balance(receiver_addr, token_obj);
+        assert!(final_balance == (token_amount as u64));
+
+        let execution_state =
+            offramp::get_execution_state(EVM_SOURCE_CHAIN_SELECTOR, sequence_number);
+        assert!(execution_state == 2); // 2 is EXECUTION_STATE_SUCCESS
+    }
+
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            ccip = @ccip,
+            ccip_offramp = @ccip_offramp,
+            owner = @0x100,
+            burn_mint_token_pool = @burn_mint_token_pool,
+            lock_release_token_pool = @lock_release_token_pool
+        )
+    ]
+    fun test_transfer_ownership_flow(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_offramp: &signer,
+        owner: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer
+    ) {
+        setup(
+            aptos_framework,
+            ccip,
+            ccip_offramp,
+            owner,
+            burn_mint_token_pool,
+            lock_release_token_pool,
+            BURN_MINT_TOKEN_POOL,
+            BURN_MINT_TOKEN_SEED
+        );
+        let new_owner = signer::address_of(aptos_framework);
+        account::create_account_for_test(new_owner);
+
+        offramp::transfer_ownership(owner, new_owner);
+
+        offramp::accept_ownership(aptos_framework);
+
+        offramp::execute_ownership_transfer(owner, new_owner);
+
+        assert!(offramp::owner() == new_owner);
+    }
+
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            ccip = @ccip,
+            ccip_offramp = @ccip_offramp,
+            owner = @0x100,
+            burn_mint_token_pool = @burn_mint_token_pool,
+            lock_release_token_pool = @lock_release_token_pool
+        )
+    ]
+    fun test_getters(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_offramp: &signer,
+        owner: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer
+    ) {
+        setup(
+            aptos_framework,
+            ccip,
+            ccip_offramp,
+            owner,
+            burn_mint_token_pool,
+            lock_release_token_pool,
+            BURN_MINT_TOKEN_POOL,
+            BURN_MINT_TOKEN_SEED
+        );
+
+        let latest_price_sequence_number = offramp::get_latest_price_sequence_number();
+        assert!(latest_price_sequence_number == 0);
+
+        let (source_chain_selectors, _source_chain_configs) =
+            offramp::get_all_source_chain_configs();
+        assert!(source_chain_selectors.length() == 1);
+        assert!(source_chain_selectors[0] == EVM_SOURCE_CHAIN_SELECTOR);
+    }
+
+    // =============== Error handling tests ===============
+
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            ccip = @ccip,
+            ccip_offramp = @ccip_offramp,
+            owner = @0x100,
+            burn_mint_token_pool = @burn_mint_token_pool,
+            lock_release_token_pool = @lock_release_token_pool
+        )
+    ]
+    #[expected_failure(abort_code = 65540, location = ccip_offramp::offramp)]
+    fun test_invalid_source_chain_selector(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_offramp: &signer,
+        owner: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer
+    ) {
+        setup(
+            aptos_framework,
+            ccip,
+            ccip_offramp,
+            owner,
+            burn_mint_token_pool,
+            lock_release_token_pool,
+            BURN_MINT_TOKEN_POOL,
+            BURN_MINT_TOKEN_SEED
+        );
+
+        // E_UNKNOWN_SOURCE_CHAIN_SELECTOR
+        let _execution_state = offramp::get_execution_state(123456789, 1);
+    }
+
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            ccip = @ccip,
+            ccip_offramp = @ccip_offramp,
+            owner = @0x100,
+            burn_mint_token_pool = @burn_mint_token_pool,
+            lock_release_token_pool = @lock_release_token_pool
+        )
+    ]
+    #[expected_failure(abort_code = 65550, location = ccip_offramp::offramp)]
+    fun test_invalid_root_retrieval(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_offramp: &signer,
+        owner: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer
+    ) {
+        setup(
+            aptos_framework,
+            ccip,
+            ccip_offramp,
+            owner,
+            burn_mint_token_pool,
+            lock_release_token_pool,
+            BURN_MINT_TOKEN_POOL,
+            BURN_MINT_TOKEN_SEED
+        );
+
+        // E_INVALID_ROOT
+        let _merkle_root = offramp::get_merkle_root(vector[]);
+    }
+}

--- a/contracts/ccip/ccip_offramp/tests/utils/bcs_helper.move
+++ b/contracts/ccip/ccip_offramp/tests/utils/bcs_helper.move
@@ -1,0 +1,48 @@
+#[test_only]
+module ccip_offramp::bcs_helper {
+    use std::bcs;
+    use ccip_offramp::offramp::{Any2AptosTokenTransfer};
+
+    public fun create_execution_report_bytes(
+        source_chain_selector: u64,
+        message_id: vector<u8>,
+        dest_chain_selector: u64,
+        sequence_number: u64,
+        nonce: u64,
+        sender: vector<u8>,
+        data: vector<u8>,
+        receiver: address,
+        gas_limit: u256,
+        token_transfers: vector<Any2AptosTokenTransfer>,
+        offchain_token_data: vector<vector<u8>>,
+        proofs: vector<vector<u8>>
+    ): vector<u8> {
+        // Serialize the execution report sequentially to match deserializer
+        let report_bytes = vector[];
+
+        // First serialize source_chain_selector
+        report_bytes.append(bcs::to_bytes(&source_chain_selector));
+
+        // Then serialize message parts in the exact order they're deserialized
+        report_bytes.append(message_id);
+        report_bytes.append(bcs::to_bytes(&source_chain_selector)); // header.source_chain_selector
+        report_bytes.append(bcs::to_bytes(&dest_chain_selector));
+        report_bytes.append(bcs::to_bytes(&sequence_number));
+        report_bytes.append(bcs::to_bytes(&nonce));
+
+        // Then message fields after header
+        report_bytes.append(bcs::to_bytes(&sender));
+        report_bytes.append(bcs::to_bytes(&data));
+        report_bytes.append(bcs::to_bytes(&receiver));
+        report_bytes.append(bcs::to_bytes(&gas_limit));
+
+        // Serialize token transfers
+        report_bytes.append(bcs::to_bytes(&token_transfers));
+
+        // Serialize offchain token data and proofs
+        report_bytes.append(bcs::to_bytes(&offchain_token_data));
+        report_bytes.append(bcs::to_bytes(&proofs));
+
+        report_bytes
+    }
+}


### PR DESCRIPTION
## Offramp and OCR3 tests
- Test commit and execute flow
- Tests end to end flow with burn/mint and lock/release token pools.

## Notes
Ignore removal of `inline` keywords, test coverage does not count `inline` functions so have to remove.
- Will revert those changes

```
Test result: OK. Total tests: 26; passed: 26; failed: 0
+-------------------------+
| Move Coverage Summary   |
+-------------------------+
Module c6bcb7d2c22391db9b56fc98d6ef142e7d8f7035dc75fae2bfc469daa1b0d0ba::ocr3_base
>>> % Module coverage: 83.36
Module c6bcb7d2c22391db9b56fc98d6ef142e7d8f7035dc75fae2bfc469daa1b0d0ba::offramp
>>> % Module coverage: 62.57
+-------------------------+
| % Move Coverage: 66.11  |
+-------------------------+
```

### Testing Notes
**Removing MCMS lines increases to 75% coverage** for `offramp.move`