### PR TITLE
Add extra SVM validation, address/remove todos

### DIFF
--- a/contracts/ccip/ccip/sources/fee_quoter.move
+++ b/contracts/ccip/ccip/sources/fee_quoter.move
@@ -50,6 +50,30 @@ module ccip::fee_quoter {
 
     const CCIP_LOCK_OR_BURN_V1_RET_BYTES: u32 = 32;
 
+    /// The maximum number of accounts that can be passed in SVMExtraArgs.
+    const SVM_EXTRA_ARGS_MAX_ACCOUNTS: u64 = 64;
+
+    /// Number of overhead accounts needed for message execution on SVM.
+    /// These are message.receiver, and the OffRamp Signer PDA specific to the receiver.
+    const SVM_MESSAGING_ACCOUNTS_OVERHEAD: u64 = 2;
+
+    /// The size of each SVM account (in bytes).
+    const SVM_ACCOUNT_BYTE_SIZE: u64 = 32;
+
+    /// The expected static payload size of a token transfer when Borsh encoded and submitted to SVM.
+    /// TokenPool extra data and offchain data sizes are dynamic, and should be accounted for separately.
+    const SVM_TOKEN_TRANSFER_DATA_OVERHEAD: u64 = (4 + 32) // source_pool
+    + 32 // token_address
+    + 4 // gas_amount
+    + 4 // extra_data overhead
+    + 32 // amount
+    + 32 // size of the token lookup table account
+    + 32 // token-related accounts in the lookup table, over-estimated to 32, typically between 11 - 13
+    + 32 // token account belonging to the token receiver, e.g ATA, not included in the token lookup table
+    + 32 // per-chain token pool config, not included in the token lookup table
+    + 32 // per-chain token billing config, not always included in the token lookup table
+    + 32; // OffRamp pool signer PDA, not included in the token lookup table;
+
     const MAX_U64: u256 = 18446744073709551615;
     const MAX_U160: u256 = 1461501637330902918203684832716283019655932542975;
     const MAX_U256: u256 =
@@ -212,6 +236,8 @@ module ccip::fee_quoter {
     const E_TO_TOKEN_AMOUNT_TOO_LARGE: u64 = 29;
     const E_UNKNOWN_FUNCTION: u64 = 30;
     const E_ZERO_TOKEN_PRICE: u64 = 31;
+    const E_TOO_MANY_SVM_EXTRA_ARGS_ACCOUNTS: u64 = 32;
+    const E_INVALID_SVM_EXTRA_ARGS_WRITABLE_BITMAP: u64 = 33;
 
     #[view]
     public fun type_and_version(): String {
@@ -621,9 +647,15 @@ module ccip::fee_quoter {
                 || chain_family_selector == CHAIN_FAMILY_SELECTOR_SUI) {
                 resolve_generic_gas_limit(dest_chain_config, extra_args)
             } else if (chain_family_selector == CHAIN_FAMILY_SELECTOR_SVM) {
-                let require_valid_token_receiver = tokens_len > 0;
                 resolve_svm_gas_limit(
-                    dest_chain_config, extra_args, require_valid_token_receiver
+                    dest_chain_config,
+                    state,
+                    dest_chain_selector,
+                    extra_args,
+                    receiver,
+                    data_len,
+                    tokens_len,
+                    local_token_addresses
                 )
             } else {
                 abort error::invalid_argument(E_UNKNOWN_CHAIN_FAMILY_SELECTOR)
@@ -783,38 +815,98 @@ module ccip::fee_quoter {
 
     inline fun resolve_svm_gas_limit(
         dest_chain_config: &DestChainConfig,
+        state: &FeeQuoterState,
+        dest_chain_selector: u64,
         extra_args: vector<u8>,
-        require_valid_token_receiver: bool
+        receiver: vector<u8>,
+        data_len: u64,
+        tokens_len: u64,
+        local_token_addresses: vector<address>
     ): u256 {
         let extra_args_len = extra_args.length();
         assert!(extra_args_len > 0, error::invalid_argument(E_INVALID_EXTRA_ARGS_DATA));
+
         let (
             compute_units,
-            _account_is_writable_bitmap,
+            account_is_writable_bitmap,
             allow_out_of_order_execution,
             token_receiver,
-            _accounts
+            accounts
         ) = decode_svm_extra_args(extra_args);
+
+        let gas_limit = compute_units;
+
         assert!(
             !dest_chain_config.enforce_out_of_order || allow_out_of_order_execution,
             error::invalid_argument(E_EXTRA_ARG_OUT_OF_ORDER_EXECUTION_MUST_BE_TRUE)
         );
         assert!(
-            compute_units <= dest_chain_config.max_per_msg_gas_limit,
+            gas_limit <= dest_chain_config.max_per_msg_gas_limit,
             error::invalid_argument(E_MESSAGE_COMPUTE_UNIT_LIMIT_TOO_HIGH)
         );
-        if (require_valid_token_receiver) {
+
+        let accounts_length = accounts.length();
+        // The max payload size for SVM is heavily dependent on the accounts passed into extra args and the number of
+        // tokens. Below, token and account overhead will count towards maxDataBytes.
+        let svm_expanded_data_length = data_len;
+
+        let receiver_uint = eth_abi::decode_u256_value(receiver);
+        if (receiver_uint == 0) {
+            // When message receiver is zero, CCIP receiver is not invoked on SVM.
+            // There should not be additional accounts specified for the receiver.
             assert!(
-                token_receiver.length() == 32,
-                error::invalid_argument(E_INVALID_TOKEN_RECEIVER)
+                accounts_length == 0,
+                error::invalid_argument(E_TOO_MANY_SVM_EXTRA_ARGS_ACCOUNTS)
             );
-            let token_receiver_uint = eth_abi::decode_u256_value(token_receiver);
+        } else {
+            // The messaging accounts needed for CCIP receiver on SVM are:
+            // message receiver, offramp PDA signer,
+            // plus remaining accounts specified in SVM extraArgs. Each account is 32 bytes.
+            svm_expanded_data_length +=((
+                accounts_length + SVM_MESSAGING_ACCOUNTS_OVERHEAD
+            ) * SVM_ACCOUNT_BYTE_SIZE);
+        };
+
+        if (tokens_len > 0) {
             assert!(
-                token_receiver_uint > 0,
+                token_receiver.length() == 32
+                    && eth_abi::decode_u256_value(token_receiver) != 0,
                 error::invalid_argument(E_INVALID_TOKEN_RECEIVER)
             );
         };
-        compute_units as u256
+        assert!(
+            accounts_length <= SVM_EXTRA_ARGS_MAX_ACCOUNTS,
+            error::invalid_argument(E_TOO_MANY_SVM_EXTRA_ARGS_ACCOUNTS)
+        );
+        assert!(
+            (account_is_writable_bitmap >> (accounts_length as u8)) == 0,
+            error::invalid_argument(E_INVALID_SVM_EXTRA_ARGS_WRITABLE_BITMAP)
+        );
+
+        svm_expanded_data_length += tokens_len * SVM_TOKEN_TRANSFER_DATA_OVERHEAD;
+
+        // The token destBytesOverhead can be very different per token so we have to take it into account as well.
+        for (i in 0..tokens_len) {
+            let local_token_address = local_token_addresses[i];
+            let destBytesOverhead =
+                get_token_transfer_fee_config_internal(
+                    state, dest_chain_selector, local_token_address
+                ).dest_bytes_overhead;
+
+            // Pools get CCIP_LOCK_OR_BURN_V1_RET_BYTES by default, but if an override is set we use that instead.
+            if (destBytesOverhead > 0) {
+                svm_expanded_data_length +=(destBytesOverhead as u64);
+            } else {
+                svm_expanded_data_length +=(CCIP_LOCK_OR_BURN_V1_RET_BYTES as u64);
+            }
+        };
+
+        assert!(
+            svm_expanded_data_length <= (dest_chain_config.max_data_bytes as u64),
+            error::invalid_argument(E_MESSAGE_TOO_LARGE)
+        );
+
+        gas_limit as u256
     }
 
     inline fun decode_generic_extra_args(

--- a/contracts/ccip/ccip/sources/fee_quoter.move
+++ b/contracts/ccip/ccip/sources/fee_quoter.move
@@ -861,9 +861,12 @@ module ccip::fee_quoter {
     inline fun decode_svm_extra_args(
         extra_args: vector<u8>
     ): (u32, u64, bool, vector<u8>, vector<vector<u8>>) {
-        // TODO: we need extra validation here. if extra_args length is less than tag length + data length,
-        // vector::slice will revert.
         let extra_args_len = extra_args.length();
+        assert!(
+            extra_args_len >= 4,
+            error::invalid_argument(E_INVALID_EXTRA_ARGS_DATA)
+        );
+
         let args_tag = extra_args.slice(0, 4);
         assert!(
             args_tag == SVM_EXTRA_ARGS_V1_TAG,

--- a/contracts/ccip/ccip/sources/state_object.move
+++ b/contracts/ccip/ccip/sources/state_object.move
@@ -52,20 +52,6 @@ module ccip::state_object {
         move_to(&object_signer, StateObjectRefs { extend_ref, transfer_ref });
     }
 
-    // TODO: this was previous a single function:
-    //
-    //   #[view]
-    //   public fun object_address(): address {
-    //       // hard code the object seed directly in order to keep the function inline.
-    //       object::create_object_address(&@ccip, b"CCIPStateObject")
-    //   }
-    //
-    // but it was failing to deploy with the following error:
-    //
-    //   "Error": "Simulation failed with status: CONSTRAINT_NOT_SATISFIED\n
-    //             Execution failed with message: metadata and code bundle mismatch: Unknown attribute (1) for key: object_address"
-    //
-    // Investigate whether this is a compiler issue and if we can revert to a single function.
     #[view]
     public fun get_object_address(): address {
         object_address()

--- a/contracts/ccip/ccip_ping_pong_demo/sources/ping_pong_demo.move
+++ b/contracts/ccip/ccip_ping_pong_demo/sources/ping_pong_demo.move
@@ -195,7 +195,6 @@ module ccip_ping_pong_demo::ping_pong_demo {
         option::none()
     }
 
-    // TODO: separate functions due to deploy error, see ccip::state_object
     #[view]
     public fun get_store_address(): address {
         store_address()

--- a/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
@@ -417,7 +417,6 @@ module burn_mint_token_pool::burn_mint_token_pool {
     // |                      Storage helpers                         |
     // ================================================================
 
-    // TODO: separate functions due to deploy error, see ccip::state_object
     #[view]
     public fun get_store_address(): address {
         store_address()

--- a/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
@@ -422,7 +422,6 @@ module lock_release_token_pool::lock_release_token_pool {
     // |                      Storage helpers                         |
     // ================================================================
 
-    // TODO: separate functions due to deploy error, see ccip::state_object
     #[view]
     public fun get_store_address(): address {
         store_address()

--- a/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
@@ -618,7 +618,6 @@ module usdc_token_pool::usdc_token_pool {
     // |                      Storage helpers                         |
     // ================================================================
 
-    // TODO: separate functions due to deploy error, see ccip::state_object
     #[view]
     public fun get_store_address(): address {
         store_address()

--- a/contracts/mcms/mcms/tests/mcms_test.move
+++ b/contracts/mcms/mcms/tests/mcms_test.move
@@ -323,9 +323,11 @@ module mcms::mcms_tests {
     }
 
     #[test(deployer = @mcms, owner = @mcms_owner, framework = @aptos_framework)]
-    #[expected_failure(
-        abort_code = mcms::mcms::E_VALID_UNTIL_EXPIRED, location = mcms::mcms
-    )]
+    #[
+        expected_failure(
+            abort_code = mcms::mcms::E_VALID_UNTIL_EXPIRED, location = mcms::mcms
+        )
+    ]
     public fun test_set_root__valid_until_expired(
         deployer: &signer, owner: &signer, framework: &signer
     ) {
@@ -431,9 +433,11 @@ module mcms::mcms_tests {
     }
 
     #[test(deployer = @mcms, owner = @mcms_owner, framework = @aptos_framework)]
-    #[expected_failure(
-        abort_code = mcms::mcms::E_WRONG_POST_OP_COUNT, location = mcms::mcms
-    )]
+    #[
+        expected_failure(
+            abort_code = mcms::mcms::E_WRONG_POST_OP_COUNT, location = mcms::mcms
+        )
+    ]
     public fun test_set_root__wrong_post_op_count(
         deployer: &signer, owner: &signer, framework: &signer
     ) {
@@ -630,9 +634,11 @@ module mcms::mcms_tests {
     }
 
     #[test(deployer = @mcms, owner = @mcms_owner, framework = @aptos_framework)]
-    #[expected_failure(
-        abort_code = mcms::mcms::E_INVALID_NUM_SIGNERS, location = mcms::mcms
-    )]
+    #[
+        expected_failure(
+            abort_code = mcms::mcms::E_INVALID_NUM_SIGNERS, location = mcms::mcms
+        )
+    ]
     public fun test_set_config__invalid_number_of_signers(
         deployer: &signer, owner: &signer, framework: &signer
     ) {
@@ -1263,8 +1269,6 @@ module mcms::mcms_tests {
         call_execute(execute_args);
     }
 
-    // // todo: test send values
-
     #[test(deployer = @mcms, owner = @mcms_owner, framework = @aptos_framework)]
     public fun test_ownable__transfer_ownership(
         deployer: &signer, owner: &signer, framework: &signer
@@ -1716,9 +1720,11 @@ module mcms::mcms_tests {
     }
 
     #[test(deployer = @mcms, owner = @mcms_owner, framework = @aptos_framework)]
-    #[expected_failure(
-        abort_code = mcms::mcms::E_OPERATION_NOT_READY, location = mcms::mcms
-    )]
+    #[
+        expected_failure(
+            abort_code = mcms::mcms::E_OPERATION_NOT_READY, location = mcms::mcms
+        )
+    ]
     public fun test_execute_batch_not_ready(
         deployer: &signer, owner: &signer, framework: &signer
     ) {
@@ -2137,9 +2143,11 @@ module mcms::mcms_tests {
     }
 
     #[test(deployer = @mcms, owner = @mcms_owner, framework = @aptos_framework)]
-    #[expected_failure(
-        abort_code = mcms::mcms::E_UNKNOWN_MCMS_MODULE, location = mcms::mcms
-    )]
+    #[
+        expected_failure(
+            abort_code = mcms::mcms::E_UNKNOWN_MCMS_MODULE, location = mcms::mcms
+        )
+    ]
     public fun test_unknown_mcms_module(
         deployer: &signer, owner: &signer, framework: &signer
     ) {


### PR DESCRIPTION
## Description
- Add extra SVM validation in fee_quoter
- Removing commented todos
    - inline function and view functions both separate is fine, [same pattern in Aptos core used](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/fungible_asset.move#L601-L610)