### PR TITLE
Revert module name assertion

### DIFF
--- a/bindings/ccip/token_admin_registry/token_admin_registry.go
+++ b/bindings/ccip/token_admin_registry/token_admin_registry.go
@@ -29,7 +29,7 @@ type TokenAdminRegistryInterface interface {
 	GetAllConfiguredTokens(opts *bind.CallOpts, startKey aptos.AccountAddress, maxCount uint64) ([]aptos.AccountAddress, aptos.AccountAddress, bool, error)
 	IsAdministrator(opts *bind.CallOpts, localToken aptos.AccountAddress, administrator aptos.AccountAddress) (bool, error)
 
-	UnregisterToken(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error)
+	UnregisterPool(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error)
 	SetPool(opts *bind.TransactOpts, localToken aptos.AccountAddress, tokenPoolAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 	TransferAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress, newAdmin aptos.AccountAddress) (*api.PendingTransaction, error)
 	AcceptAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error)
@@ -45,7 +45,7 @@ type TokenAdminRegistryEncoder interface {
 	GetTokenConfig(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetAllConfiguredTokens(startKey aptos.AccountAddress, maxCount uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	IsAdministrator(localToken aptos.AccountAddress, administrator aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
-	UnregisterToken(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	UnregisterPool(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	SetPool(localToken aptos.AccountAddress, tokenPoolAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	TransferAdminRole(localToken aptos.AccountAddress, newAdmin aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	AcceptAdminRole(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
@@ -56,7 +56,7 @@ type TokenAdminRegistryEncoder interface {
 	MCMSEntrypoint(Metadata aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
-const FunctionInfo = `[{"package":"ccip","module":"token_admin_registry","name":"accept_admin_role","parameters":[{"name":"local_token","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"assert_can_register","parameters":[{"name":"registry_owner_address","type":"address"},{"name":"token_pool_address","type":"address"},{"name":"fungible_asset_metadata","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"finish_lock_or_burn","parameters":[{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"finish_release_or_mint","parameters":[{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"mcms_entrypoint","parameters":[{"name":"_metadata","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"set_pool","parameters":[{"name":"local_token","type":"address"},{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"start_lock_or_burn","parameters":[{"name":"token_pool_address","type":"address"},{"name":"sender","type":"address"},{"name":"remote_chain_selector","type":"u64"},{"name":"receiver","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"token_admin_registry","name":"transfer_admin_role","parameters":[{"name":"local_token","type":"address"},{"name":"new_admin","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"unregister_token","parameters":[{"name":"local_token","type":"address"}]}]`
+const FunctionInfo = `[{"package":"ccip","module":"token_admin_registry","name":"accept_admin_role","parameters":[{"name":"local_token","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"assert_can_register","parameters":[{"name":"registry_owner_address","type":"address"},{"name":"token_pool_address","type":"address"},{"name":"fungible_asset_metadata","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"finish_lock_or_burn","parameters":[{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"finish_release_or_mint","parameters":[{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"mcms_entrypoint","parameters":[{"name":"_metadata","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"set_pool","parameters":[{"name":"local_token","type":"address"},{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"start_lock_or_burn","parameters":[{"name":"token_pool_address","type":"address"},{"name":"sender","type":"address"},{"name":"remote_chain_selector","type":"u64"},{"name":"receiver","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"token_admin_registry","name":"transfer_admin_role","parameters":[{"name":"local_token","type":"address"},{"name":"new_admin","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"unregister_pool","parameters":[{"name":"local_token","type":"address"}]}]`
 
 func NewTokenAdminRegistry(address aptos.AccountAddress, client aptos.AptosRpcClient) TokenAdminRegistryInterface {
 	contract := bind.NewBoundContract(address, "ccip", "token_admin_registry", client)
@@ -282,8 +282,8 @@ func (c TokenAdminRegistryContract) IsAdministrator(opts *bind.CallOpts, localTo
 
 // Entry Functions
 
-func (c TokenAdminRegistryContract) UnregisterToken(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error) {
-	module, function, typeTags, args, err := c.tokenAdminRegistryEncoder.UnregisterToken(localToken)
+func (c TokenAdminRegistryContract) UnregisterPool(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.tokenAdminRegistryEncoder.UnregisterPool(localToken)
 	if err != nil {
 		return nil, err
 	}
@@ -371,8 +371,8 @@ func (c tokenAdminRegistryEncoder) IsAdministrator(localToken aptos.AccountAddre
 	})
 }
 
-func (c tokenAdminRegistryEncoder) UnregisterToken(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("unregister_token", nil, []string{
+func (c tokenAdminRegistryEncoder) UnregisterPool(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("unregister_pool", nil, []string{
 		"address",
 	}, []any{
 		localToken,

--- a/contracts/ccip/ccip/sources/token_admin_registry.move
+++ b/contracts/ccip/ccip/sources/token_admin_registry.move
@@ -430,7 +430,7 @@ module ccip::token_admin_registry {
         abort error::permission_denied(E_NOT_FUNGIBLE_ASSET_OWNER)
     }
 
-    public entry fun unregister_token(
+    public entry fun unregister_pool(
         caller: &signer, local_token: address
     ) acquires TokenAdminRegistryState, TokenPoolRegistration {
         let state = borrow_state_mut();

--- a/contracts/ccip/ccip/tests/token_admin_registry_test.move
+++ b/contracts/ccip/ccip/tests/token_admin_registry_test.move
@@ -115,7 +115,7 @@ module ccip::token_admin_registry_test {
         assert!(admin == initial_administrator);
 
         // Unregister token
-        token_admin_registry::unregister_token(owner, token_addr);
+        token_admin_registry::unregister_pool(owner, token_addr);
 
         // Verify the token is unregistered (pool address should be @0x0)
         let pool_addr = token_admin_registry::get_pool(token_addr);
@@ -232,7 +232,7 @@ module ccip::token_admin_registry_test {
 
     #[test(ccip = @ccip, owner = @mcms, not_admin = @0x300)]
     #[expected_failure(abort_code = 327703, location = ccip::token_admin_registry)]
-    fun test_unregister_token_not_admin(
+    fun test_unregister_pool_not_admin(
         ccip: &signer, owner: &signer, not_admin: &signer
     ) {
         account::create_account_for_test(signer::address_of(not_admin));
@@ -250,12 +250,12 @@ module ccip::token_admin_registry_test {
 
         // Try to unregister the token with a non-admin signer
         // Should fail with E_NOT_ADMINISTRATOR
-        token_admin_registry::unregister_token(not_admin, token_addr);
+        token_admin_registry::unregister_pool(not_admin, token_addr);
     }
 
     #[test(ccip = @ccip, owner = @mcms)]
     #[expected_failure(abort_code = 65558, location = ccip::token_admin_registry)]
-    fun test_unregister_token_not_registered(
+    fun test_unregister_pool_not_registered(
         ccip: &signer, owner: &signer
     ) {
         let (ccip_obj_signer, _mock_obj_signer, token_obj) = setup(ccip, owner);
@@ -263,7 +263,7 @@ module ccip::token_admin_registry_test {
 
         // Try to unregister a token that is not registered
         // Should fail with E_FUNGIBLE_ASSET_NOT_REGISTERED
-        token_admin_registry::unregister_token(&ccip_obj_signer, token_addr);
+        token_admin_registry::unregister_pool(&ccip_obj_signer, token_addr);
     }
 
     #[test(ccip = @ccip, owner = @mcms)]

--- a/contracts/mcms/mcms/sources/mcms_registry.move
+++ b/contracts/mcms/mcms/sources/mcms_registry.move
@@ -571,10 +571,6 @@ module mcms::mcms_registry {
             proof_type_info.account_address() == account_address,
             error::invalid_argument(E_PROOF_NOT_AT_ACCOUNT_ADDRESS)
         );
-        assert!(
-            proof_type_info.module_name() == module_name_bytes,
-            error::invalid_argument(E_PROOF_NOT_IN_MODULE)
-        );
 
         let owner_signer =
             account::create_signer_with_capability(&registration.owner_cap);

--- a/contracts/mcms/mcms/tests/mcms_registry_test.move
+++ b/contracts/mcms/mcms/tests/mcms_registry_test.move
@@ -378,21 +378,6 @@ module mcms::mcms_registry_test {
         mcms_registry::accept_code_object(deployer, object_address);
     }
 
-    #[test(deployer = @mcms, owner = @mcms_owner, framework = @0x1)]
-    #[expected_failure(abort_code = 65542, location = mcms::mcms_registry)]
-    public fun test_proof_not_in_module(
-        deployer: &signer, owner: &signer, framework: &signer
-    ) {
-        setup(framework, deployer, owner);
-        mcms_account::init_module_for_testing(deployer);
-        mcms_registry::init_module_for_testing(deployer);
-
-        let module_name = string::utf8(b"incorrect_module_name");
-        // Fails with E_PROOF_NOT_IN_MODULE
-        let _owner_addr =
-            mcms_registry::register_entrypoint(deployer, module_name, ModuleProof {});
-    }
-
     // Test Module MCMS Entrypoint
     public fun mcms_entrypoint<T: key>(_metadata: object::Object<T>): option::Option<u128> {
         option::none()


### PR DESCRIPTION
- Revert Adding module name verification against proof back
- Rename `unregister_token` to `unregister_pool` for consistency