### PR TITLE
Remove transfer ref from lock_release_token_pool.move

### DIFF
--- a/bindings/ccip_token_pools/lock_release_token_pool/lock_release_token_pool/lock_release_token_pool.go
+++ b/bindings/ccip_token_pools/lock_release_token_pool/lock_release_token_pool/lock_release_token_pool.go
@@ -29,6 +29,9 @@ type LockReleaseTokenPoolInterface interface {
 	GetRemotePools(opts *bind.CallOpts, remoteChainSelector uint64) ([][]byte, error)
 	IsRemotePool(opts *bind.CallOpts, remoteChainSelector uint64, remotePoolAddress []byte) (bool, error)
 	GetRemoteToken(opts *bind.CallOpts, remoteChainSelector uint64) ([]byte, error)
+	PoolPrimaryStore(opts *bind.CallOpts) (aptos.AccountAddress, error)
+	Balance(opts *bind.CallOpts) (uint64, error)
+	DerivedBalance(opts *bind.CallOpts) (uint64, error)
 	IsSupportedChain(opts *bind.CallOpts, remoteChainSelector uint64) (bool, error)
 	GetSupportedChains(opts *bind.CallOpts) ([]uint64, error)
 	GetAllowlistEnabled(opts *bind.CallOpts) (bool, error)
@@ -56,6 +59,9 @@ type LockReleaseTokenPoolEncoder interface {
 	GetRemotePools(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	IsRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetRemoteToken(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	PoolPrimaryStore() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Balance() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	DerivedBalance() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	IsSupportedChain(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetSupportedChains() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetAllowlistEnabled() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
@@ -257,6 +263,69 @@ func (c LockReleaseTokenPoolContract) GetRemoteToken(opts *bind.CallOpts, remote
 
 	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
 		return *new([]byte), err
+	}
+	return r0, nil
+}
+
+func (c LockReleaseTokenPoolContract) PoolPrimaryStore(opts *bind.CallOpts) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.PoolPrimaryStore()
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	var (
+		r0 bind.StdObject
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+	return r0.Address(), nil
+}
+
+func (c LockReleaseTokenPoolContract) Balance(opts *bind.CallOpts) (uint64, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.Balance()
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	var (
+		r0 uint64
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(uint64), err
+	}
+	return r0, nil
+}
+
+func (c LockReleaseTokenPoolContract) DerivedBalance(opts *bind.CallOpts) (uint64, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.DerivedBalance()
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	var (
+		r0 uint64
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(uint64), err
 	}
 	return r0, nil
 }
@@ -497,6 +566,18 @@ func (c lockReleaseTokenPoolEncoder) GetRemoteToken(remoteChainSelector uint64) 
 	}, []any{
 		remoteChainSelector,
 	})
+}
+
+func (c lockReleaseTokenPoolEncoder) PoolPrimaryStore() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("pool_primary_store", nil, []string{}, []any{})
+}
+
+func (c lockReleaseTokenPoolEncoder) Balance() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("balance", nil, []string{}, []any{})
+}
+
+func (c lockReleaseTokenPoolEncoder) DerivedBalance() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("derived_balance", nil, []string{}, []any{})
 }
 
 func (c lockReleaseTokenPoolEncoder) IsSupportedChain(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {

--- a/contracts/ccip/ccip_onramp/tests/mock_token.move
+++ b/contracts/ccip/ccip_onramp/tests/mock_token.move
@@ -1,0 +1,45 @@
+#[test_only]
+module ccip_onramp::mock_token {
+    use std::fungible_asset::{Self, FungibleAsset, TransferRef};
+    use std::object::{Self, Object, ConstructorRef};
+    use std::string::{Self};
+    use std::option::{Self};
+    use std::primary_fungible_store;
+
+    public fun add_dynamic_dispatch_function(
+        ccip_onramp_signer: &signer, constructor_ref: &ConstructorRef
+    ) {
+        let deposit =
+            std::function_info::new_function_info(
+                ccip_onramp_signer,
+                string::utf8(b"mock_token"),
+                string::utf8(b"lock_or_burn")
+            );
+        let withdraw =
+            std::function_info::new_function_info(
+                ccip_onramp_signer,
+                string::utf8(b"mock_token"),
+                string::utf8(b"release_or_mint")
+            );
+        std::dispatchable_fungible_asset::register_dispatch_functions(
+            constructor_ref,
+            option::some(withdraw),
+            option::some(deposit),
+            option::none()
+        );
+    }
+
+    public fun lock_or_burn<T: key>(
+        store: Object<T>, fa: FungibleAsset, _transfer_ref: &TransferRef
+    ) {
+        fungible_asset::deposit(store, fa);
+    }
+
+    public fun release_or_mint<T: key>(
+        store: Object<T>, amount: u64, transfer_ref: &TransferRef
+    ): FungibleAsset {
+        primary_fungible_store::withdraw_with_ref(
+            transfer_ref, object::owner(store), amount
+        )
+    }
+}

--- a/contracts/ccip/ccip_onramp/tests/onramp_dispatchable_token_test.move
+++ b/contracts/ccip/ccip_onramp/tests/onramp_dispatchable_token_test.move
@@ -1,0 +1,721 @@
+#[test_only]
+module ccip_onramp::onramp_dispatchable_token_test {
+    use std::signer;
+    use std::string::{Self};
+    use std::option;
+    use std::vector;
+    use std::object::{Self, Object, ExtendRef, ObjectCore};
+    use std::account;
+    use std::fungible_asset::{Self, Metadata, MintRef, BurnRef, TransferRef, FungibleStore};
+    use std::primary_fungible_store;
+    use std::timestamp;
+    use std::event;
+
+    use ccip::token_admin_registry;
+    use ccip::rmn_remote;
+    use ccip::nonce_manager;
+    use ccip::eth_abi;
+    use ccip_onramp::onramp;
+    use ccip::auth::{Self};
+    use ccip::state_object::{Self};
+    use ccip::fee_quoter::{Self};
+    use ccip_onramp::mock_token;
+
+    use ccip_token_pool::token_pool;
+    use burn_mint_token_pool::burn_mint_token_pool;
+    use lock_release_token_pool::lock_release_token_pool;
+
+    const SOURCE_CHAIN_SELECTOR: u64 = 1;
+    const DEST_CHAIN_SELECTOR: u64 = 5678;
+    const CHAIN_FAMILY_SELECTOR_EVM: vector<u8> = x"2812d52c";
+    const CHAIN_FAMILY_SELECTOR_SVM: vector<u8> = x"1e10bdc4";
+    const CHAIN_FAMILY_SELECTOR_APTOS: vector<u8> = x"ac77ffec";
+    const TOKEN_AMOUNT: u64 = 5000;
+
+    const OUTBOUND_CAPACITY: u64 = 1000000000000000000;
+    const OUTBOUND_RATE: u64 = 1000000000000000000;
+    const INBOUND_CAPACITY: u64 = 1000000000000000000;
+    const INBOUND_RATE: u64 = 1000000000000000000;
+
+    const OWNER: address = @0x100;
+    const ROUTER: address = @0x200;
+    const FEE_AGGREGATOR: address = @0x300;
+    const ALLOWLIST_ADMIN: address = @0x400;
+    const SENDER: address = @0x500;
+
+    /// POOL TYPES
+    const BURN_MINT_TOKEN_POOL: u8 = 0;
+    const LOCK_RELEASE_TOKEN_POOL: u8 = 1;
+
+    const MOCK_EVM_ADDRESS: address = @0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97;
+    const MOCK_EVM_ADDRESS_VECTOR: vector<u8> = x"4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97";
+
+    const TOKEN_POOL_MODULE_NAME: vector<u8> = b"test_token_pool";
+
+    // Extra args constants
+    const GENERIC_EXTRA_ARGS_V2_TAG: vector<u8> = x"181dcf10";
+    const GAS_LIMIT: u64 = 5000000;
+    const ALLOW_OUT_OF_ORDER_EXECUTION: bool = true;
+
+    struct TestToken has key, store {
+        metadata: Object<Metadata>,
+        extend_ref: ExtendRef,
+        mint_ref: MintRef,
+        burn_ref: BurnRef,
+        transfer_ref: TransferRef
+    }
+
+    struct CCIPSendResult has drop {
+        message_id: vector<u8>,
+        token_obj: Object<Metadata>,
+        sender_store: Object<FungibleStore>,
+        fee_token_amount: u64,
+        sent_amount: u64
+    }
+
+    fun execute_ccip_send_test(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_onramp: &signer,
+        owner: &signer,
+        sender: &signer,
+        router: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer,
+        pool_type: u8,
+        token_name: vector<u8>,
+        is_dispatchable: bool,
+        generate_transfer_ref: bool
+    ): CCIPSendResult acquires TestToken {
+        let (_owner_addr, token_obj) =
+            setup(
+                aptos_framework,
+                ccip,
+                ccip_onramp,
+                owner,
+                burn_mint_token_pool,
+                lock_release_token_pool,
+                pool_type,
+                token_name,
+                is_dispatchable,
+                generate_transfer_ref
+            );
+
+        auth::apply_allowed_onramp_updates(
+            owner,
+            vector[], // onramps_to_remove
+            vector[onramp::get_state_address()] // onramps_to_add
+        );
+
+        let token_addr = object::object_address(&token_obj);
+        let token = borrow_global<TestToken>(token_addr);
+        let sent_amount = TOKEN_AMOUNT;
+
+        let sender_store =
+            primary_fungible_store::ensure_primary_store_exists(
+                signer::address_of(sender), token.metadata
+            );
+
+        // Mint tokens to sender store first
+        fungible_asset::mint_to(&token.mint_ref, sender_store, sent_amount);
+
+        let receiver = vector[];
+        eth_abi::encode_address(&mut receiver, MOCK_EVM_ADDRESS);
+        let data = b"hello world";
+        let token_addresses = vector[token_addr];
+        let token_amounts = vector[TOKEN_AMOUNT];
+        let token_store_addresses = vector[@0x0]; // Use primary store
+        let fee_token = token_addr; // Using same token for fee
+        let fee_token_store = @0x0; // Use primary store
+        let extra_args = create_valid_extra_args();
+
+        let fee_token_amount =
+            onramp::get_fee(
+                DEST_CHAIN_SELECTOR,
+                receiver,
+                data,
+                token_addresses,
+                token_amounts,
+                token_store_addresses,
+                fee_token,
+                fee_token_store,
+                extra_args
+            );
+
+        fungible_asset::mint_to(
+            &token.mint_ref,
+            sender_store,
+            fee_token_amount
+        );
+
+        let message_id =
+            onramp::ccip_send(
+                router,
+                sender,
+                DEST_CHAIN_SELECTOR,
+                receiver,
+                data,
+                token_addresses,
+                token_amounts,
+                token_store_addresses,
+                fee_token,
+                fee_token_store,
+                extra_args
+            );
+
+        CCIPSendResult {
+            message_id,
+            token_obj,
+            sender_store,
+            fee_token_amount,
+            sent_amount
+        }
+    }
+
+    fun assert_ccip_send_success(result: &CCIPSendResult) {
+        assert!(result.message_id.length() > 0);
+
+        // Verify sequence number was incremented
+        let (sequence_number, _, _) = onramp::get_dest_chain_config(DEST_CHAIN_SELECTOR);
+        assert!(sequence_number == 1);
+
+        // Verify tokens were transferred
+        let sender_balance = fungible_asset::balance(result.sender_store);
+        assert!(sender_balance == 0); // All tokens sent
+
+        // Verify fee token was transferred
+        // let token_metadata = object::convert<TestToken, Metadata>(result.token_obj);
+        let onramp_state_balance =
+            primary_fungible_store::balance(
+                onramp::get_state_address(), result.token_obj
+            );
+        assert!(onramp_state_balance == result.fee_token_amount);
+    }
+
+    fun assert_lock_release_pool_success(result: &CCIPSendResult) {
+        assert_ccip_send_success(result);
+
+        // Check token pool balance to see if tokens are locked
+        let token_pool_addr = lock_release_token_pool::get_store_address();
+        let token_pool_balance =
+            primary_fungible_store::balance(token_pool_addr, result.token_obj);
+        assert!(token_pool_balance == result.sent_amount);
+
+        assert!(
+            event::emitted_events<token_pool::Locked>().length() == 1
+        );
+    }
+
+    fun assert_burn_mint_pool_success(result: &CCIPSendResult) {
+        assert_ccip_send_success(result);
+        assert!(
+            event::emitted_events<token_pool::Burned>().length() == 1
+        );
+    }
+
+    // ========================== Dynamic Dispatch Tests with Token Pools ==========================
+    //
+    // These tests are used to verify the dynamic dispatch of the tokens registered with token pools
+    //
+    // - Dynamic dispatch for `burn_mint_token_pool` works because we use refs
+    // - For `lock_release_token_pool`, this takes an `Option<TransferRef>`
+    //   Tokens that have dynamic dispatch enabled NEED to provide a `TransferRef`
+    //   Tokens that do not have dynamic dispatch enabled can provide `option::none()`
+    // ============================================================================================
+
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            ccip = @ccip,
+            ccip_onramp = @ccip_onramp,
+            owner = @0x100,
+            sender = @0x500,
+            router = @0x200,
+            burn_mint_token_pool = @burn_mint_token_pool,
+            lock_release_token_pool = @lock_release_token_pool
+        )
+    ]
+    fun test_token_dispatch_ccip_send_lock_release_token_pool(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_onramp: &signer,
+        owner: &signer,
+        sender: &signer,
+        router: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer
+    ) acquires TestToken {
+        let result =
+            execute_ccip_send_test(
+                aptos_framework,
+                ccip,
+                ccip_onramp,
+                owner,
+                sender,
+                router,
+                burn_mint_token_pool,
+                lock_release_token_pool,
+                LOCK_RELEASE_TOKEN_POOL,
+                b"LockReleaseToken",
+                true, // is_dispatchable
+                true // generate_transfer_ref
+            );
+
+        assert_lock_release_pool_success(&result);
+    }
+
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            ccip = @ccip,
+            ccip_onramp = @ccip_onramp,
+            owner = @0x100,
+            sender = @0x500,
+            router = @0x200,
+            burn_mint_token_pool = @burn_mint_token_pool,
+            lock_release_token_pool = @lock_release_token_pool
+        )
+    ]
+    fun test_token_dispatch_ccip_send_burn_mint_token_pool(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_onramp: &signer,
+        owner: &signer,
+        sender: &signer,
+        router: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer
+    ) acquires TestToken {
+        let result =
+            execute_ccip_send_test(
+                aptos_framework,
+                ccip,
+                ccip_onramp,
+                owner,
+                sender,
+                router,
+                burn_mint_token_pool,
+                lock_release_token_pool,
+                BURN_MINT_TOKEN_POOL,
+                b"TestToken",
+                true, // is_dispatchable
+                false // generate_transfer_ref
+            );
+
+        assert_burn_mint_pool_success(&result);
+    }
+
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            ccip = @ccip,
+            ccip_onramp = @ccip_onramp,
+            owner = @0x100,
+            burn_mint_token_pool = @burn_mint_token_pool,
+            lock_release_token_pool = @lock_release_token_pool
+        )
+    ]
+    #[
+        expected_failure(
+            abort_code = lock_release_token_pool::lock_release_token_pool::E_DISPATCHABLE_TOKEN_WITHOUT_TRANSFER_REF,
+            location = lock_release_token_pool::lock_release_token_pool
+        )
+    ]
+    fun test_dispatchable_token_without_transfer_ref_lock_release_token_pool(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_onramp: &signer,
+        owner: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer
+    ) {
+        // E_DISPATCHABLE_TOKEN_WITHOUT_TRANSFER_REF
+        // Cannot register dispatchable token without a transfer ref
+        let (_owner_addr, _token_obj) =
+            setup(
+                aptos_framework,
+                ccip,
+                ccip_onramp,
+                owner,
+                burn_mint_token_pool,
+                lock_release_token_pool,
+                LOCK_RELEASE_TOKEN_POOL,
+                b"LockReleaseToken",
+                true, // is_dispatchable
+                false // generate_transfer_ref
+            );
+    }
+
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            ccip = @ccip,
+            ccip_onramp = @ccip_onramp,
+            owner = @0x100,
+            sender = @0x500,
+            router = @0x200,
+            burn_mint_token_pool = @burn_mint_token_pool,
+            lock_release_token_pool = @lock_release_token_pool
+        )
+    ]
+    fun test_non_dispatchable_token_without_transfer_ref_success(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_onramp: &signer,
+        owner: &signer,
+        sender: &signer,
+        router: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer
+    ) acquires TestToken {
+        let result =
+            execute_ccip_send_test(
+                aptos_framework,
+                ccip,
+                ccip_onramp,
+                owner,
+                sender,
+                router,
+                burn_mint_token_pool,
+                lock_release_token_pool,
+                LOCK_RELEASE_TOKEN_POOL,
+                b"LockReleaseToken",
+                false, // is_dispatchable
+                false // generate_transfer_ref
+            );
+
+        assert_lock_release_pool_success(&result);
+    }
+
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            ccip = @ccip,
+            ccip_onramp = @ccip_onramp,
+            owner = @0x100,
+            sender = @0x500,
+            router = @0x200,
+            burn_mint_token_pool = @burn_mint_token_pool,
+            lock_release_token_pool = @lock_release_token_pool
+        )
+    ]
+    fun test_non_dispatchable_token_with_transfer_ref_success(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_onramp: &signer,
+        owner: &signer,
+        sender: &signer,
+        router: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer
+    ) acquires TestToken {
+        let result =
+            execute_ccip_send_test(
+                aptos_framework,
+                ccip,
+                ccip_onramp,
+                owner,
+                sender,
+                router,
+                burn_mint_token_pool,
+                lock_release_token_pool,
+                LOCK_RELEASE_TOKEN_POOL,
+                b"LockReleaseToken",
+                false, // is_dispatchable
+                true // generate_transfer_ref
+            );
+
+        assert_lock_release_pool_success(&result);
+    }
+
+    fun setup(
+        aptos_framework: &signer,
+        ccip: &signer,
+        ccip_onramp: &signer,
+        owner: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer,
+        pool_type: u8, // 0 for burn_mint, 1 for lock_release
+        seed: vector<u8>,
+        is_dispatchable: bool,
+        generate_transfer_ref: bool
+    ): (address, Object<Metadata>) {
+        let owner_addr = signer::address_of(owner);
+        account::create_account_for_test(signer::address_of(burn_mint_token_pool));
+        account::create_account_for_test(signer::address_of(lock_release_token_pool));
+        init_timestamp(aptos_framework, 100000);
+
+        // Create object for @ccip_onramp
+        let _constructor_ref = object::create_named_object(owner, b"ccip_onramp");
+        let ccip_onramp_obj_signer = object::generate_signer(&_constructor_ref);
+
+        // Create object for @ccip
+        let _constructor_ref = object::create_named_object(owner, b"ccip");
+
+        // Create object for @burn_mint_token_pool
+        let constructor_ref = object::create_named_object(
+            owner, b"burn_mint_token_pool"
+        );
+        let burn_mint_token_pool_obj_signer = &object::generate_signer(&constructor_ref);
+
+        // Create object for @lock_release_token_pool
+        let constructor_ref =
+            object::create_named_object(owner, b"lock_release_token_pool");
+        let lock_release_token_pool_obj_signer =
+            &object::generate_signer(&constructor_ref);
+
+        // Create object for @ccip_token_pool
+        let constructor_ref =
+            object::create_named_object(
+                burn_mint_token_pool_obj_signer, b"ccip_token_pool"
+            );
+        let ccip_token_pool_obj =
+            object::object_from_constructor_ref<ObjectCore>(&constructor_ref);
+        // We need to transfer ownership of ccip_token_pool to lock_release_token_pool
+        if (pool_type == LOCK_RELEASE_TOKEN_POOL) {
+            // transfer ownership of ccip_token_pool to lock_release_token_pool
+            object::transfer(
+                burn_mint_token_pool_obj_signer,
+                ccip_token_pool_obj,
+                signer::address_of(lock_release_token_pool_obj_signer)
+            );
+        };
+
+        state_object::init_module_for_testing(ccip);
+        auth::test_init_module(owner);
+        rmn_remote::initialize(owner, SOURCE_CHAIN_SELECTOR);
+
+        token_admin_registry::init_module_for_testing(ccip);
+        onramp::test_init_module(ccip_onramp);
+        nonce_manager::test_init_module(ccip_onramp);
+
+        let (token_obj, token_addr) =
+            create_test_token_and_pool(
+                owner,
+                burn_mint_token_pool,
+                lock_release_token_pool,
+                pool_type,
+                seed,
+                &ccip_onramp_obj_signer,
+                is_dispatchable,
+                generate_transfer_ref
+            );
+
+        fee_quoter::initialize(owner, 0, token_addr, 12400, vector[token_addr]);
+
+        onramp::initialize(
+            owner,
+            SOURCE_CHAIN_SELECTOR,
+            FEE_AGGREGATOR,
+            ALLOWLIST_ADMIN,
+            vector[DEST_CHAIN_SELECTOR], // dest_chain_selectors
+            vector[ROUTER], // dest_chain_routers
+            vector[false] // dest_chain_allowlist_enabled
+        );
+        assert!(onramp::owner() == owner_addr);
+
+        // ========================== Fee Quoter ==========================
+        //
+        // We set fees to 0 as we want to test the dynamic dispatch of the tokens registered
+        // with the token pools.
+        //
+        // =================================================================
+
+        fee_quoter::apply_fee_token_updates(owner, vector[], vector[token_addr]);
+        fee_quoter::apply_token_transfer_fee_config_updates(
+            owner,
+            DEST_CHAIN_SELECTOR, // dest_chain_selector
+            vector[token_addr], // add_tokens
+            vector[0], // add_min_fee_usd_cents
+            vector[0], // add_max_fee_usd_cents
+            vector[0], // add_deci_bps
+            vector[0], // add_dest_gas_overhead
+            vector[0], // add_dest_bytes_overhead
+            vector[true], // add_is_enabled
+            vector[] // remove_tokens
+        );
+        fee_quoter::apply_dest_chain_config_updates(
+            owner,
+            DEST_CHAIN_SELECTOR, // dest_chain_selector
+            true, // is_enabled
+            1, // max_number_of_tokens_per_msg
+            10000, // max_data_bytes
+            7000000, // max_per_msg_gas_limit
+            0, // dest_gas_overhead
+            0, // dest_gas_per_payload_byte_base
+            0, // dest_gas_per_payload_byte_high
+            0, // dest_gas_per_payload_byte_threshold
+            0, // dest_data_availability_overhead_gas
+            0, // dest_gas_per_data_availability_byte
+            0, // dest_data_availability_multiplier_bps
+            CHAIN_FAMILY_SELECTOR_EVM, // chain_family_selector
+            false, // enforce_out_of_order
+            0, // default_token_fee_usd_cents
+            0, // default_token_dest_gas_overhead
+            1000000, // default_tx_gas_limit
+            0, // gas_multiplier_wei_per_eth
+            10000000, // gas_price_staleness_threshold
+            0 // network_fee_usd_cents
+        );
+        fee_quoter::apply_premium_multiplier_wei_per_eth_updates(
+            owner,
+            vector[token_addr], // tokens
+            vector[0] // premium_multiplier_wei_per_eth
+        );
+
+        // To be able to call token_admin_dispatcher::dispatch_lock_or_burn
+        // Need to register onramp signer as an allowed onramp
+        auth::apply_allowed_onramp_updates(
+            owner,
+            vector[], // onramps_to_remove
+            vector[signer::address_of(ccip_onramp)] // onramps_to_add
+        );
+
+        // To be able to call fee_quoter::update_prices, need to register as an allowed offramp
+        auth::apply_allowed_offramp_updates(
+            owner,
+            vector[], // offramps_to_remove
+            vector[owner_addr] // offramps_to_add
+        );
+
+        fee_quoter::update_prices(
+            owner,
+            vector[token_addr], // source_tokens
+            vector[1000], // source_usd_per_token
+            vector[DEST_CHAIN_SELECTOR], // gas_dest_chain_selectors
+            vector[0] // gas_usd_per_unit_gas
+        );
+
+        (owner_addr, token_obj)
+    }
+
+    fun create_test_token_and_pool(
+        owner: &signer,
+        burn_mint_token_pool: &signer,
+        lock_release_token_pool: &signer,
+        pool_type: u8, // 0 for burn_mint, 1 for lock_release
+        seed: vector<u8>,
+        ccip_onramp_signer: &signer,
+        is_dispatchable: bool,
+        generate_transfer_ref: bool
+    ): (Object<Metadata>, address) {
+        let constructor_ref = object::create_named_object(owner, seed);
+
+        primary_fungible_store::create_primary_store_enabled_fungible_asset(
+            &constructor_ref,
+            option::none(), // maximum supply
+            string::utf8(seed), // name
+            string::utf8(seed), // symbol
+            0, // decimals
+            string::utf8(b"http://www.example.com/favicon.ico"), // icon uri
+            string::utf8(b"http://www.example.com") // project uri
+        );
+
+        // Add dynamic dispatch function to the token if it is dispatchable
+        if (is_dispatchable) {
+            mock_token::add_dynamic_dispatch_function(
+                ccip_onramp_signer, &constructor_ref
+            );
+        };
+
+        let metadata = object::object_from_constructor_ref(&constructor_ref);
+
+        let obj_signer = object::generate_signer(&constructor_ref);
+        let extend_ref = object::generate_extend_ref(&constructor_ref);
+        let mint_ref = fungible_asset::generate_mint_ref(&constructor_ref);
+        let burn_ref = fungible_asset::generate_burn_ref(&constructor_ref);
+        let transfer_ref =
+            if (generate_transfer_ref) {
+                option::some(fungible_asset::generate_transfer_ref(&constructor_ref))
+            } else {
+                option::none()
+            };
+
+        // ======================== Create token pool ========================
+        let token_addr = object::object_address(&metadata);
+
+        let remote_token_address = vector[];
+        eth_abi::encode_address(&mut remote_token_address, MOCK_EVM_ADDRESS);
+
+        if (pool_type == BURN_MINT_TOKEN_POOL) {
+            burn_mint_token_pool::test_init_module(burn_mint_token_pool);
+            burn_mint_token_pool::initialize(burn_mint_token_pool, burn_ref, mint_ref);
+            burn_mint_token_pool::apply_chain_updates(
+                owner,
+                vector[],
+                vector[DEST_CHAIN_SELECTOR],
+                vector[vector[remote_token_address]],
+                vector[remote_token_address]
+            );
+            burn_mint_token_pool::set_chain_rate_limiter_config(
+                owner,
+                DEST_CHAIN_SELECTOR,
+                true,
+                OUTBOUND_CAPACITY, // outbound_capacity
+                OUTBOUND_RATE, // outbound_rate
+                true,
+                INBOUND_CAPACITY, // inbound_capacity
+                INBOUND_RATE // inbound_rate
+            );
+        } else {
+            lock_release_token_pool::test_init_module(lock_release_token_pool);
+            lock_release_token_pool::initialize(lock_release_token_pool, transfer_ref);
+            lock_release_token_pool::apply_chain_updates(
+                owner,
+                vector[],
+                vector[DEST_CHAIN_SELECTOR],
+                vector[vector[remote_token_address]],
+                vector[remote_token_address]
+            );
+            lock_release_token_pool::set_chain_rate_limiter_config(
+                owner,
+                DEST_CHAIN_SELECTOR,
+                true,
+                OUTBOUND_CAPACITY, // outbound_capacity
+                OUTBOUND_RATE, // outbound_rate
+                true,
+                INBOUND_CAPACITY, // inbound_capacity
+                INBOUND_RATE // inbound_rate
+            );
+        };
+
+        // Add a delay to allow the token bucket to refill
+        timestamp::update_global_time_for_test_secs(timestamp::now_seconds() + 10);
+
+        // =========== Create token refs ==================
+
+        let mint_ref = fungible_asset::generate_mint_ref(&constructor_ref);
+        let burn_ref = fungible_asset::generate_burn_ref(&constructor_ref);
+        let transfer_ref = fungible_asset::generate_transfer_ref(&constructor_ref);
+        move_to(
+            &obj_signer,
+            TestToken { metadata, extend_ref, mint_ref, burn_ref, transfer_ref }
+        );
+
+        (metadata, token_addr)
+    }
+
+    fun init_timestamp(aptos_framework: &signer, timestamp_seconds: u64) {
+        timestamp::set_time_has_started_for_testing(aptos_framework);
+        timestamp::update_global_time_for_test_secs(timestamp_seconds);
+    }
+
+    fun create_valid_extra_args(): vector<u8> {
+        let extra_args = vector[];
+
+        // Add the V2 tag as first 4 bytes
+        vector::append(&mut extra_args, GENERIC_EXTRA_ARGS_V2_TAG);
+
+        // Add eth_abi encoded gas limit (100000 as u256)
+        let gas_limit_data = vector[];
+        eth_abi::encode_u256(&mut gas_limit_data, (GAS_LIMIT as u256));
+        vector::append(&mut extra_args, gas_limit_data);
+
+        // Add eth_abi encoded boolean (true) for allow_out_of_order_execution
+        let execution_flag_data = vector[];
+        eth_abi::encode_bool(&mut execution_flag_data, ALLOW_OUT_OF_ORDER_EXECUTION);
+        vector::append(&mut extra_args, execution_flag_data);
+
+        extra_args
+    }
+}

--- a/contracts/ccip/ccip_onramp/tests/onramp_test.move
+++ b/contracts/ccip/ccip_onramp/tests/onramp_test.move
@@ -7,9 +7,11 @@ module ccip_onramp::onramp_test {
     use std::object::{Self, Object, ExtendRef, ObjectCore};
     use std::bcs;
     use std::account;
-    use aptos_framework::fungible_asset::{Self, Metadata, MintRef, BurnRef, TransferRef};
-    use aptos_framework::primary_fungible_store;
-    use aptos_framework::timestamp;
+    use std::fungible_asset::{Self, Metadata, MintRef, BurnRef, TransferRef};
+    use std::primary_fungible_store;
+    use std::timestamp;
+    use std::event;
+
     use ccip::token_admin_registry;
     use ccip::rmn_remote;
     use ccip::nonce_manager;
@@ -19,6 +21,7 @@ module ccip_onramp::onramp_test {
     use ccip::state_object::{Self};
     use ccip::fee_quoter::{Self};
 
+    use ccip_token_pool::token_pool;
     use burn_mint_token_pool::burn_mint_token_pool;
     use lock_release_token_pool::lock_release_token_pool;
 
@@ -78,7 +81,8 @@ module ccip_onramp::onramp_test {
         burn_mint_token_pool: &signer,
         lock_release_token_pool: &signer,
         pool_type: u8, // 0 for burn_mint, 1 for lock_release
-        seed: vector<u8>
+        seed: vector<u8>,
+        is_dispatchable: bool
     ): (address, Object<Metadata>) {
         let owner_addr = signer::address_of(owner);
         account::create_account_for_test(signer::address_of(burn_mint_token_pool));
@@ -134,7 +138,8 @@ module ccip_onramp::onramp_test {
                 burn_mint_token_pool,
                 lock_release_token_pool,
                 pool_type,
-                seed
+                seed,
+                is_dispatchable
             );
 
         let one_e_18 = 1_000_000_000_000_000_000;
@@ -213,7 +218,8 @@ module ccip_onramp::onramp_test {
         burn_mint_token_pool: &signer,
         lock_release_token_pool: &signer,
         pool_type: u8, // 0 for burn_mint, 1 for lock_release
-        seed: vector<u8>
+        seed: vector<u8>,
+        is_dispatchable: bool
     ): (Object<Metadata>, address) {
         let constructor_ref = object::create_named_object(owner, seed);
 
@@ -233,7 +239,12 @@ module ccip_onramp::onramp_test {
         let extend_ref = object::generate_extend_ref(&constructor_ref);
         let mint_ref = fungible_asset::generate_mint_ref(&constructor_ref);
         let burn_ref = fungible_asset::generate_burn_ref(&constructor_ref);
-        let transfer_ref = fungible_asset::generate_transfer_ref(&constructor_ref);
+        let transfer_ref =
+            if (is_dispatchable) {
+                option::some(fungible_asset::generate_transfer_ref(&constructor_ref))
+            } else {
+                option::none()
+            };
 
         // ======================== Create token pool ========================
         let token_addr = object::object_address(&metadata);
@@ -339,7 +350,8 @@ module ccip_onramp::onramp_test {
             burn_mint_token_pool,
             lock_release_token_pool,
             BURN_MINT_TOKEN_POOL,
-            b"TestToken"
+            b"TestToken",
+            false
         );
 
         let static_config = onramp::get_static_config();
@@ -391,7 +403,8 @@ module ccip_onramp::onramp_test {
             burn_mint_token_pool,
             lock_release_token_pool,
             BURN_MINT_TOKEN_POOL,
-            b"TestToken"
+            b"TestToken",
+            false
         );
 
         // Update dynamic config
@@ -442,7 +455,8 @@ module ccip_onramp::onramp_test {
             burn_mint_token_pool,
             lock_release_token_pool,
             BURN_MINT_TOKEN_POOL,
-            b"TestToken"
+            b"TestToken",
+            false
         );
 
         // Try to update dynamic config with unauthorized account
@@ -475,7 +489,8 @@ module ccip_onramp::onramp_test {
             burn_mint_token_pool,
             lock_release_token_pool,
             BURN_MINT_TOKEN_POOL,
-            b"TestToken"
+            b"TestToken",
+            false
         );
 
         let dest_chain_selectors = vector[DEST_CHAIN_SELECTOR];
@@ -551,7 +566,8 @@ module ccip_onramp::onramp_test {
             burn_mint_token_pool,
             lock_release_token_pool,
             BURN_MINT_TOKEN_POOL,
-            b"TestToken"
+            b"TestToken",
+            false
         );
 
         // First enable allowlist for destination chain
@@ -637,7 +653,8 @@ module ccip_onramp::onramp_test {
                 burn_mint_token_pool,
                 lock_release_token_pool,
                 BURN_MINT_TOKEN_POOL,
-                b"TestToken"
+                b"TestToken",
+                false
             );
 
         auth::apply_allowed_onramp_updates(
@@ -716,6 +733,10 @@ module ccip_onramp::onramp_test {
         let onramp_state_balance =
             primary_fungible_store::balance(onramp::get_state_address(), token.metadata);
         assert!(onramp_state_balance == fee_token_amount);
+
+        assert!(
+            event::emitted_events<token_pool::Burned>().length() == 1
+        );
     }
 
     #[
@@ -749,7 +770,8 @@ module ccip_onramp::onramp_test {
                 burn_mint_token_pool,
                 lock_release_token_pool,
                 LOCK_RELEASE_TOKEN_POOL,
-                b"LockReleaseToken"
+                b"LockReleaseToken",
+                false
             );
 
         auth::apply_allowed_onramp_updates(
@@ -833,8 +855,11 @@ module ccip_onramp::onramp_test {
         let token_pool_addr = lock_release_token_pool::get_store_address();
         let token_pool_balance =
             primary_fungible_store::balance(token_pool_addr, token.metadata);
-        std::debug::print(&token_pool_balance);
         assert!(token_pool_balance == sent_amount);
+
+        assert!(
+            event::emitted_events<token_pool::Locked>().length() == 1
+        );
     }
 
     #[
@@ -864,7 +889,8 @@ module ccip_onramp::onramp_test {
             burn_mint_token_pool,
             lock_release_token_pool,
             BURN_MINT_TOKEN_POOL,
-            b"TestToken"
+            b"TestToken",
+            false
         );
         initialize_onramp(owner);
     }
@@ -897,7 +923,8 @@ module ccip_onramp::onramp_test {
                 burn_mint_token_pool,
                 lock_release_token_pool,
                 BURN_MINT_TOKEN_POOL,
-                b"TestToken"
+                b"TestToken",
+                false
             );
         let token_addr = object::object_address(&token_obj);
 
@@ -934,7 +961,8 @@ module ccip_onramp::onramp_test {
             burn_mint_token_pool,
             lock_release_token_pool,
             BURN_MINT_TOKEN_POOL,
-            b"TestToken"
+            b"TestToken",
+            false
         );
 
         assert!(onramp::is_chain_supported(DEST_CHAIN_SELECTOR));
@@ -969,7 +997,8 @@ module ccip_onramp::onramp_test {
             burn_mint_token_pool,
             lock_release_token_pool,
             BURN_MINT_TOKEN_POOL,
-            b"TestToken"
+            b"TestToken",
+            false
         );
 
         // After initialization, sequence number should be 0, so next expected is 1
@@ -1025,7 +1054,8 @@ module ccip_onramp::onramp_test {
             burn_mint_token_pool,
             lock_release_token_pool,
             BURN_MINT_TOKEN_POOL,
-            b"TestToken"
+            b"TestToken",
+            false
         );
 
         assert!(onramp::owner() == signer::address_of(owner));
@@ -1070,7 +1100,8 @@ module ccip_onramp::onramp_test {
             burn_mint_token_pool,
             lock_release_token_pool,
             BURN_MINT_TOKEN_POOL,
-            b"TestToken"
+            b"TestToken",
+            false
         );
 
         let nonce =
@@ -1105,7 +1136,8 @@ module ccip_onramp::onramp_test {
                 burn_mint_token_pool,
                 lock_release_token_pool,
                 BURN_MINT_TOKEN_POOL,
-                b"TestToken"
+                b"TestToken",
+                false
             );
 
         let token_addr = object::object_address(&token_obj);
@@ -1167,7 +1199,8 @@ module ccip_onramp::onramp_test {
             burn_mint_token_pool,
             lock_release_token_pool,
             BURN_MINT_TOKEN_POOL,
-            b"TestToken"
+            b"TestToken",
+            false
         );
 
         let dest_chain_selectors = vector[DEST_CHAIN_SELECTOR];
@@ -1220,7 +1253,8 @@ module ccip_onramp::onramp_test {
             burn_mint_token_pool,
             lock_release_token_pool,
             BURN_MINT_TOKEN_POOL,
-            b"TestToken"
+            b"TestToken",
+            false
         );
 
         onramp::apply_dest_chain_config_updates(
@@ -1267,7 +1301,8 @@ module ccip_onramp::onramp_test {
                 burn_mint_token_pool,
                 lock_release_token_pool,
                 BURN_MINT_TOKEN_POOL,
-                b"TestToken"
+                b"TestToken",
+                false
             );
 
         let type_version = onramp::type_and_version();
@@ -1342,7 +1377,8 @@ module ccip_onramp::onramp_test {
                 burn_mint_token_pool,
                 lock_release_token_pool,
                 BURN_MINT_TOKEN_POOL,
-                b"TestToken"
+                b"TestToken",
+                false
             );
         setup_mcms(mcms);
         onramp::register_mcms_entrypoint(ccip_onramp);
@@ -1405,7 +1441,8 @@ module ccip_onramp::onramp_test {
                 burn_mint_token_pool,
                 lock_release_token_pool,
                 BURN_MINT_TOKEN_POOL,
-                b"TestToken"
+                b"TestToken",
+                false
             );
         setup_mcms(mcms);
         onramp::register_mcms_entrypoint(ccip_onramp);
@@ -1476,7 +1513,8 @@ module ccip_onramp::onramp_test {
                 burn_mint_token_pool,
                 lock_release_token_pool,
                 BURN_MINT_TOKEN_POOL,
-                b"TestToken"
+                b"TestToken",
+                false
             );
         setup_mcms(mcms);
         onramp::register_mcms_entrypoint(ccip_onramp);
@@ -1555,7 +1593,8 @@ module ccip_onramp::onramp_test {
                 burn_mint_token_pool,
                 lock_release_token_pool,
                 BURN_MINT_TOKEN_POOL,
-                b"TestToken"
+                b"TestToken",
+                false
             );
         setup_mcms(mcms);
         onramp::register_mcms_entrypoint(ccip_onramp);

--- a/contracts/ccip/ccip_token_pools/README.md
+++ b/contracts/ccip/ccip_token_pools/README.md
@@ -1,0 +1,448 @@
+# CCIP Token Pools on Aptos
+
+## Overview
+
+CCIP Token Pools are smart contracts that manage the cross-chain transfer of tokens in the Chainlink Cross-Chain Interoperability Protocol (CCIP). On Aptos, token pools handle the locking/releasing or burning/minting of tokens when they are transferred to/from other blockchains.
+
+### Key Points
+
+Tokens with dynamic dispatch are supported for both pools, however the deposit and withdraw overrides are not invoked during `lock_or_burn` and `release_or_mint` functions.
+
+## Pool Types
+
+There are **3 types** of token pools available on Aptos:
+
+1. **Lock/Release Token Pool** (`lock_release_token_pool`)
+2. **Burn/Mint Token Pool** (`burn_mint_token_pool`)
+3. **USDC Token Pool** (`usdc_token_pool`)
+
+### 1. Lock/Release Token Pool (`lock_release_token_pool`)
+
+- Tokens that have dynamic dispatch configured for **custom deposit and withdraw functions must provide a `transfer_ref`** when initializing this pool.
+- Tokens which do not have `transfer_ref` available can still register with this pool but **they must not have custom dispatch logic** on deposit and withdraw configured.
+
+**Operation Modes**:
+
+1. **With TransferRef**:
+
+   - Uses `deposit_with_ref()` and `withdraw_with_ref()`
+   - Bypasses custom deposit and withdraw dispatch logic
+   - **Required** for tokens with custom dispatch
+
+2. **Without TransferRef**:
+   - Uses `fungible_asset::deposit/withdraw()`
+   - **Only allowed** for tokens without dynamic dispatch configured
+
+**Mechanism**:
+
+- **Outbound**: Locks tokens in the pool's store
+- **Inbound**: Releases previously locked tokens
+
+**When to Use**:
+
+- For tokens that exist natively on Aptos and need to be "locked" when sent to other chains
+- You want to maintain the original token supply on Aptos
+- Tokens that do not have mint/burn refs saved
+
+#### Token Pool Configuration Matrix
+
+| Has Dynamic Dispatch | TransferRef Provided | Is Valid   |
+| -------------------- | -------------------- | ---------- |
+| ❌                   | ❌ **(Optional)**    | **Yes ✅** |
+| ❌                   | ✅ **(Optional)**    | **Yes ✅** |
+| ✅                   | ✅ **Mandatory**     | **Yes ✅** |
+| ✅                   | ❌ **Mandatory**     | **No ❌**  |
+
+### 2. Burn/Mint Token Pool (`burn_mint_token_pool`)
+
+- `mint_ref` and `burn_ref` are required for initialization with this pool.
+
+**Mechanism**:
+
+- **Outbound**: Burns tokens from total supply
+- **Inbound**: Mints new tokens, increasing total supply
+
+**When to Use**:
+
+- Total supply must be increased or decreased across swaps
+- Tokens which need to be burned and minted across chains, such as wrapped or synthetic tokens
+- You have mint/burn capabilities for the token
+- Simpler accounting model preferred
+
+### 3. USDC Token Pool (`usdc_token_pool`)
+
+- Specialized pool for USDC tokens that integrates with Circle's Cross-Chain Transfer Protocol (CCTP)
+- Uses Circle's native burn/mint mechanism for USDC transfers
+- Requires integration with Circle's `message_transmitter` and `token_messenger_minter` contracts
+
+**Mechanism**:
+
+- **Outbound**: Burns USDC via Circle's protocol and emits attestation
+- **Inbound**: Mints USDC using Circle's attestation system
+
+**When to Use**:
+
+- Specifically for USDC token transfers
+
+## Deployment Guide
+
+### Prerequisites
+
+1. **Token Must Exist**: Deploy your fungible asset first
+2. **Token Ownership Required**: **Only the token owner can deploy pools**. The deployer must be one of:
+   - The direct owner of the token object
+   - The root owner of the token object
+
+### Deploy Pool Contract
+
+For **Lock/Release Pool**:
+
+```bash
+aptos move deploy-object \
+  --package-dir contracts/ccip/ccip_token_pools/lock_release_token_pool \
+  --address-name lock_release_token_pool \
+  --named-addresses lock_release_local_token=<YOUR_TOKEN_ADDRESS>,\
+ccip=<CCIP_ADDRESS>,\
+ccip_token_pool=<CCIP_TOKEN_POOL_ADDRESS>,\
+token_pool_administrator=<TOKEN_POOL_ADMINISTRATOR_ADDRESS>,\
+mcms=<MCMS_ADDRESS>,\
+mcms_register_entrypoints=<MCMS_REGISTER_ENTRYPOINTS_ADDRESS>
+```
+
+For **Burn/Mint Pool**:
+
+```bash
+aptos move deploy-object \
+  --package-dir contracts/ccip/ccip_token_pools/burn_mint_token_pool \
+  --address-name burn_mint_token_pool \
+  --named-addresses burn_mint_local_token=<YOUR_TOKEN_ADDRESS>,\
+ccip=<CCIP_ADDRESS>,\
+ccip_token_pool=<CCIP_TOKEN_POOL_ADDRESS>,\
+token_pool_administrator=<TOKEN_POOL_ADMINISTRATOR_ADDRESS>,\
+mcms=<MCMS_ADDRESS>,\
+mcms_register_entrypoints=<MCMS_REGISTER_ENTRYPOINTS_ADDRESS>
+```
+
+For **USDC Pool**:
+
+```bash
+aptos move deploy-object \
+  --package-dir contracts/ccip/ccip_token_pools/usdc_token_pool \
+  --address-name usdc_token_pool \
+  --named-addresses local_token=<YOUR_TOKEN_ADDRESS>,\
+ccip=<CCIP_ADDRESS>,\
+ccip_token_pool=<CCIP_TOKEN_POOL_ADDRESS>,\
+token_pool_administrator=<TOKEN_POOL_ADMINISTRATOR_ADDRESS>,\
+mcms=<MCMS_ADDRESS>,\
+message_transmitter=<MESSAGE_TRANSMITTER_ADDRESS>,\
+token_messenger_minter=<TOKEN_MESSENGER_MINTER_ADDRESS>,\
+deployer=<DEPLOYER_ADDRESS>
+```
+
+### Initialize Pool
+
+**Lock/Release Pool**:
+
+```move
+// For tokens WITHOUT dynamic dispatch
+lock_release_token_pool::initialize(admin_signer, option::none());
+
+// For tokens WITH dynamic dispatch
+lock_release_token_pool::initialize(admin_signer, option::some(transfer_ref));
+```
+
+**Burn/Mint Pool**:
+
+```move
+burn_mint_token_pool::initialize(admin_signer, burn_ref, mint_ref);
+```
+
+**USDC Pool**:
+
+```move
+usdc_token_pool::initialize(admin_signer);
+```
+
+### Configure Cross-Chain Support
+
+```move
+// Add supported destination chains
+pool::apply_chain_updates(
+    admin_signer,
+    vector[], // remote_chain_selectors_to_remove
+    vector[destination_chain_selector], // remote_chain_selectors_to_add
+    vector[vector[remote_pool_address]], // remote_pool_addresses_to_add
+    vector[remote_token_address] // remote_token_addresses_to_add
+);
+```
+
+### Set Rate Limits
+
+```move
+pool::set_chain_rate_limiter_config(
+    admin_signer,
+    remote_chain_selector,
+    true,  // outbound_is_enabled
+    1000000, // outbound_capacity
+    100,     // outbound_rate
+    true,    // inbound_is_enabled
+    1000000, // inbound_capacity
+    100      // inbound_rate
+);
+```
+
+### Configure Allowlist
+
+Configure who can call the pool functions:
+
+```move
+pool::apply_allowlist_updates(
+    admin_signer,
+    vector[], // removes
+    vector[0xabc], // adds
+);
+```
+
+## Token Admin Registry Integration
+
+### Automatic Registration Process
+
+The Token Admin Registry manages which pools are authorized for specific tokens. It maintains a **1:1 mapping** of tokens to pools.
+
+**During pool deployment**, each pool automatically registers itself with the Token Admin Registry via the `init_module` function:
+
+```move
+// Automatic registration during pool deployment (in init_module)
+token_admin_registry::register_pool(
+    publisher,
+    pool_module_name,  // e.g., b"lock_release_token_pool"
+    token_address,
+    administrator_address,
+    CallbackProof {}
+);
+```
+
+This ensures that:
+
+- The token is immediately associated with the new pool
+- The specified administrator has control over the pool
+- The pool can be called by CCIP for cross-chain operations
+
+### Pool Management Functions
+
+**Check Current Pool**:
+
+```move
+let pool_address = token_admin_registry::get_pool(token_address);
+```
+
+**Check Pool Administrator**:
+
+```move
+let admin_address = token_admin_registry::get_administrator(token_address);
+```
+
+**Transfer Pool Admin**:
+
+```move
+token_admin_registry::transfer_admin_role(admin_signer, token_address, new_admin);
+```
+
+**Accept Admin Role**:
+
+```move
+token_admin_registry::accept_admin_role(new_admin_signer, token_address);
+```
+
+### Pool Unregistration
+
+To completely remove a pool from the Token Admin Registry:
+
+```move
+token_admin_registry::unregister_pool(
+    admin_signer,
+    token_address
+);
+```
+
+**⚠️ Warning**: Unregistering a pool will:
+
+- Remove the token-to-pool mapping
+- Disable cross-chain transfers for that token unless registered with another pool
+- Require re-registration to restore functionality
+
+### Pool Upgrades
+
+To upgrade an existing pool to a new version:
+
+#### Option 1: Upgrade Existing Pool Object
+
+If you want to upgrade the code of an existing pool:
+
+```bash
+aptos move upgrade-object \
+  --object-address <TOKEN_POOL_ADDRESS> \
+  --address-name lock_release_token_pool \
+  --named-addresses lock_release_local_token=<YOUR_TOKEN_ADDRESS>,\
+ccip=<CCIP_ADDRESS>,\
+ccip_token_pool=<CCIP_TOKEN_POOL_ADDRESS>,\
+token_pool_administrator=<TOKEN_POOL_ADMINISTRATOR_ADDRESS>,\
+mcms=<MCMS_ADDRESS>,\
+mcms_register_entrypoints=<MCMS_REGISTER_ENTRYPOINTS_ADDRESS>
+```
+
+Where `TOKEN_POOL_ADDRESS` is the address of the existing pool object.
+
+#### Option 2: Deploy New Pool and Switch Registration
+
+To switch pools for a token, you can deploy a new pool contract and update the Token Admin Registry to point to the new pool.
+This is useful for major upgrades or changes in pool logic.
+
+1. **Deploy New Pool**: Deploy the new pool contract using the deployment commands above
+
+2. **Switch Pool Registration**:
+
+   ```move
+   token_admin_registry::set_pool(
+       admin_signer,
+       token_address,
+       new_pool_address
+   );
+   ```
+
+3. **Migrate Funds/Refs**
+
+   - For Lock/Release pools:
+     - Move locked funds from old to new pool
+     - Migrate TransferRef if provided
+   - For Burn/Mint pools
+     - Migrate BurnRef and MintRef
+
+4. **Update Configurations**: Set up rate limits and chain configs on new pool
+
+5. **Cleanup**: Optionally unregister or disable the old pool
+
+#### Upgrade Considerations
+
+- **State Migration**: Plan how to handle existing state and locked funds
+- **Downtime**: Coordinate upgrades to minimize service interruption
+- **Testing**: Thoroughly test new pool versions before upgrading
+- **Rollback Plan**: Have a strategy to revert if issues arise
+
+## Configuration Best Practices
+
+### Rate Limiting
+
+- **Capacity**: Maximum token units (in smallest denomination) that can be transferred in a time window
+- **Rate**: Token unit refill rate per second (in smallest denomination)
+- **Separate Limits**: Configure different limits for inbound vs outbound
+- **Denomination**: All rate limit values are specified in the token's smallest unit (e.g., for a token with 18 decimals, 1 full token = 10^18 units)
+
+```move
+// Conservative example for high-value tokens
+// Note: All amounts are in the smallest denomination of the token (e.g., wei for ETH)
+set_chain_rate_limiter_config(
+    admin,
+    chain_selector,
+    true, 1000000,  // outbound: 1M units capacity (smallest denomination)
+    100,            // 100 units/second refill (smallest denomination)
+    true, 2000000,  // inbound: 2M units capacity (smallest denomination)
+    200             // 200 units/second refill (smallest denomination)
+);
+```
+
+### Multi-Chain Setup
+
+```move
+// Configure multiple destination chains
+let chain_selectors = vector[ethereum_selector, polygon_selector, bsc_selector];
+let remote_pools = vector[
+    vector[eth_pool_address],
+    vector[polygon_pool_address],
+    vector[bsc_pool_address]
+];
+let remote_tokens = vector[eth_token, polygon_token, bsc_token];
+
+apply_chain_updates(admin, vector[], chain_selectors, remote_pools, remote_tokens);
+```
+
+### Security Considerations
+
+1. **TransferRef Storage**: Store TransferRef securely if provided
+2. **Admin Key Management**: Use multi-sig for pool administration
+3. **Rate Limits**: Set conservative limits initially
+4. **Allowlists**: Consider using allowlists for restricted tokens
+5. **Monitoring**: Monitor pool balances and cross-chain activity
+
+## Troubleshooting
+
+### Common Issues
+
+**"Dispatchable token without transfer ref"**
+
+- **Cause**: Token has custom dispatch but no TransferRef provided
+- **Solution**: Provide TransferRef during initialization or create token without dynamic dispatch
+
+**"Insufficient balance"**
+
+- **Cause**: Pool doesn't have enough tokens for release
+- **Solution**: Check pool balance and inbound transfer history, Fund pool if needed
+
+**"Chain not supported"**
+
+- **Cause**: Destination chain not configured
+- **Solution**: Add chain via `apply_chain_updates()`
+
+**"Rate limit exceeded"**
+
+- **Cause**: Transfer exceeds configured rate limits
+- **Solution**: Wait for rate limit refill or increase limits
+
+**"Pool not registered"**
+
+- **Cause**: Token is not associated with any pool in Token Admin Registry
+- **Solution**: Deploy and register a pool for the token
+
+### Diagnostic Commands
+
+```move
+// Check pool configuration
+pool::get_supported_chains();
+pool::balance();
+pool::get_remote_pools(chain_selector);
+
+// Check token admin registry
+token_admin_registry::get_pool(token_address);
+token_admin_registry::get_administrator(token_address);
+```
+
+## Migration from Other Chains
+
+When bringing tokens from EVM chains to Aptos:
+
+1. **Assess Token Type**:
+
+   - Simple ERC-20 → Use any pool type
+   - Custom logic → Implement equivalent in Aptos with dispatch
+
+2. **Choose Pool Strategy**:
+
+   - Keep original on source chain → Lock/Release
+   - Burn on source, mint on Aptos → Burn/Mint
+   - USDC specifically → USDC Pool
+
+3. **Handle Custom Logic**:
+
+   - Implement custom dynamic dispatch functions if needed
+   - Always provide TransferRef for pools if token uses dynamic dispatch
+
+4. **Configure Mappings**:
+   - Map remote token addresses correctly
+   - Set up bidirectional pool relationships
+
+## Support and Resources
+
+- **CCIP Documentation**: [Chainlink CCIP Docs](https://docs.chain.link/ccip)
+- **Aptos Move Documentation**: [Aptos Developer Docs](https://aptos.dev)
+- **Contract Source**: `contracts/ccip/ccip_token_pools/`
+- **Example Implementations**: `contracts/ccip/ccip_token_pools/*/tests/`

--- a/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
@@ -1,16 +1,17 @@
 module lock_release_token_pool::lock_release_token_pool {
     use std::account::{Self, SignerCapability};
     use std::error;
-    use std::fungible_asset::{Self, FungibleAsset, Metadata, TransferRef};
+    use std::fungible_asset::{Self, FungibleAsset, Metadata, TransferRef, FungibleStore};
+    use std::dispatchable_fungible_asset;
     use std::primary_fungible_store;
     use std::object::{Self, Object, ObjectCore};
-    use std::option;
+    use std::option::{Self, Option};
     use std::signer;
     use std::string::{Self, String};
 
     use ccip::ownable;
     use ccip::token_admin_registry;
-    use ccip_token_pool::token_pool;
+    use ccip_token_pool::token_pool::{Self, TokenPoolState};
 
     use mcms::mcms_registry;
     use mcms::bcs_stream;
@@ -28,7 +29,7 @@ module lock_release_token_pool::lock_release_token_pool {
         ownable_state: ownable::OwnableState,
         token_pool_state: token_pool::TokenPoolState,
         store_signer_address: address,
-        transfer_ref: TransferRef
+        transfer_ref: Option<TransferRef>
     }
 
     const E_NOT_PUBLISHER: u64 = 1;
@@ -37,6 +38,7 @@ module lock_release_token_pool::lock_release_token_pool {
     const E_INVALID_ARGUMENTS: u64 = 4;
     const E_UNKNOWN_FUNCTION: u64 = 5;
     const E_LOCAL_TOKEN_MISMATCH: u64 = 6;
+    const E_DISPATCHABLE_TOKEN_WITHOUT_TRANSFER_REF: u64 = 7;
 
     // ================================================================
     // |                             Init                             |
@@ -100,21 +102,18 @@ module lock_release_token_pool::lock_release_token_pool {
         );
     }
 
+    /// Tokens that have dynamic dispatch enabled must provide a `TransferRef`
+    /// Tokens that do not have dynamic dispatch enabled can provide `option::none()`
+    /// You can still provide a transfer ref for tokens that don't have dynamic dispatch enabled
+    /// if you choose to do so.
     public fun initialize(
-        caller: &signer, transfer_ref: TransferRef
+        caller: &signer, transfer_ref: Option<TransferRef>
     ) acquires LockReleaseTokenPoolDeployment {
         assert_can_initialize(signer::address_of(caller));
 
         assert!(
             exists<LockReleaseTokenPoolDeployment>(@lock_release_token_pool),
             error::invalid_argument(E_ALREADY_INITIALIZED)
-        );
-
-        let metadata = object::address_to_object<Metadata>(@lock_release_local_token);
-        let transfer_ref_metadata = fungible_asset::transfer_ref_metadata(&transfer_ref);
-        assert!(
-            metadata == transfer_ref_metadata,
-            error::invalid_argument(E_LOCAL_TOKEN_MISMATCH)
         );
 
         let LockReleaseTokenPoolDeployment {
@@ -124,12 +123,28 @@ module lock_release_token_pool::lock_release_token_pool {
         } = move_from<LockReleaseTokenPoolDeployment>(@lock_release_token_pool);
 
         let store_signer = account::create_signer_with_capability(&store_signer_cap);
+        let store_signer_address = signer::address_of(&store_signer);
+
+        // If transfer ref is not provided, tokens with dynamic dispatch on deposit and withdraw
+        // are not allowed for this pool
+        if (transfer_ref.is_none()) {
+            let store =
+                primary_fungible_store::primary_store(
+                    store_signer_address,
+                    token_pool::get_fa_metadata(&token_pool_state)
+                );
+            assert!(
+                fungible_asset::deposit_dispatch_function(store).is_none()
+                    && fungible_asset::withdraw_dispatch_function(store).is_none(),
+                E_DISPATCHABLE_TOKEN_WITHOUT_TRANSFER_REF
+            );
+        };
 
         let pool = LockReleaseTokenPoolState {
-            ownable_state,
-            store_signer_address: signer::address_of(&store_signer),
             store_signer_cap,
+            ownable_state,
             token_pool_state,
+            store_signer_address,
             transfer_ref
         };
         move_to(&store_signer, pool);
@@ -202,6 +217,29 @@ module lock_release_token_pool::lock_release_token_pool {
         token_pool::remove_remote_pool(
             &mut pool.token_pool_state, remote_chain_selector, remote_pool_address
         );
+    }
+
+    inline fun has_transfer_ref(pool: &LockReleaseTokenPoolState): bool {
+        pool.transfer_ref.is_some()
+    }
+
+    #[view]
+    public fun pool_primary_store(): Object<FungibleStore> acquires LockReleaseTokenPoolState {
+        let pool = borrow_pool();
+        primary_fungible_store::primary_store(
+            pool.store_signer_address,
+            token_pool::get_fa_metadata(&pool.token_pool_state)
+        )
+    }
+
+    #[view]
+    public fun balance(): u64 acquires LockReleaseTokenPoolState {
+        fungible_asset::balance(pool_primary_store())
+    }
+
+    #[view]
+    public fun derived_balance(): u64 acquires LockReleaseTokenPoolState {
+        dispatchable_fungible_asset::derived_balance(pool_primary_store())
     }
 
     #[view]
@@ -289,13 +327,17 @@ module lock_release_token_pool::lock_release_token_pool {
 
         // Construct lock_or_burn output before we lose access to fa
         let dest_pool_data = token_pool::encode_local_decimals(&fa);
+        let metadata = token_pool::get_fa_metadata(&pool.token_pool_state);
+        let store =
+            primary_fungible_store::primary_store(pool.store_signer_address, metadata);
 
         // Lock the funds in the pool
-        primary_fungible_store::deposit_with_ref(
-            &pool.transfer_ref,
-            pool.store_signer_address,
-            fa
-        );
+        if (has_transfer_ref(pool)) {
+            let transfer_ref = pool.transfer_ref.borrow();
+            fungible_asset::deposit_with_ref(transfer_ref, store, fa);
+        } else {
+            fungible_asset::deposit(store, fa);
+        };
 
         // set the output for this lock or burn operation.
         token_admin_registry::set_lock_or_burn_output_v1(
@@ -325,13 +367,19 @@ module lock_release_token_pool::lock_release_token_pool {
             &mut pool.token_pool_state, &input, local_amount
         );
 
+        let store_signer = account::create_signer_with_capability(&pool.store_signer_cap);
+        let metadata = token_pool::get_fa_metadata(&pool.token_pool_state);
+        let store =
+            primary_fungible_store::primary_store(pool.store_signer_address, metadata);
+
         // Withdraw the amount from the store for release. this will revert if the store has insufficient balance.
         let fa =
-            primary_fungible_store::withdraw_with_ref(
-                &pool.transfer_ref,
-                pool.store_signer_address,
-                local_amount
-            );
+            if (has_transfer_ref(pool)) {
+                let transfer_ref = pool.transfer_ref.borrow();
+                fungible_asset::withdraw_with_ref(transfer_ref, store, local_amount)
+            } else {
+                fungible_asset::withdraw(&store_signer, store, local_amount)
+            };
 
         // set the output for this release or mint operation.
         token_admin_registry::set_release_or_mint_output_v1(


### PR DESCRIPTION
## Description

Support for dispatchable tokens in `lock_release_token_pool.move`

- Tokens that have dynamic dispatch enabled must provide a `TransferRef`
- Tokens that do not have dynamic dispatch enabled can provide `option::none()`
- You can still provide a transfer ref for tokens that don't have dynamic dispatch enabled if you choose to do so.