### PR TITLE
Add platform_secondary package + add to deployment CI

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,6 +5,7 @@ fmt: ## Format Move contracts.
 	movefmt --dir-path=contracts/large_packages
 	movefmt --dir-path=contracts/mcms
 	movefmt --dir-path=contracts/platform
+	movefmt --dir-path=contracts/platform_secondary
 	movefmt --dir-path=contracts/test
 
 .PHONY: wrappers

--- a/bindings/platform_secondary.go
+++ b/bindings/platform_secondary.go
@@ -1,0 +1,76 @@
+package platform_secondary
+
+import (
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/api"
+	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	"github.com/smartcontractkit/chainlink-aptos/bindings/compile"
+	module_forwarder "github.com/smartcontractkit/chainlink-aptos/bindings/platform_secondary/forwarder"
+	module_storage "github.com/smartcontractkit/chainlink-aptos/bindings/platform_secondary/storage"
+	"github.com/smartcontractkit/chainlink-aptos/contracts"
+)
+
+type PlatformSecondary interface {
+	Address() aptos.AccountAddress
+
+	Forwarder() module_forwarder.ForwarderInterface
+	Storage() module_storage.StorageInterface
+}
+
+var _ PlatformSecondary = PlatformSecondaryContract{}
+
+type PlatformSecondaryContract struct {
+	address aptos.AccountAddress
+
+	forwarder module_forwarder.ForwarderInterface
+	storage   module_storage.StorageInterface
+}
+
+func (C PlatformSecondaryContract) Address() aptos.AccountAddress {
+	return C.address
+}
+
+func (C PlatformSecondaryContract) Forwarder() module_forwarder.ForwarderInterface {
+	return C.forwarder
+}
+func (C PlatformSecondaryContract) Storage() module_storage.StorageInterface {
+	return C.storage
+}
+
+var FunctionInfo = bind.MustParseFunctionInfo(
+	module_forwarder.FunctionInfo,
+	module_storage.FunctionInfo,
+)
+
+func Compile(ownerAddress aptos.AccountAddress) (compile.CompiledPackage, error) {
+	namedAddresses := map[string]aptos.AccountAddress{
+		"owner_secondary": ownerAddress,
+	}
+	// Compile using CLI
+	return compile.CompilePackage(contracts.PlatformSecondary, namedAddresses)
+}
+
+func Bind(address aptos.AccountAddress, client aptos.AptosRpcClient) PlatformSecondary {
+	return PlatformSecondaryContract{
+		address:   address,
+		forwarder: module_forwarder.NewForwarder(address, client),
+		storage:   module_storage.NewStorage(address, client),
+	}
+}
+
+// DeployToObject deploys the PlatformSecondary contract to a new named object.
+// The resulting address will be calculated using the deployer's account address and the next sequence number
+func DeployToObject(
+	auth aptos.TransactionSigner,
+	client aptos.AptosRpcClient,
+	ownerAddress aptos.AccountAddress,
+) (aptos.AccountAddress, *api.PendingTransaction, PlatformSecondary, error) {
+	namedAddresses := map[string]aptos.AccountAddress{
+		"owner_secondary": ownerAddress,
+	}
+	address, tx, err := bind.DeployPackageToObject(auth, client, contracts.PlatformSecondary, namedAddresses)
+	if err != nil {
+		return aptos.AccountAddress{}, nil, nil, err
+	}
+	return address, tx, Bind(address, client), nil
+}

--- a/bindings/platform_secondary/forwarder/forwarder.go
+++ b/bindings/platform_secondary/forwarder/forwarder.go
@@ -1,0 +1,415 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package module_forwarder
+
+import (
+	"math/big"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/api"
+
+	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	"github.com/smartcontractkit/chainlink-aptos/relayer/codec"
+)
+
+var (
+	_ = aptos.AccountAddress{}
+	_ = api.PendingTransaction{}
+	_ = big.NewInt
+	_ = bind.NewBoundContract
+	_ = codec.DecodeAptosJsonValue
+)
+
+type ForwarderInterface interface {
+	GetTransmissionState(opts *bind.CallOpts, receiver aptos.AccountAddress, workflowExecutionId []byte, reportId uint16) (bool, error)
+	GetTransmitter(opts *bind.CallOpts, receiver aptos.AccountAddress, workflowExecutionId []byte, reportId uint16) (*aptos.AccountAddress, error)
+	GetOwner(opts *bind.CallOpts) (aptos.AccountAddress, error)
+	GetConfig(opts *bind.CallOpts, donId uint32, configVersion uint32) (Config, error)
+
+	SetConfig(opts *bind.TransactOpts, donId uint32, configVersion uint32, f byte, oracles [][]byte) (*api.PendingTransaction, error)
+	ClearConfig(opts *bind.TransactOpts, donId uint32, configVersion uint32) (*api.PendingTransaction, error)
+	Report(opts *bind.TransactOpts, receiver aptos.AccountAddress, rawReport []byte, signatures [][]byte) (*api.PendingTransaction, error)
+	TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
+	AcceptOwnership(opts *bind.TransactOpts) (*api.PendingTransaction, error)
+
+	// Encoder returns the encoder implementation of this module.
+	Encoder() ForwarderEncoder
+}
+
+type ForwarderEncoder interface {
+	GetTransmissionState(receiver aptos.AccountAddress, workflowExecutionId []byte, reportId uint16) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetTransmitter(receiver aptos.AccountAddress, workflowExecutionId []byte, reportId uint16) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetOwner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetConfig(donId uint32, configVersion uint32) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetConfig(donId uint32, configVersion uint32, f byte, oracles [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ClearConfig(donId uint32, configVersion uint32) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Report(receiver aptos.AccountAddress, rawReport []byte, signatures [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetStateAddr() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SignatureFromBytes(bytes []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	TransmissionId(receiver aptos.AccountAddress, workflowExecutionId []byte, reportId uint16) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Dispatch(receiver aptos.AccountAddress, metadata []byte, data []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ToU16be(data []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ToU32be(data []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	ValidateAndProcessReport(receiver aptos.AccountAddress, rawReport []byte, signatures []Signature) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+}
+
+const FunctionInfo = `[{"package":"platform_secondary","module":"forwarder","name":"accept_ownership","parameters":null},{"package":"platform_secondary","module":"forwarder","name":"clear_config","parameters":[{"name":"don_id","type":"u32"},{"name":"config_version","type":"u32"}]},{"package":"platform_secondary","module":"forwarder","name":"dispatch","parameters":[{"name":"receiver","type":"address"},{"name":"metadata","type":"vector\u003cu8\u003e"},{"name":"data","type":"vector\u003cu8\u003e"}]},{"package":"platform_secondary","module":"forwarder","name":"get_state_addr","parameters":null},{"package":"platform_secondary","module":"forwarder","name":"report","parameters":[{"name":"receiver","type":"address"},{"name":"raw_report","type":"vector\u003cu8\u003e"},{"name":"signatures","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"platform_secondary","module":"forwarder","name":"set_config","parameters":[{"name":"don_id","type":"u32"},{"name":"config_version","type":"u32"},{"name":"f","type":"u8"},{"name":"oracles","type":"vector\u003cvector\u003cu8\u003e\u003e"}]},{"package":"platform_secondary","module":"forwarder","name":"signature_from_bytes","parameters":[{"name":"bytes","type":"vector\u003cu8\u003e"}]},{"package":"platform_secondary","module":"forwarder","name":"to_u16be","parameters":[{"name":"data","type":"vector\u003cu8\u003e"}]},{"package":"platform_secondary","module":"forwarder","name":"to_u32be","parameters":[{"name":"data","type":"vector\u003cu8\u003e"}]},{"package":"platform_secondary","module":"forwarder","name":"transfer_ownership","parameters":[{"name":"to","type":"address"}]},{"package":"platform_secondary","module":"forwarder","name":"transmission_id","parameters":[{"name":"receiver","type":"address"},{"name":"workflow_execution_id","type":"vector\u003cu8\u003e"},{"name":"report_id","type":"u16"}]},{"package":"platform_secondary","module":"forwarder","name":"validate_and_process_report","parameters":[{"name":"receiver","type":"address"},{"name":"raw_report","type":"vector\u003cu8\u003e"},{"name":"signatures","type":"vector\u003cSignature\u003e"}]}]`
+
+func NewForwarder(address aptos.AccountAddress, client aptos.AptosRpcClient) ForwarderInterface {
+	contract := bind.NewBoundContract(address, "platform_secondary", "forwarder", client)
+	return ForwarderContract{
+		BoundContract:    contract,
+		forwarderEncoder: forwarderEncoder{BoundContract: contract},
+	}
+}
+
+// Structs
+
+type ConfigId struct {
+	DonId         uint32 `move:"u32"`
+	ConfigVersion uint32 `move:"u32"`
+}
+
+type State struct {
+	OwnerAddress        aptos.AccountAddress `move:"address"`
+	PendingOwnerAddress aptos.AccountAddress `move:"address"`
+}
+
+type Config struct {
+	F byte `move:"u8"`
+}
+
+type ConfigSet struct {
+	DonId         uint32   `move:"u32"`
+	ConfigVersion uint32   `move:"u32"`
+	F             byte     `move:"u8"`
+	Signers       [][]byte `move:"vector<vector<u8>>"`
+}
+
+type ReportProcessed struct {
+	Receiver            aptos.AccountAddress `move:"address"`
+	WorkflowExecutionId []byte               `move:"vector<u8>"`
+	ReportId            uint16               `move:"u16"`
+}
+
+type OwnershipTransferRequested struct {
+	From aptos.AccountAddress `move:"address"`
+	To   aptos.AccountAddress `move:"address"`
+}
+
+type OwnershipTransferred struct {
+	From aptos.AccountAddress `move:"address"`
+	To   aptos.AccountAddress `move:"address"`
+}
+
+type Signature struct {
+}
+
+type OracleSet struct {
+	DonId         uint32   `move:"u32"`
+	ConfigVersion uint32   `move:"u32"`
+	F             byte     `move:"u8"`
+	Oracles       [][]byte `move:"vector<vector<u8>>"`
+}
+
+type ForwarderContract struct {
+	*bind.BoundContract
+	forwarderEncoder
+}
+
+var _ ForwarderInterface = ForwarderContract{}
+
+func (c ForwarderContract) Encoder() ForwarderEncoder {
+	return c.forwarderEncoder
+}
+
+// View Functions
+
+func (c ForwarderContract) GetTransmissionState(opts *bind.CallOpts, receiver aptos.AccountAddress, workflowExecutionId []byte, reportId uint16) (bool, error) {
+	module, function, typeTags, args, err := c.forwarderEncoder.GetTransmissionState(receiver, workflowExecutionId, reportId)
+	if err != nil {
+		return *new(bool), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(bool), err
+	}
+
+	var (
+		r0 bool
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(bool), err
+	}
+	return r0, nil
+}
+
+func (c ForwarderContract) GetTransmitter(opts *bind.CallOpts, receiver aptos.AccountAddress, workflowExecutionId []byte, reportId uint16) (*aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.forwarderEncoder.GetTransmitter(receiver, workflowExecutionId, reportId)
+	if err != nil {
+		return *new(*aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(*aptos.AccountAddress), err
+	}
+
+	var (
+		r0 bind.StdOption[aptos.AccountAddress]
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(*aptos.AccountAddress), err
+	}
+	return r0.Value(), nil
+}
+
+func (c ForwarderContract) GetOwner(opts *bind.CallOpts) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.forwarderEncoder.GetOwner()
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	var (
+		r0 aptos.AccountAddress
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+	return r0, nil
+}
+
+func (c ForwarderContract) GetConfig(opts *bind.CallOpts, donId uint32, configVersion uint32) (Config, error) {
+	module, function, typeTags, args, err := c.forwarderEncoder.GetConfig(donId, configVersion)
+	if err != nil {
+		return *new(Config), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(Config), err
+	}
+
+	var (
+		r0 Config
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(Config), err
+	}
+	return r0, nil
+}
+
+// Entry Functions
+
+func (c ForwarderContract) SetConfig(opts *bind.TransactOpts, donId uint32, configVersion uint32, f byte, oracles [][]byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.forwarderEncoder.SetConfig(donId, configVersion, f, oracles)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c ForwarderContract) ClearConfig(opts *bind.TransactOpts, donId uint32, configVersion uint32) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.forwarderEncoder.ClearConfig(donId, configVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c ForwarderContract) Report(opts *bind.TransactOpts, receiver aptos.AccountAddress, rawReport []byte, signatures [][]byte) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.forwarderEncoder.Report(receiver, rawReport, signatures)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c ForwarderContract) TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.forwarderEncoder.TransferOwnership(to)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c ForwarderContract) AcceptOwnership(opts *bind.TransactOpts) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.forwarderEncoder.AcceptOwnership()
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+// Encoder
+type forwarderEncoder struct {
+	*bind.BoundContract
+}
+
+func (c forwarderEncoder) GetTransmissionState(receiver aptos.AccountAddress, workflowExecutionId []byte, reportId uint16) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_transmission_state", nil, []string{
+		"address",
+		"vector<u8>",
+		"u16",
+	}, []any{
+		receiver,
+		workflowExecutionId,
+		reportId,
+	})
+}
+
+func (c forwarderEncoder) GetTransmitter(receiver aptos.AccountAddress, workflowExecutionId []byte, reportId uint16) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_transmitter", nil, []string{
+		"address",
+		"vector<u8>",
+		"u16",
+	}, []any{
+		receiver,
+		workflowExecutionId,
+		reportId,
+	})
+}
+
+func (c forwarderEncoder) GetOwner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_owner", nil, []string{}, []any{})
+}
+
+func (c forwarderEncoder) GetConfig(donId uint32, configVersion uint32) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_config", nil, []string{
+		"u32",
+		"u32",
+	}, []any{
+		donId,
+		configVersion,
+	})
+}
+
+func (c forwarderEncoder) SetConfig(donId uint32, configVersion uint32, f byte, oracles [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("set_config", nil, []string{
+		"u32",
+		"u32",
+		"u8",
+		"vector<vector<u8>>",
+	}, []any{
+		donId,
+		configVersion,
+		f,
+		oracles,
+	})
+}
+
+func (c forwarderEncoder) ClearConfig(donId uint32, configVersion uint32) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("clear_config", nil, []string{
+		"u32",
+		"u32",
+	}, []any{
+		donId,
+		configVersion,
+	})
+}
+
+func (c forwarderEncoder) Report(receiver aptos.AccountAddress, rawReport []byte, signatures [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("report", nil, []string{
+		"address",
+		"vector<u8>",
+		"vector<vector<u8>>",
+	}, []any{
+		receiver,
+		rawReport,
+		signatures,
+	})
+}
+
+func (c forwarderEncoder) TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("transfer_ownership", nil, []string{
+		"address",
+	}, []any{
+		to,
+	})
+}
+
+func (c forwarderEncoder) AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("accept_ownership", nil, []string{}, []any{})
+}
+
+func (c forwarderEncoder) GetStateAddr() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_state_addr", nil, []string{}, []any{})
+}
+
+func (c forwarderEncoder) SignatureFromBytes(bytes []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("signature_from_bytes", nil, []string{
+		"vector<u8>",
+	}, []any{
+		bytes,
+	})
+}
+
+func (c forwarderEncoder) TransmissionId(receiver aptos.AccountAddress, workflowExecutionId []byte, reportId uint16) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("transmission_id", nil, []string{
+		"address",
+		"vector<u8>",
+		"u16",
+	}, []any{
+		receiver,
+		workflowExecutionId,
+		reportId,
+	})
+}
+
+func (c forwarderEncoder) Dispatch(receiver aptos.AccountAddress, metadata []byte, data []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("dispatch", nil, []string{
+		"address",
+		"vector<u8>",
+		"vector<u8>",
+	}, []any{
+		receiver,
+		metadata,
+		data,
+	})
+}
+
+func (c forwarderEncoder) ToU16be(data []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("to_u16be", nil, []string{
+		"vector<u8>",
+	}, []any{
+		data,
+	})
+}
+
+func (c forwarderEncoder) ToU32be(data []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("to_u32be", nil, []string{
+		"vector<u8>",
+	}, []any{
+		data,
+	})
+}
+
+func (c forwarderEncoder) ValidateAndProcessReport(receiver aptos.AccountAddress, rawReport []byte, signatures []Signature) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("validate_and_process_report", nil, []string{
+		"address",
+		"vector<u8>",
+		"vector<Signature>",
+	}, []any{
+		receiver,
+		rawReport,
+		signatures,
+	})
+}

--- a/bindings/platform_secondary/storage/storage.go
+++ b/bindings/platform_secondary/storage/storage.go
@@ -1,0 +1,175 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package module_storage
+
+import (
+	"math/big"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/api"
+
+	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	"github.com/smartcontractkit/chainlink-aptos/relayer/codec"
+)
+
+var (
+	_ = aptos.AccountAddress{}
+	_ = api.PendingTransaction{}
+	_ = big.NewInt
+	_ = bind.NewBoundContract
+	_ = codec.DecodeAptosJsonValue
+)
+
+type StorageInterface interface {
+	ParseReportMetadata(opts *bind.CallOpts, metadata []byte) (ReportMetadata, error)
+
+	MigrateToV2(opts *bind.TransactOpts, callbackAddresses []aptos.AccountAddress) (*api.PendingTransaction, error)
+
+	// Encoder returns the encoder implementation of this module.
+	Encoder() StorageEncoder
+}
+
+type StorageEncoder interface {
+	ParseReportMetadata(metadata []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	MigrateToV2(callbackAddresses []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	Insert(receiver aptos.AccountAddress, callbackMetadata []byte, callbackData []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	StorageExists(objAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	StorageAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+}
+
+const FunctionInfo = `[{"package":"platform_secondary","module":"storage","name":"insert","parameters":[{"name":"receiver","type":"address"},{"name":"callback_metadata","type":"vector\u003cu8\u003e"},{"name":"callback_data","type":"vector\u003cu8\u003e"}]},{"package":"platform_secondary","module":"storage","name":"migrate_to_v2","parameters":[{"name":"callback_addresses","type":"vector\u003caddress\u003e"}]},{"package":"platform_secondary","module":"storage","name":"storage_address","parameters":null},{"package":"platform_secondary","module":"storage","name":"storage_exists","parameters":[{"name":"obj_address","type":"address"}]}]`
+
+func NewStorage(address aptos.AccountAddress, client aptos.AptosRpcClient) StorageInterface {
+	contract := bind.NewBoundContract(address, "platform_secondary", "storage", client)
+	return StorageContract{
+		BoundContract:  contract,
+		storageEncoder: storageEncoder{BoundContract: contract},
+	}
+}
+
+// Structs
+
+type Entry struct {
+	Metadata bind.StdObject `move:"aptos_framework::object::Object"`
+}
+
+type Dispatcher struct {
+}
+
+type DispatcherV2 struct {
+}
+
+type Storage struct {
+	Metadata []byte `move:"vector<u8>"`
+	Data     []byte `move:"vector<u8>"`
+}
+
+type ReportMetadata struct {
+	WorkflowCid   []byte `move:"vector<u8>"`
+	WorkflowName  []byte `move:"vector<u8>"`
+	WorkflowOwner []byte `move:"vector<u8>"`
+	ReportId      []byte `move:"vector<u8>"`
+}
+
+type TestProof struct {
+}
+
+type TestProof2 struct {
+}
+
+type TestProof3 struct {
+}
+
+type TestProof4 struct {
+}
+
+type StorageContract struct {
+	*bind.BoundContract
+	storageEncoder
+}
+
+var _ StorageInterface = StorageContract{}
+
+func (c StorageContract) Encoder() StorageEncoder {
+	return c.storageEncoder
+}
+
+// View Functions
+
+func (c StorageContract) ParseReportMetadata(opts *bind.CallOpts, metadata []byte) (ReportMetadata, error) {
+	module, function, typeTags, args, err := c.storageEncoder.ParseReportMetadata(metadata)
+	if err != nil {
+		return *new(ReportMetadata), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(ReportMetadata), err
+	}
+
+	var (
+		r0 ReportMetadata
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(ReportMetadata), err
+	}
+	return r0, nil
+}
+
+// Entry Functions
+
+func (c StorageContract) MigrateToV2(opts *bind.TransactOpts, callbackAddresses []aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.storageEncoder.MigrateToV2(callbackAddresses)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+// Encoder
+type storageEncoder struct {
+	*bind.BoundContract
+}
+
+func (c storageEncoder) ParseReportMetadata(metadata []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("parse_report_metadata", nil, []string{
+		"vector<u8>",
+	}, []any{
+		metadata,
+	})
+}
+
+func (c storageEncoder) MigrateToV2(callbackAddresses []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("migrate_to_v2", nil, []string{
+		"vector<address>",
+	}, []any{
+		callbackAddresses,
+	})
+}
+
+func (c storageEncoder) Insert(receiver aptos.AccountAddress, callbackMetadata []byte, callbackData []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("insert", nil, []string{
+		"address",
+		"vector<u8>",
+		"vector<u8>",
+	}, []any{
+		receiver,
+		callbackMetadata,
+		callbackData,
+	})
+}
+
+func (c storageEncoder) StorageExists(objAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("storage_exists", nil, []string{
+		"address",
+	}, []any{
+		objAddress,
+	})
+}
+
+func (c storageEncoder) StorageAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("storage_address", nil, []string{}, []any{})
+}

--- a/contracts/contracts.go
+++ b/contracts/contracts.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 )
 
-//go:embed ccip large_packages mcms vendored data-feeds platform managed_token mcms-registrar
+//go:embed ccip large_packages mcms vendored data-feeds platform platform_secondary managed_token mcms-registrar
 var Embed embed.FS
 
 type Package string

--- a/contracts/contracts.go
+++ b/contracts/contracts.go
@@ -26,8 +26,9 @@ const (
 	ManagedToken  = Package("managed_token")
 	MCMSRegistrar = Package("mcms-registrar")
 
-	DataFeeds = Package("data_feeds")
-	Platform  = Package("platform")
+	DataFeeds         = Package("data_feeds")
+	Platform          = Package("platform")
+	PlatformSecondary = Package("platform_secondary")
 
 	MCMS     = Package("mcms")
 	MCMSTest = Package("mcms_test")
@@ -50,6 +51,7 @@ var Contracts map[Package]string = map[Package]string{
 	CCIPOnramp:           filepath.Join("ccip", "ccip_onramp"),
 	DataFeeds:            "data-feeds",
 	Platform:             "platform",
+	PlatformSecondary:    "platform_secondary",
 
 	ManagedToken:  filepath.Join("managed_token"),
 	MCMSRegistrar: filepath.Join("mcms-registrar"),

--- a/contracts/platform_secondary/Move.toml
+++ b/contracts/platform_secondary/Move.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ChainlinkPlatformSecondary"
+version = "1.0.0"
+authors = []
+
+[addresses]
+platform_secondary = "_"
+owner_secondary = "_"
+
+[dev-addresses]
+platform_secondary = "0x200"
+owner_secondary = "0x22"
+
+[dependencies]
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "34025227eb5367c449bf9dae3cd226fe5c187904", subdir = "aptos-move/framework/aptos-framework" }
+
+[dev-dependencies]

--- a/contracts/platform_secondary/sources/forwarder.move
+++ b/contracts/platform_secondary/sources/forwarder.move
@@ -1,0 +1,593 @@
+module platform_secondary::forwarder {
+    use aptos_framework::object::{Self, ExtendRef, TransferRef};
+    use aptos_std::smart_table::{SmartTable, Self};
+
+    use std::error;
+    use std::event;
+    use std::vector;
+    use std::bit_vector;
+    use std::option::{Self, Option};
+    use std::signer;
+    use std::bcs;
+
+    const E_INVALID_DATA_LENGTH: u64 = 1;
+    const E_INVALID_SIGNER: u64 = 2;
+    const E_DUPLICATE_SIGNER: u64 = 3;
+    const E_INVALID_SIGNATURE_COUNT: u64 = 4;
+    const E_INVALID_SIGNATURE: u64 = 5;
+    const E_ALREADY_PROCESSED: u64 = 6;
+    const E_NOT_OWNER: u64 = 7;
+    const E_MALFORMED_SIGNATURE: u64 = 8;
+    const E_FAULT_TOLERANCE_MUST_BE_POSITIVE: u64 = 9;
+    const E_EXCESS_SIGNERS: u64 = 10;
+    const E_INSUFFICIENT_SIGNERS: u64 = 11;
+    const E_CALLBACK_DATA_NOT_CONSUMED: u64 = 12;
+    const E_CANNOT_TRANSFER_TO_SELF: u64 = 13;
+    const E_NOT_PROPOSED_OWNER: u64 = 14;
+    const E_CONFIG_ID_NOT_FOUND: u64 = 15;
+    const E_INVALID_REPORT_VERSION: u64 = 16;
+
+    const MAX_ORACLES: u64 = 31;
+
+    const APP_OBJECT_SEED: vector<u8> = b"FORWARDER";
+
+    struct ConfigId has key, store, drop, copy {
+        don_id: u32,
+        config_version: u32
+    }
+
+    struct State has key {
+        owner_address: address,
+        pending_owner_address: address,
+        extend_ref: ExtendRef,
+        transfer_ref: TransferRef,
+
+        // (don_id, config_version) => config
+        configs: SmartTable<ConfigId, Config>,
+        reports: SmartTable<vector<u8>, address>
+    }
+
+    struct Config has key, store, drop, copy {
+        f: u8,
+        // oracles: SimpleMap<address, Oracle>,
+        oracles: vector<ed25519::UnvalidatedPublicKey>
+    }
+
+    #[event]
+    struct ConfigSet has drop, store {
+        don_id: u32,
+        config_version: u32,
+        f: u8,
+        signers: vector<vector<u8>>
+    }
+
+    #[event]
+    struct ReportProcessed has drop, store {
+        receiver: address,
+        workflow_execution_id: vector<u8>,
+        report_id: u16
+    }
+
+    #[event]
+    struct OwnershipTransferRequested has drop, store {
+        from: address,
+        to: address
+    }
+
+    #[event]
+    struct OwnershipTransferred has drop, store {
+        from: address,
+        to: address
+    }
+
+    inline fun assert_is_owner(state: &State, target_address: address) {
+        assert!(
+            state.owner_address == target_address,
+            error::permission_denied(E_NOT_OWNER)
+        );
+    }
+
+    fun init_module(publisher: &signer) {
+        assert!(signer::address_of(publisher) == @platform_secondary, 1);
+
+        let constructor_ref = object::create_named_object(publisher, APP_OBJECT_SEED);
+
+        let extend_ref = object::generate_extend_ref(&constructor_ref);
+        let transfer_ref = object::generate_transfer_ref(&constructor_ref);
+        let app_signer = &object::generate_signer(&constructor_ref);
+
+        move_to(
+            app_signer,
+            State {
+                owner_address: @owner_secondary,
+                pending_owner_address: @0x0,
+                configs: smart_table::new(),
+                reports: smart_table::new(),
+                extend_ref,
+                transfer_ref
+            }
+        );
+    }
+
+    inline fun get_state_addr(): address {
+        object::create_object_address(&@platform_secondary, APP_OBJECT_SEED)
+    }
+
+    public entry fun set_config(
+        authority: &signer,
+        don_id: u32,
+        config_version: u32,
+        f: u8,
+        oracles: vector<vector<u8>>
+    ) acquires State {
+        let state = borrow_global_mut<State>(get_state_addr());
+
+        assert_is_owner(state, signer::address_of(authority));
+
+        assert!(f != 0, error::invalid_argument(E_FAULT_TOLERANCE_MUST_BE_POSITIVE));
+        assert!(
+            vector::length(&oracles) <= MAX_ORACLES,
+            error::invalid_argument(E_EXCESS_SIGNERS)
+        );
+        assert!(
+            vector::length(&oracles) >= 3 * (f as u64) + 1,
+            error::invalid_argument(E_INSUFFICIENT_SIGNERS)
+        );
+
+        smart_table::upsert(
+            &mut state.configs,
+            ConfigId { don_id, config_version },
+            Config {
+                f,
+                oracles: vector::map(
+                    oracles,
+                    |oracle| { ed25519::new_unvalidated_public_key_from_bytes(oracle) }
+                )
+            }
+        );
+
+        event::emit(
+            ConfigSet { don_id, config_version, f, signers: oracles }
+        );
+    }
+
+    public entry fun clear_config(
+        authority: &signer, don_id: u32, config_version: u32
+    ) acquires State {
+        let state = borrow_global_mut<State>(get_state_addr());
+
+        assert_is_owner(state, signer::address_of(authority));
+
+        smart_table::remove(&mut state.configs, ConfigId { don_id, config_version });
+
+        event::emit(
+            ConfigSet { don_id, config_version, f: 0, signers: vector::empty() }
+        );
+    }
+
+    use aptos_std::aptos_hash::blake2b_256;
+    use aptos_std::ed25519;
+
+    struct Signature has drop {
+        public_key: ed25519::UnvalidatedPublicKey, // TODO: pass signer index rather than key to save on space and gas?
+        sig: ed25519::Signature
+    }
+
+    public fun signature_from_bytes(bytes: vector<u8>): Signature {
+        assert!(
+            vector::length(&bytes) == 96,
+            error::invalid_argument(E_MALFORMED_SIGNATURE)
+        );
+        let public_key =
+            ed25519::new_unvalidated_public_key_from_bytes(vector::slice(&bytes, 0, 32));
+        let sig = ed25519::new_signature_from_bytes(vector::slice(&bytes, 32, 96));
+        Signature { sig, public_key }
+    }
+
+    inline fun transmission_id(
+        receiver: address, workflow_execution_id: vector<u8>, report_id: u16
+    ): vector<u8> {
+        let id = bcs::to_bytes(&receiver);
+        vector::append(&mut id, workflow_execution_id);
+        vector::append(&mut id, bcs::to_bytes(&report_id));
+        id
+    }
+
+    /// The dispatch call knows both storage and indirectly the callback, thus the separate module.
+    fun dispatch(
+        receiver: address, metadata: vector<u8>, data: vector<u8>
+    ) {
+        let meta = platform_secondary::storage::insert(receiver, metadata, data);
+        aptos_framework::dispatchable_fungible_asset::derived_supply(meta);
+        let obj_address =
+            object::object_address<aptos_framework::fungible_asset::Metadata>(&meta);
+        assert!(
+            !platform_secondary::storage::storage_exists(obj_address),
+            E_CALLBACK_DATA_NOT_CONSUMED
+        );
+    }
+
+    entry fun report(
+        transmitter: &signer,
+        receiver: address,
+        raw_report: vector<u8>,
+        signatures: vector<vector<u8>>
+    ) acquires State {
+        let signatures = vector::map(
+            signatures, |signature| signature_from_bytes(signature)
+        );
+
+        let (metadata, data) =
+            validate_and_process_report(transmitter, receiver, raw_report, signatures);
+        // NOTE: unable to catch failure here
+        dispatch(receiver, metadata, data);
+    }
+
+    inline fun to_u16be(data: vector<u8>): u16 {
+        // reverse big endian to little endian
+        vector::reverse(&mut data);
+        aptos_std::from_bcs::to_u16(data)
+    }
+
+    inline fun to_u32be(data: vector<u8>): u32 {
+        // reverse big endian to little endian
+        vector::reverse(&mut data);
+        aptos_std::from_bcs::to_u32(data)
+    }
+
+    fun validate_and_process_report(
+        transmitter: &signer,
+        receiver: address,
+        raw_report: vector<u8>,
+        signatures: vector<Signature>
+    ): (vector<u8>, vector<u8>) acquires State {
+        let state = borrow_global_mut<State>(get_state_addr());
+
+        // report_context = vector::slice(&raw_report, 0, 96);
+        let report = vector::slice(&raw_report, 96, vector::length(&raw_report));
+
+        // parse out report metadata
+        // version | workflow_execution_id | timestamp | don_id | config_version | ...
+        let report_version = *vector::borrow(&report, 0);
+        assert!(report_version == 1, E_INVALID_REPORT_VERSION);
+
+        let workflow_execution_id = vector::slice(&report, 1, 33);
+        // _timestamp
+        let don_id = vector::slice(&report, 37, 41);
+        let don_id = to_u32be(don_id);
+        let config_version = vector::slice(&report, 41, 45);
+        let config_version = to_u32be(config_version);
+        let report_id = vector::slice(&report, 107, 109);
+        let report_id = to_u16be(report_id);
+        let metadata = vector::slice(&report, 45, 109);
+        let data = vector::slice(&report, 109, vector::length(&report));
+
+        let config_id = ConfigId { don_id, config_version };
+        assert!(smart_table::contains(&state.configs, config_id), E_CONFIG_ID_NOT_FOUND);
+        let config = smart_table::borrow(&state.configs, config_id);
+
+        // check if report was already delivered
+        let transmission_id = transmission_id(receiver, workflow_execution_id, report_id);
+        let processed = smart_table::contains(&state.reports, transmission_id);
+        assert!(!processed, E_ALREADY_PROCESSED);
+
+        let required_signatures = (config.f as u64) + 1;
+        assert!(
+            vector::length(&signatures) == required_signatures,
+            error::invalid_argument(E_INVALID_SIGNATURE_COUNT)
+        );
+
+        // blake2b(report_context | report)
+        let msg = blake2b_256(raw_report);
+
+        let signed = bit_vector::new(vector::length(&config.oracles));
+
+        vector::for_each_ref(
+            &signatures,
+            |signature| {
+                let signature: &Signature = signature; // some compiler versions can't infer the type here
+
+                let (valid, index) = vector::index_of(
+                    &config.oracles, &signature.public_key
+                );
+                assert!(valid, error::invalid_argument(E_INVALID_SIGNER));
+
+                // check for duplicate signers
+                let duplicate = bit_vector::is_index_set(&signed, index);
+                assert!(!duplicate, error::invalid_argument(E_DUPLICATE_SIGNER));
+                bit_vector::set(&mut signed, index);
+
+                let result =
+                    ed25519::signature_verify_strict(
+                        &signature.sig, &signature.public_key, msg
+                    );
+                assert!(result, error::invalid_argument(E_INVALID_SIGNATURE));
+            }
+        );
+
+        // mark as delivered
+        smart_table::add(
+            &mut state.reports, transmission_id, signer::address_of(transmitter)
+        );
+
+        event::emit(ReportProcessed { receiver, workflow_execution_id, report_id });
+
+        (metadata, data)
+    }
+
+    #[view]
+    public fun get_transmission_state(
+        receiver: address, workflow_execution_id: vector<u8>, report_id: u16
+    ): bool acquires State {
+        let state = borrow_global<State>(get_state_addr());
+        let transmission_id = transmission_id(receiver, workflow_execution_id, report_id);
+
+        return smart_table::contains(&state.reports, transmission_id)
+    }
+
+    #[view]
+    public fun get_transmitter(
+        receiver: address, workflow_execution_id: vector<u8>, report_id: u16
+    ): Option<address> acquires State {
+        let state = borrow_global<State>(get_state_addr());
+        let transmission_id = transmission_id(receiver, workflow_execution_id, report_id);
+
+        if (!smart_table::contains(&state.reports, transmission_id)) {
+            return option::none()
+        };
+        option::some(*smart_table::borrow(&state.reports, transmission_id))
+    }
+
+    // Ownership functions
+
+    #[view]
+    public fun get_owner(): address acquires State {
+        let state = borrow_global<State>(get_state_addr());
+        state.owner_address
+    }
+
+    #[view]
+    public fun get_config(don_id: u32, config_version: u32): Config acquires State {
+        let state = borrow_global<State>(get_state_addr());
+        let config_id = ConfigId { don_id, config_version };
+        *smart_table::borrow(&state.configs, config_id)
+    }
+
+    public entry fun transfer_ownership(authority: &signer, to: address) acquires State {
+        let state = borrow_global_mut<State>(get_state_addr());
+        assert_is_owner(state, signer::address_of(authority));
+        assert!(
+            state.owner_address != to,
+            error::invalid_argument(E_CANNOT_TRANSFER_TO_SELF)
+        );
+
+        state.pending_owner_address = to;
+
+        event::emit(OwnershipTransferRequested { from: state.owner_address, to });
+    }
+
+    public entry fun accept_ownership(authority: &signer) acquires State {
+        let state = borrow_global_mut<State>(get_state_addr());
+        assert!(
+            state.pending_owner_address == signer::address_of(authority),
+            error::permission_denied(E_NOT_PROPOSED_OWNER)
+        );
+
+        let old_owner_address = state.owner_address;
+        state.owner_address = state.pending_owner_address;
+        state.pending_owner_address = @0x0;
+
+        event::emit(
+            OwnershipTransferred { from: old_owner_address, to: state.owner_address }
+        );
+    }
+
+    #[test_only]
+    public fun init_module_for_testing(publisher: &signer) {
+        init_module(publisher);
+    }
+
+    #[test_only]
+    public entry fun set_up_test(
+        owner_secondary: &signer, publisher: &signer
+    ) {
+        use aptos_framework::account::{Self};
+        account::create_account_for_test(signer::address_of(owner_secondary));
+        account::create_account_for_test(signer::address_of(publisher));
+
+        init_module(publisher);
+    }
+
+    #[test_only]
+    struct OracleSet has drop {
+        don_id: u32,
+        config_version: u32,
+        f: u8,
+        oracles: vector<vector<u8>>,
+        signers: vector<ed25519::SecretKey>
+    }
+
+    #[test_only]
+    fun generate_oracle_set(): OracleSet {
+        let don_id = 0;
+        let f = 1;
+
+        let signers = vector[];
+        let oracles = vector[];
+        for (i in 0..31) {
+            let (sk, pk) = ed25519::generate_keys();
+            vector::push_back(&mut signers, sk);
+            vector::push_back(&mut oracles, ed25519::validated_public_key_to_bytes(&pk));
+        };
+        OracleSet { don_id, config_version: 1, f, oracles, signers }
+    }
+
+    #[test_only]
+    fun sign_report(
+        config: &OracleSet, report: vector<u8>, report_context: vector<u8>
+    ): vector<Signature> {
+        // blake2b(report_context, report)
+        let msg = report_context;
+        vector::append(&mut msg, report);
+        let msg = blake2b_256(msg);
+
+        let signatures = vector[];
+        let required_signatures = config.f + 1;
+        for (i in 0..required_signatures) {
+            let config_signer = vector::borrow(&config.signers, (i as u64));
+            let public_key =
+                ed25519::new_unvalidated_public_key_from_bytes(
+                    *vector::borrow(&config.oracles, (i as u64))
+                );
+            let sig = ed25519::sign_arbitrary_bytes(config_signer, msg);
+            vector::push_back(&mut signatures, Signature { sig, public_key });
+        };
+        signatures
+    }
+
+    #[test(owner_secondary = @owner_secondary, publisher = @platform_secondary)]
+    public entry fun test_happy_path(
+        owner_secondary: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        let config = generate_oracle_set();
+
+        // configure DON
+        set_config(
+            owner_secondary,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        // generate report
+        let version = 1;
+        let timestamp: u32 = 1;
+        let workflow_id =
+            x"6d795f6964000000000000000000000000000000000000000000000000000000";
+        let workflow_name = x"000000000000DEADBEEF";
+        let workflow_owner = x"0000000000000000000000000000000000000051";
+        let report_id = x"0001";
+        let execution_id =
+            x"6d795f657865637574696f6e5f69640000000000000000000000000000000000";
+        let mercury_reports = vector[x"010203", x"aabbcc"];
+
+        let report = vector[];
+        // header
+        vector::push_back(&mut report, version);
+        vector::append(&mut report, execution_id);
+
+        let bytes = bcs::to_bytes(&timestamp);
+        // convert little-endian to big-endian
+        vector::reverse(&mut bytes);
+        vector::append(&mut report, bytes);
+
+        let bytes = bcs::to_bytes(&config.don_id);
+        // convert little-endian to big-endian
+        vector::reverse(&mut bytes);
+        vector::append(&mut report, bytes);
+
+        let bytes = bcs::to_bytes(&config.config_version);
+        // convert little-endian to big-endian
+        vector::reverse(&mut bytes);
+        vector::append(&mut report, bytes);
+
+        // metadata
+        vector::append(&mut report, workflow_id);
+        vector::append(&mut report, workflow_name);
+        vector::append(&mut report, workflow_owner);
+        vector::append(&mut report, report_id);
+        // report
+        vector::append(&mut report, bcs::to_bytes(&mercury_reports));
+
+        let report_context =
+            x"a0b000000000000000000000000000000000000000000000000000000000000a0b000000000000000000000000000000000000000000000000000000000000a0b000000000000000000000000000000000000000000000000000000000000000";
+        assert!(vector::length(&report_context) == 96, 1);
+
+        let raw_report = vector[];
+        vector::append(&mut raw_report, report_context);
+        vector::append(&mut raw_report, report);
+
+        // sign report
+        let signatures = sign_report(&config, report, report_context);
+
+        // call entrypoint
+        validate_and_process_report(
+            owner_secondary,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[
+        test(
+            owner_secondary = @owner_secondary,
+            publisher = @platform_secondary,
+            new_owner = @0xbeef
+        )
+    ]
+    fun test_transfer_ownership_success(
+        owner_secondary: &signer, publisher: &signer, new_owner: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        assert!(get_owner() == @owner_secondary, 1);
+
+        transfer_ownership(owner_secondary, signer::address_of(new_owner));
+        accept_ownership(new_owner);
+
+        assert!(get_owner() == signer::address_of(new_owner), 2);
+    }
+
+    #[
+        test(
+            owner_secondary = @owner_secondary,
+            publisher = @platform_secondary,
+            unknown_user = @0xbeef
+        )
+    ]
+    #[expected_failure(abort_code = 327687, location = platform_secondary::forwarder)]
+    fun test_transfer_ownership_failure_not_owner(
+        owner_secondary: &signer, publisher: &signer, unknown_user: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        assert!(get_owner() == @owner_secondary, 1);
+
+        transfer_ownership(unknown_user, signer::address_of(unknown_user));
+    }
+
+    #[test(owner_secondary = @owner_secondary, publisher = @platform_secondary)]
+    #[expected_failure(abort_code = 65549, location = platform_secondary::forwarder)]
+    fun test_transfer_ownership_failure_transfer_to_self(
+        owner_secondary: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        assert!(get_owner() == @owner_secondary, 1);
+
+        transfer_ownership(owner_secondary, signer::address_of(owner_secondary));
+    }
+
+    #[
+        test(
+            owner_secondary = @owner_secondary,
+            publisher = @platform_secondary,
+            new_owner = @0xbeef
+        )
+    ]
+    #[expected_failure(abort_code = 327694, location = platform_secondary::forwarder)]
+    fun test_transfer_ownership_failure_not_proposed_owner(
+        owner_secondary: &signer, publisher: &signer, new_owner: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        assert!(get_owner() == @owner_secondary, 1);
+
+        transfer_ownership(owner_secondary, @0xfeeb);
+        accept_ownership(new_owner);
+    }
+}

--- a/contracts/platform_secondary/sources/storage.move
+++ b/contracts/platform_secondary/sources/storage.move
@@ -1,0 +1,526 @@
+/// The storage module stores all the state associated with the dispatch service.
+module platform_secondary::storage {
+    use std::option;
+    use std::string;
+    use std::signer;
+    use std::vector;
+
+    use aptos_std::table::{Self, Table};
+    use aptos_std::smart_table::{SmartTable, Self};
+    use aptos_std::type_info::{Self, TypeInfo};
+
+    use aptos_framework::dispatchable_fungible_asset;
+    use aptos_framework::function_info::FunctionInfo;
+    use aptos_framework::fungible_asset::{Self, Metadata};
+    use aptos_framework::object::{Self, ExtendRef, TransferRef, Object};
+
+    const APP_OBJECT_SEED: vector<u8> = b"STORAGE";
+
+    friend platform_secondary::forwarder;
+
+    const E_UNKNOWN_RECEIVER: u64 = 1;
+    const E_INVALID_METADATA_LENGTH: u64 = 2;
+
+    struct Entry has key, store, drop {
+        metadata: Object<Metadata>,
+        extend_ref: ExtendRef
+    }
+
+    struct Dispatcher has key {
+        /// Tracks the input type to the dispatch handler.
+        dispatcher: Table<TypeInfo, Entry>,
+        address_to_typeinfo: Table<address, TypeInfo>,
+        /// Used to store temporary data for dispatching.
+        extend_ref: ExtendRef,
+        transfer_ref: TransferRef
+    }
+
+    struct DispatcherV2 has key {
+        dispatcher: SmartTable<TypeInfo, Entry>,
+        address_to_typeinfo: SmartTable<address, TypeInfo>
+    }
+
+    /// Store the data to dispatch here.
+    struct Storage has drop, key {
+        metadata: vector<u8>,
+        data: vector<u8>
+    }
+
+    struct ReportMetadata has key, store, drop {
+        workflow_cid: vector<u8>,
+        workflow_name: vector<u8>,
+        workflow_owner: vector<u8>,
+        report_id: vector<u8>
+    }
+
+    /// Registers an account and callback for future dispatching, and a proof type `T`
+    /// for the callback function to retrieve arguments. Note that the function will
+    /// abort if the account has already been registered.
+    ///
+    /// The address of `account` is used to represent the callback by the dispatcher.
+    /// See the `dispatch` function in `forwarder.move`.
+    ///
+    /// Providing an instance of `T` guarantees that only a privileged module can call `register` for that type.
+    /// The type `T` should ideally only have the `drop` ability and no other abilities to prevent
+    /// copying and persisting in global storage.
+    public fun register<T: drop>(
+        account: &signer, callback: FunctionInfo, _proof: T
+    ) acquires Dispatcher, DispatcherV2 {
+        let typename = type_info::type_name<T>();
+        let constructor_ref =
+            object::create_named_object(&storage_signer(), *string::bytes(&typename));
+        let extend_ref = object::generate_extend_ref(&constructor_ref);
+        let metadata =
+            fungible_asset::add_fungibility(
+                &constructor_ref,
+                option::none(),
+                // this was `typename` but it fails due to ENAME_TOO_LONG
+                string::utf8(b"storage"),
+                string::utf8(b"dis"),
+                0,
+                string::utf8(b""),
+                string::utf8(b"")
+            );
+        dispatchable_fungible_asset::register_derive_supply_dispatch_function(
+            &constructor_ref, option::some(callback)
+        );
+
+        let dispatcher = borrow_global_mut<DispatcherV2>(storage_address());
+        smart_table::add(
+            &mut dispatcher.dispatcher,
+            type_info::type_of<T>(),
+            Entry { metadata, extend_ref }
+        );
+        smart_table::add(
+            &mut dispatcher.address_to_typeinfo,
+            signer::address_of(account),
+            type_info::type_of<T>()
+        );
+    }
+
+    public entry fun migrate_to_v2(
+        callback_addresses: vector<address>
+    ) acquires Dispatcher, DispatcherV2 {
+        let addr = storage_address();
+
+        if (!exists<DispatcherV2>(addr)) {
+            move_to(
+                &storage_signer(),
+                DispatcherV2 {
+                    dispatcher: smart_table::new(),
+                    address_to_typeinfo: smart_table::new()
+                }
+            );
+        };
+
+        let dispatcher = borrow_global_mut<Dispatcher>(addr);
+        let dispatcher_v2 = borrow_global_mut<DispatcherV2>(addr);
+
+        vector::for_each_ref(
+            &callback_addresses,
+            |callback_address| {
+                // Aborts if the callback address does not exist.
+                let type_info =
+                    table::remove(
+                        &mut dispatcher.address_to_typeinfo, *callback_address
+                    );
+                let entry = table::remove(&mut dispatcher.dispatcher, type_info);
+
+                smart_table::add(
+                    &mut dispatcher_v2.address_to_typeinfo,
+                    *callback_address,
+                    type_info
+                );
+                smart_table::add(&mut dispatcher_v2.dispatcher, type_info, entry);
+            }
+        );
+    }
+
+    /// Insert into this module as the callback needs to retrieve and avoid a cyclical dependency:
+    /// engine -> storage and then engine -> callback -> storage
+    public(friend) fun insert(
+        receiver: address, callback_metadata: vector<u8>, callback_data: vector<u8>
+    ): Object<Metadata> acquires Dispatcher, DispatcherV2 {
+        // TODO: delete this clause after migration completes
+        if (!exists<DispatcherV2>(storage_address())) {
+            let dispatcher = borrow_global<Dispatcher>(storage_address());
+            let typeinfo = *table::borrow(&dispatcher.address_to_typeinfo, receiver);
+            assert!(
+                table::contains(&dispatcher.dispatcher, typeinfo),
+                E_UNKNOWN_RECEIVER
+            );
+            let Entry { metadata: asset_metadata, extend_ref } =
+                table::borrow(&dispatcher.dispatcher, typeinfo);
+            let obj_signer = object::generate_signer_for_extending(extend_ref);
+            move_to(
+                &obj_signer, Storage { data: callback_data, metadata: callback_metadata }
+            );
+            return *asset_metadata
+        };
+
+        let dispatcher = borrow_global<DispatcherV2>(storage_address());
+        let typeinfo = *smart_table::borrow(&dispatcher.address_to_typeinfo, receiver);
+        assert!(
+            smart_table::contains(&dispatcher.dispatcher, typeinfo),
+            E_UNKNOWN_RECEIVER
+        );
+        let Entry { metadata: asset_metadata, extend_ref } =
+            smart_table::borrow(&dispatcher.dispatcher, typeinfo);
+        let obj_signer = object::generate_signer_for_extending(extend_ref);
+        move_to(&obj_signer, Storage { data: callback_data, metadata: callback_metadata });
+        *asset_metadata
+    }
+
+    public(friend) fun storage_exists(obj_address: address): bool {
+        object::object_exists<Storage>(obj_address)
+    }
+
+    /// Second half of the process for retrieving. This happens outside engine to prevent the
+    /// cyclical dependency.
+    public fun retrieve<T: drop>(
+        _proof: T
+    ): (vector<u8>, vector<u8>) acquires Dispatcher, DispatcherV2, Storage {
+        // TODO: delete this clause after migration completes
+        if (!exists<DispatcherV2>(storage_address())) {
+            let dispatcher = borrow_global<Dispatcher>(storage_address());
+            let typeinfo = type_info::type_of<T>();
+            let Entry { metadata: _, extend_ref } =
+                table::borrow(&dispatcher.dispatcher, typeinfo);
+            let obj_address = object::address_from_extend_ref(extend_ref);
+            let data = move_from<Storage>(obj_address);
+            return (data.metadata, data.data)
+        };
+        let dispatcher = borrow_global<DispatcherV2>(storage_address());
+        let typeinfo = type_info::type_of<T>();
+        let Entry { metadata: _, extend_ref } =
+            smart_table::borrow(&dispatcher.dispatcher, typeinfo);
+        let obj_address = object::address_from_extend_ref(extend_ref);
+        let data = move_from<Storage>(obj_address);
+        (data.metadata, data.data)
+    }
+
+    #[view]
+    public fun parse_report_metadata(metadata: vector<u8>): ReportMetadata {
+        // workflow_cid             // offset 0,  size 32
+        // workflow_name            // offset 32, size 10
+        // workflow_owner           // offset 42, size 20
+        // report_id                // offset 62, size  2
+        assert!(vector::length(&metadata) == 64, E_INVALID_METADATA_LENGTH);
+
+        let workflow_cid = vector::slice(&metadata, 0, 32);
+        let workflow_name = vector::slice(&metadata, 32, 42);
+        let workflow_owner = vector::slice(&metadata, 42, 62);
+        let report_id = vector::slice(&metadata, 62, 64);
+
+        ReportMetadata { workflow_cid, workflow_name, workflow_owner, report_id }
+    }
+
+    /// Prepares the dispatch table.
+    fun init_module(publisher: &signer) {
+        assert!(signer::address_of(publisher) == @platform_secondary, 1);
+
+        let constructor_ref = object::create_named_object(publisher, APP_OBJECT_SEED);
+
+        let extend_ref = object::generate_extend_ref(&constructor_ref);
+        let transfer_ref = object::generate_transfer_ref(&constructor_ref);
+        let object_signer = object::generate_signer(&constructor_ref);
+
+        move_to(
+            &object_signer,
+            Dispatcher {
+                dispatcher: table::new(),
+                address_to_typeinfo: table::new(),
+                extend_ref,
+                transfer_ref
+            }
+        );
+
+        move_to(
+            &object_signer,
+            DispatcherV2 {
+                dispatcher: smart_table::new(),
+                address_to_typeinfo: smart_table::new()
+            }
+        );
+    }
+
+    inline fun storage_address(): address {
+        object::create_object_address(&@platform_secondary, APP_OBJECT_SEED)
+    }
+
+    inline fun storage_signer(): signer acquires Dispatcher {
+        object::generate_signer_for_extending(
+            &borrow_global<Dispatcher>(storage_address()).extend_ref
+        )
+    }
+
+    // Struct accessors
+
+    public fun get_report_metadata_workflow_cid(
+        report_metadata: &ReportMetadata
+    ): vector<u8> {
+        report_metadata.workflow_cid
+    }
+
+    public fun get_report_metadata_workflow_name(
+        report_metadata: &ReportMetadata
+    ): vector<u8> {
+        report_metadata.workflow_name
+    }
+
+    public fun get_report_metadata_workflow_owner(
+        report_metadata: &ReportMetadata
+    ): vector<u8> {
+        report_metadata.workflow_owner
+    }
+
+    public fun get_report_metadata_report_id(
+        report_metadata: &ReportMetadata
+    ): vector<u8> {
+        report_metadata.report_id
+    }
+
+    #[test_only]
+    public fun init_module_for_testing(publisher: &signer) {
+        init_module(publisher);
+    }
+
+    #[test]
+    fun test_parse_report_metadata() {
+        let metadata =
+            x"6d795f6964000000000000000000000000000000000000000000000000000000000000000000deadbeef00000000000000000000000000000000000000510001";
+        let expected_workflow_cid =
+            x"6d795f6964000000000000000000000000000000000000000000000000000000";
+        let expected_workflow_name = x"000000000000DEADBEEF";
+        let expected_workflow_owner = x"0000000000000000000000000000000000000051";
+        let expected_report_id = x"0001";
+
+        let parsed_metadata = parse_report_metadata(metadata);
+        assert!(parsed_metadata.workflow_cid == expected_workflow_cid, 1);
+        assert!(parsed_metadata.workflow_name == expected_workflow_name, 1);
+        assert!(parsed_metadata.workflow_owner == expected_workflow_owner, 1);
+        assert!(parsed_metadata.report_id == expected_report_id, 1);
+    }
+
+    #[test_only]
+    fun init_module_deprecated(publisher: &signer) {
+        assert!(signer::address_of(publisher) == @platform_secondary, 1);
+
+        let constructor_ref = object::create_named_object(publisher, APP_OBJECT_SEED);
+
+        let extend_ref = object::generate_extend_ref(&constructor_ref);
+        let transfer_ref = object::generate_transfer_ref(&constructor_ref);
+        let object_signer = object::generate_signer(&constructor_ref);
+
+        move_to(
+            &object_signer,
+            Dispatcher {
+                dispatcher: table::new(),
+                address_to_typeinfo: table::new(),
+                extend_ref,
+                transfer_ref
+            }
+        );
+    }
+
+    #[test_only]
+    fun register_deprecated<T: drop>(
+        account: &signer, callback: FunctionInfo, _proof: T
+    ) acquires Dispatcher {
+        let typename = type_info::type_name<T>();
+        let constructor_ref =
+            object::create_named_object(&storage_signer(), *string::bytes(&typename));
+        let extend_ref = object::generate_extend_ref(&constructor_ref);
+        let metadata =
+            fungible_asset::add_fungibility(
+                &constructor_ref,
+                option::none(),
+                // this was `typename` but it fails due to ENAME_TOO_LONG
+                string::utf8(b"storage"),
+                string::utf8(b"dis"),
+                0,
+                string::utf8(b""),
+                string::utf8(b"")
+            );
+        dispatchable_fungible_asset::register_derive_supply_dispatch_function(
+            &constructor_ref, option::some(callback)
+        );
+
+        let dispatcher = borrow_global_mut<Dispatcher>(storage_address());
+        table::add(
+            &mut dispatcher.dispatcher,
+            type_info::type_of<T>(),
+            Entry { metadata, extend_ref }
+        );
+        table::add(
+            &mut dispatcher.address_to_typeinfo,
+            signer::address_of(account),
+            type_info::type_of<T>()
+        );
+    }
+
+    #[test_only]
+    struct TestProof has drop {}
+
+    #[test_only]
+    struct TestProof2 has drop {}
+
+    #[test_only]
+    struct TestProof3 has drop {}
+
+    #[test_only]
+    struct TestProof4 has drop {}
+
+    #[test_only]
+    public fun test_callback<T: key>(_metadata: Object<T>): option::Option<u128> {
+        option::none()
+    }
+
+    #[test(publisher = @platform_secondary)]
+    fun test_v2_migration(publisher: &signer) acquires Dispatcher, DispatcherV2, Storage {
+        init_module_deprecated(publisher);
+
+        let test_callback =
+            aptos_framework::function_info::new_function_info(
+                publisher,
+                string::utf8(b"storage"),
+                string::utf8(b"test_callback")
+            );
+
+        register_deprecated(publisher, test_callback, TestProof {});
+
+        let (derived_publisher, _) =
+            aptos_framework::account::create_resource_account(
+                publisher, b"TEST_V2_MIGRATION"
+            );
+        let (derived_publisher2, _) =
+            aptos_framework::account::create_resource_account(
+                publisher, b"TEST_V2_MIGRATION_2"
+            );
+        let (derived_publisher3, _) =
+            aptos_framework::account::create_resource_account(
+                publisher, b"TEST_V2_MIGRATION_3"
+            );
+
+        register_deprecated(&derived_publisher, test_callback, TestProof2 {});
+        register_deprecated(&derived_publisher2, test_callback, TestProof3 {});
+
+        let callback_metadata = vector[1, 2, 3, 4];
+        let callback_data = vector[5, 6, 7, 8, 9];
+
+        // test initial migration
+        {
+            // test that insert and retrieve work before migration
+            insert(signer::address_of(publisher), callback_metadata, callback_data);
+            let (received_metadata, received_data) = retrieve<TestProof>(TestProof {});
+            assert!(callback_metadata == received_metadata, 1);
+            assert!(callback_data == received_data, 1);
+
+            let derived_addr = signer::address_of(&derived_publisher);
+            migrate_to_v2(vector[@platform_secondary, derived_addr]);
+
+            // test that insert and retrieve still work after migration
+            insert(signer::address_of(publisher), callback_metadata, callback_data);
+            let (received_metadata, received_data) = retrieve<TestProof>(TestProof {});
+            assert!(callback_metadata == received_metadata, 1);
+            assert!(callback_data == received_data, 1);
+
+            let dispatcher = borrow_global<Dispatcher>(storage_address());
+            assert!(
+                !table::contains(
+                    &dispatcher.dispatcher, type_info::type_of<TestProof>()
+                ),
+                1
+            );
+            assert!(
+                !table::contains(&dispatcher.address_to_typeinfo, @platform_secondary),
+                1
+            );
+            assert!(
+                !table::contains(
+                    &dispatcher.dispatcher, type_info::type_of<TestProof2>()
+                ),
+                1
+            );
+            assert!(!table::contains(&dispatcher.address_to_typeinfo, derived_addr), 1);
+
+            let dispatcher_v2 = borrow_global<DispatcherV2>(storage_address());
+            assert!(
+                smart_table::contains(
+                    &dispatcher_v2.dispatcher, type_info::type_of<TestProof>()
+                ),
+                1
+            );
+            assert!(
+                smart_table::contains(
+                    &dispatcher_v2.address_to_typeinfo, @platform_secondary
+                ),
+                1
+            );
+            assert!(
+                smart_table::contains(
+                    &dispatcher_v2.dispatcher, type_info::type_of<TestProof2>()
+                ),
+                1
+            );
+            assert!(
+                smart_table::contains(&dispatcher_v2.address_to_typeinfo, derived_addr),
+                1
+            );
+        };
+
+        // migrate a second time, when DispatcherV2 already exists.
+        {
+            let derived_addr = signer::address_of(&derived_publisher2);
+            migrate_to_v2(vector[derived_addr]);
+
+            let dispatcher = borrow_global<Dispatcher>(storage_address());
+            assert!(
+                !table::contains(
+                    &dispatcher.dispatcher, type_info::type_of<TestProof3>()
+                ),
+                1
+            );
+            assert!(!table::contains(&dispatcher.address_to_typeinfo, derived_addr), 1);
+
+            let dispatcher_v2 = borrow_global<DispatcherV2>(storage_address());
+            assert!(
+                smart_table::contains(
+                    &dispatcher_v2.dispatcher, type_info::type_of<TestProof3>()
+                ),
+                1
+            );
+            assert!(
+                smart_table::contains(&dispatcher_v2.address_to_typeinfo, derived_addr),
+                1
+            );
+        };
+
+        // test the upgraded register function
+        {
+            let derived_addr = signer::address_of(&derived_publisher3);
+            register(&derived_publisher3, test_callback, TestProof4 {});
+
+            let dispatcher = borrow_global<Dispatcher>(storage_address());
+            assert!(
+                !table::contains(
+                    &dispatcher.dispatcher, type_info::type_of<TestProof4>()
+                ),
+                1
+            );
+            assert!(!table::contains(&dispatcher.address_to_typeinfo, derived_addr), 1);
+
+            let dispatcher_v2 = borrow_global<DispatcherV2>(storage_address());
+            assert!(
+                smart_table::contains(
+                    &dispatcher_v2.dispatcher, type_info::type_of<TestProof4>()
+                ),
+                1
+            );
+            assert!(
+                smart_table::contains(&dispatcher_v2.address_to_typeinfo, derived_addr),
+                1
+            );
+        }
+    }
+}

--- a/gen.go
+++ b/gen.go
@@ -39,3 +39,6 @@ package aptos
 
 //go:generate go run ./cmd/bindgen --input ./contracts/platform/sources/forwarder.move --output ./bindings/platform/forwarder
 //go:generate go run ./cmd/bindgen --input ./contracts/platform/sources/storage.move --output ./bindings/platform/storage
+
+//go:generate go run ./cmd/bindgen --input ./contracts/platform_secondary/sources/forwarder.move --output ./bindings/platform_secondary/forwarder
+//go:generate go run ./cmd/bindgen --input ./contracts/platform_secondary/sources/storage.move --output ./bindings/platform_secondary/storage

--- a/integration-tests/deploy/deployer.go
+++ b/integration-tests/deploy/deployer.go
@@ -86,8 +86,9 @@ type PostgresClient struct {
 }
 
 type Contracts struct {
-	KeystoneAddress  string
-	DataFeedsAddress string
+	KeystoneAddress          string
+	KeystoneSecondaryAddress string
+	DataFeedsAddress         string
 }
 
 func New(lggr *zerolog.Logger) *Deployer {

--- a/integration-tests/deploy/devnet.go
+++ b/integration-tests/deploy/devnet.go
@@ -127,7 +127,7 @@ func (d *Deployer) DeployPlatform() error {
 		"--package-dir=/contracts/platform",
 		"--address-name=platform",
 		"--named-addresses",
-		fmt.Sprintf("platform=%s,owner=%s", DEVNET_ACC, DEVNET_ACC),
+		fmt.Sprintf("owner=%s", DEVNET_ACC, DEVNET_ACC),
 		"--profile=default",
 		"--assume-yes",
 	}
@@ -149,6 +149,36 @@ func (d *Deployer) DeployPlatform() error {
 	return nil
 }
 
+func (d *Deployer) DeployPlatformSecondary() error {
+	cmdStr := []string{
+		"aptos",
+		"move",
+		"create-object-and-publish-package",
+		"--package-dir=/contracts/platform_secondary",
+		"--address-name=platform_secondary",
+		"--named-addresses",
+		fmt.Sprintf("owner_secondary=%s", DEVNET_ACC),
+		"--profile=default",
+		"--assume-yes",
+	}
+
+	out, err := ExecCmd(d.Devnet.Client, cmdStr, *d.lggr)
+	if err != nil {
+		return err
+	}
+
+	// Fetch contract address from output
+	regex := regexp.MustCompile(`0x[a-zA-Z0-9]+`)
+	d.Contracts.KeystoneSecondaryAddress = regex.FindString(strings.Split(out, "Code was successfully deployed to object address ")[1])
+
+	if d.Contracts.KeystoneSecondaryAddress == "" {
+		return errors.New("Could not set keystone secondary address")
+	}
+
+	d.lggr.Info().Msg(out)
+	return nil
+}
+
 func (d *Deployer) DeployDataFeeds(platformAddress string) error {
 	cmdStr := []string{
 		"aptos",
@@ -157,7 +187,7 @@ func (d *Deployer) DeployDataFeeds(platformAddress string) error {
 		"--package-dir=/contracts/data-feeds",
 		"--address-name=data_feeds",
 		"--named-addresses",
-		fmt.Sprintf("data_feeds=%s,platform=%s,owner=%s", DEVNET_ACC, platformAddress, DEVNET_ACC),
+		fmt.Sprintf("platform=%s,owner=%s", DEVNET_ACC, platformAddress, DEVNET_ACC),
 		"--profile=default",
 		"--assume-yes",
 	}

--- a/integration-tests/deploy/devnet.go
+++ b/integration-tests/deploy/devnet.go
@@ -127,7 +127,7 @@ func (d *Deployer) DeployPlatform() error {
 		"--package-dir=/contracts/platform",
 		"--address-name=platform",
 		"--named-addresses",
-		fmt.Sprintf("owner=%s", DEVNET_ACC, DEVNET_ACC),
+		fmt.Sprintf("owner=%s", DEVNET_ACC),
 		"--profile=default",
 		"--assume-yes",
 	}
@@ -187,7 +187,7 @@ func (d *Deployer) DeployDataFeeds(platformAddress string) error {
 		"--package-dir=/contracts/data-feeds",
 		"--address-name=data_feeds",
 		"--named-addresses",
-		fmt.Sprintf("platform=%s,owner=%s", DEVNET_ACC, platformAddress, DEVNET_ACC),
+		fmt.Sprintf("platform=%s,owner=%s", platformAddress, DEVNET_ACC),
 		"--profile=default",
 		"--assume-yes",
 	}

--- a/integration-tests/smoke/ocr3_test.go
+++ b/integration-tests/smoke/ocr3_test.go
@@ -45,6 +45,9 @@ func TestOCR3Keystone(t *testing.T) {
 	err = deployer.DeployPlatform()
 	require.NoError(t, err, "Could not deploy Platform")
 
+	err = deployer.DeployPlatformSecondary()
+	require.NoError(t, err, "Could not deploy Platform Secondary")
+
 	err = deployer.DeployDataFeeds(deployer.Contracts.KeystoneAddress)
 	require.NoError(t, err, "Could not deploy Data Feeds")
 


### PR DESCRIPTION
This patch adds a new package `platform_secondary`, which is needed to deploy a second Forwarder for the upcoming Data Feeds Registry upgrade.

Full Data Feeds Registry upgrade PR:
https://github.com/smartcontractkit/chainlink-aptos/pull/133