### PR TITLE
Merge pool events

### DIFF
--- a/bindings/ccip_token_pools/token_pool/token_pool/token_pool.go
+++ b/bindings/ccip_token_pools/token_pool/token_pool/token_pool.go
@@ -65,26 +65,17 @@ type RemoteChainConfig struct {
 type CallbackProof struct {
 }
 
-type Locked struct {
-	LocalToken aptos.AccountAddress `move:"address"`
-	Amount     uint64               `move:"u64"`
+type LockedOrBurned struct {
+	RemoteChainSelector uint64               `move:"u64"`
+	LocalToken          aptos.AccountAddress `move:"address"`
+	Amount              uint64               `move:"u64"`
 }
 
-type Released struct {
-	LocalToken aptos.AccountAddress `move:"address"`
-	Recipient  aptos.AccountAddress `move:"address"`
-	Amount     uint64               `move:"u64"`
-}
-
-type Burned struct {
-	LocalToken aptos.AccountAddress `move:"address"`
-	Amount     uint64               `move:"u64"`
-}
-
-type Minted struct {
-	LocalToken aptos.AccountAddress `move:"address"`
-	Recipient  aptos.AccountAddress `move:"address"`
-	Amount     uint64               `move:"u64"`
+type ReleasedOrMinted struct {
+	RemoteChainSelector uint64               `move:"u64"`
+	LocalToken          aptos.AccountAddress `move:"address"`
+	Recipient           aptos.AccountAddress `move:"address"`
+	Amount              uint64               `move:"u64"`
 }
 
 type AllowlistRemove struct {

--- a/contracts/ccip/ccip_onramp/tests/onramp_dispatchable_token_test.move
+++ b/contracts/ccip/ccip_onramp/tests/onramp_dispatchable_token_test.move
@@ -202,14 +202,14 @@ module ccip_onramp::onramp_dispatchable_token_test {
         assert!(token_pool_balance == result.sent_amount);
 
         assert!(
-            event::emitted_events<token_pool::Locked>().length() == 1
+            event::emitted_events<token_pool::LockedOrBurned>().length() == 1
         );
     }
 
     fun assert_burn_mint_pool_success(result: &CCIPSendResult) {
         assert_ccip_send_success(result);
         assert!(
-            event::emitted_events<token_pool::Burned>().length() == 1
+            event::emitted_events<token_pool::LockedOrBurned>().length() == 1
         );
     }
 

--- a/contracts/ccip/ccip_onramp/tests/onramp_test.move
+++ b/contracts/ccip/ccip_onramp/tests/onramp_test.move
@@ -735,7 +735,7 @@ module ccip_onramp::onramp_test {
         assert!(onramp_state_balance == fee_token_amount);
 
         assert!(
-            event::emitted_events<token_pool::Burned>().length() == 1
+            event::emitted_events<token_pool::LockedOrBurned>().length() == 1
         );
     }
 
@@ -858,7 +858,7 @@ module ccip_onramp::onramp_test {
         assert!(token_pool_balance == sent_amount);
 
         assert!(
-            event::emitted_events<token_pool::Locked>().length() == 1
+            event::emitted_events<token_pool::LockedOrBurned>().length() == 1
         );
     }
 

--- a/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
@@ -335,7 +335,7 @@ module burn_mint_token_pool::burn_mint_token_pool {
 
         let recipient = token_admin_registry::get_release_or_mint_receiver(&input);
 
-        token_pool::emit_minted(
+        token_pool::emit_released_or_minted(
             &mut pool.token_pool_state,
             recipient,
             local_amount

--- a/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
@@ -308,7 +308,9 @@ module burn_mint_token_pool::burn_mint_token_pool {
         let remote_chain_selector =
             token_admin_registry::get_lock_or_burn_remote_chain_selector(&input);
 
-        token_pool::emit_locked_or_burned(&mut pool.token_pool_state, fa_amount, remote_chain_selector);
+        token_pool::emit_locked_or_burned(
+            &mut pool.token_pool_state, fa_amount, remote_chain_selector
+        );
     }
 
     public fun release_or_mint<T: key>(

--- a/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
@@ -305,7 +305,7 @@ module burn_mint_token_pool::burn_mint_token_pool {
             dest_pool_data
         );
 
-        token_pool::emit_burned(&mut pool.token_pool_state, fa_amount);
+        token_pool::emit_locked_or_burned(&mut pool.token_pool_state, fa_amount);
     }
 
     public fun release_or_mint<T: key>(

--- a/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
@@ -305,7 +305,10 @@ module burn_mint_token_pool::burn_mint_token_pool {
             dest_pool_data
         );
 
-        token_pool::emit_locked_or_burned(&mut pool.token_pool_state, fa_amount);
+        let remote_chain_selector =
+            token_admin_registry::get_lock_or_burn_remote_chain_selector(&input);
+
+        token_pool::emit_locked_or_burned(&mut pool.token_pool_state, fa_amount, remote_chain_selector);
     }
 
     public fun release_or_mint<T: key>(
@@ -334,11 +337,14 @@ module burn_mint_token_pool::burn_mint_token_pool {
         );
 
         let recipient = token_admin_registry::get_release_or_mint_receiver(&input);
+        let remote_chain_selector =
+            token_admin_registry::get_release_or_mint_remote_chain_selector(&input);
 
         token_pool::emit_released_or_minted(
             &mut pool.token_pool_state,
             recipient,
-            local_amount
+            local_amount,
+            remote_chain_selector
         );
 
         // return the withdrawn fungible asset.

--- a/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
@@ -11,7 +11,7 @@ module lock_release_token_pool::lock_release_token_pool {
 
     use ccip::ownable;
     use ccip::token_admin_registry;
-    use ccip_token_pool::token_pool::{Self, TokenPoolState};
+    use ccip_token_pool::token_pool::{Self};
 
     use mcms::mcms_registry;
     use mcms::bcs_stream;
@@ -347,7 +347,7 @@ module lock_release_token_pool::lock_release_token_pool {
             dest_pool_data
         );
 
-        token_pool::emit_locked(&mut pool.token_pool_state, fa_amount);
+        token_pool::emit_locked_or_burned(&mut pool.token_pool_state, fa_amount);
     }
 
     public fun release_or_mint<T: key>(

--- a/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
@@ -388,7 +388,7 @@ module lock_release_token_pool::lock_release_token_pool {
 
         let recipient = token_admin_registry::get_release_or_mint_receiver(&input);
 
-        token_pool::emit_released(
+        token_pool::emit_released_or_minted(
             &mut pool.token_pool_state,
             recipient,
             local_amount

--- a/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
@@ -339,7 +339,6 @@ module lock_release_token_pool::lock_release_token_pool {
             fungible_asset::deposit(store, fa);
         };
 
-
         // set the output for this lock or burn operation.
         token_admin_registry::set_lock_or_burn_output_v1(
             @lock_release_token_pool,
@@ -351,7 +350,9 @@ module lock_release_token_pool::lock_release_token_pool {
         let remote_chain_selector =
             token_admin_registry::get_lock_or_burn_remote_chain_selector(&input);
 
-        token_pool::emit_locked_or_burned(&mut pool.token_pool_state, fa_amount,      remote_chain_selector);
+        token_pool::emit_locked_or_burned(
+            &mut pool.token_pool_state, fa_amount, remote_chain_selector
+        );
     }
 
     public fun release_or_mint<T: key>(

--- a/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
@@ -339,6 +339,7 @@ module lock_release_token_pool::lock_release_token_pool {
             fungible_asset::deposit(store, fa);
         };
 
+
         // set the output for this lock or burn operation.
         token_admin_registry::set_lock_or_burn_output_v1(
             @lock_release_token_pool,
@@ -347,7 +348,10 @@ module lock_release_token_pool::lock_release_token_pool {
             dest_pool_data
         );
 
-        token_pool::emit_locked_or_burned(&mut pool.token_pool_state, fa_amount);
+        let remote_chain_selector =
+            token_admin_registry::get_lock_or_burn_remote_chain_selector(&input);
+
+        token_pool::emit_locked_or_burned(&mut pool.token_pool_state, fa_amount,      remote_chain_selector);
     }
 
     public fun release_or_mint<T: key>(
@@ -387,11 +391,14 @@ module lock_release_token_pool::lock_release_token_pool {
         );
 
         let recipient = token_admin_registry::get_release_or_mint_receiver(&input);
+        let remote_chain_selector =
+            token_admin_registry::get_release_or_mint_remote_chain_selector(&input);
 
         token_pool::emit_released_or_minted(
             &mut pool.token_pool_state,
             recipient,
-            local_amount
+            local_amount,
+            remote_chain_selector
         );
 
         // return the withdrawn fungible asset.

--- a/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
@@ -266,7 +266,7 @@ module managed_token_pool::managed_token_pool {
             dest_pool_data
         );
 
-        token_pool::emit_burned(&mut pool.token_pool_state, fa_amount);
+        token_pool::emit_locked_or_burned(&mut pool.token_pool_state, fa_amount);
     }
 
     public fun release_or_mint<T: key>(

--- a/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
@@ -266,7 +266,10 @@ module managed_token_pool::managed_token_pool {
             dest_pool_data
         );
 
-        token_pool::emit_locked_or_burned(&mut pool.token_pool_state, fa_amount);
+        let remote_chain_selector =
+            token_admin_registry::get_lock_or_burn_remote_chain_selector(&input);
+
+        token_pool::emit_locked_or_burned(&mut pool.token_pool_state, fa_amount, remote_chain_selector);
     }
 
     public fun release_or_mint<T: key>(
@@ -303,11 +306,14 @@ module managed_token_pool::managed_token_pool {
         );
 
         let recipient = token_admin_registry::get_release_or_mint_receiver(&input);
+        let remote_chain_selector =
+            token_admin_registry::get_release_or_mint_remote_chain_selector(&input);
 
         token_pool::emit_released_or_minted(
             &mut pool.token_pool_state,
             recipient,
-            local_amount
+            local_amount,
+            remote_chain_selector
         );
 
         // return the withdrawn fungible asset.

--- a/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
@@ -304,7 +304,7 @@ module managed_token_pool::managed_token_pool {
 
         let recipient = token_admin_registry::get_release_or_mint_receiver(&input);
 
-        token_pool::emit_minted(
+        token_pool::emit_released_or_minted(
             &mut pool.token_pool_state,
             recipient,
             local_amount

--- a/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
@@ -269,7 +269,9 @@ module managed_token_pool::managed_token_pool {
         let remote_chain_selector =
             token_admin_registry::get_lock_or_burn_remote_chain_selector(&input);
 
-        token_pool::emit_locked_or_burned(&mut pool.token_pool_state, fa_amount, remote_chain_selector);
+        token_pool::emit_locked_or_burned(
+            &mut pool.token_pool_state, fa_amount, remote_chain_selector
+        );
     }
 
     public fun release_or_mint<T: key>(

--- a/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool.move
+++ b/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool.move
@@ -411,18 +411,25 @@ module ccip_token_pool::token_pool {
     // ================================================================
 
     public fun emit_released_or_minted(
-        state: &mut TokenPoolState, recipient: address, amount: u64, remote_chain_selector: u64
+        state: &mut TokenPoolState,
+        recipient: address,
+        amount: u64,
+        remote_chain_selector: u64
     ) {
         let local_token = object::object_address(&state.fa_metadata);
 
-        event::emit(ReleasedOrMinted { remote_chain_selector, local_token, recipient, amount });
+        event::emit(
+            ReleasedOrMinted { remote_chain_selector, local_token, recipient, amount }
+        );
         event::emit_event(
             &mut state.released_events,
             ReleasedOrMinted { remote_chain_selector, local_token, recipient, amount }
         );
     }
 
-    public fun emit_locked_or_burned(state: &mut TokenPoolState, amount: u64,  remote_chain_selector: u64) {
+    public fun emit_locked_or_burned(
+        state: &mut TokenPoolState, amount: u64, remote_chain_selector: u64
+    ) {
         let local_token = object::object_address(&state.fa_metadata);
 
         event::emit(LockedOrBurned { remote_chain_selector, local_token, amount });

--- a/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool.move
+++ b/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool.move
@@ -40,12 +40,14 @@ module ccip_token_pool::token_pool {
 
     #[event]
     struct LockedOrBurned has store, drop {
+        remote_chain_selector: u64,
         local_token: address,
         amount: u64
     }
 
     #[event]
     struct ReleasedOrMinted has store, drop {
+        remote_chain_selector: u64,
         local_token: address,
         recipient: address,
         amount: u64
@@ -409,24 +411,24 @@ module ccip_token_pool::token_pool {
     // ================================================================
 
     public fun emit_released_or_minted(
-        state: &mut TokenPoolState, recipient: address, amount: u64
+        state: &mut TokenPoolState, recipient: address, amount: u64, remote_chain_selector: u64
     ) {
         let local_token = object::object_address(&state.fa_metadata);
 
-        event::emit(ReleasedOrMinted { local_token, recipient, amount });
+        event::emit(ReleasedOrMinted { remote_chain_selector, local_token, recipient, amount });
         event::emit_event(
             &mut state.released_events,
-            ReleasedOrMinted { local_token, recipient, amount }
+            ReleasedOrMinted { remote_chain_selector, local_token, recipient, amount }
         );
     }
 
-    public fun emit_locked_or_burned(state: &mut TokenPoolState, amount: u64) {
+    public fun emit_locked_or_burned(state: &mut TokenPoolState, amount: u64,  remote_chain_selector: u64) {
         let local_token = object::object_address(&state.fa_metadata);
 
-        event::emit(LockedOrBurned { local_token, amount });
+        event::emit(LockedOrBurned { remote_chain_selector, local_token, amount });
         event::emit_event(
             &mut state.locked_events,
-            LockedOrBurned { local_token, amount }
+            LockedOrBurned { remote_chain_selector, local_token, amount }
         );
     }
 

--- a/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool.move
+++ b/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool.move
@@ -3,8 +3,7 @@ module ccip_token_pool::token_pool {
     use std::error;
     use std::event::{Self, EventHandle};
     use std::fungible_asset::{Self, FungibleAsset, Metadata};
-    use std::object::{Self, Object, ObjectCore};
-    use std::signer;
+    use std::object::{Self, Object};
     use std::smart_table::{Self, SmartTable};
 
     use ccip::eth_abi;
@@ -25,8 +24,7 @@ module ccip_token_pool::token_pool {
         remote_chain_configs: SmartTable<u64, RemoteChainConfig>,
         rate_limiter_config: token_pool_rate_limiter::RateLimitState,
         locked_events: EventHandle<LockedOrBurned>,
-        released_events: EventHandle<Released>,
-        minted_events: EventHandle<Minted>,
+        released_events: EventHandle<ReleasedOrMinted>,
         remote_pool_added_events: EventHandle<RemotePoolAdded>,
         remote_pool_removed_events: EventHandle<RemotePoolRemoved>,
         chain_added_events: EventHandle<ChainAdded>
@@ -47,14 +45,7 @@ module ccip_token_pool::token_pool {
     }
 
     #[event]
-    struct Released has store, drop {
-        local_token: address,
-        recipient: address,
-        amount: u64
-    }
-
-    #[event]
-    struct Minted has store, drop {
+    struct ReleasedOrMinted has store, drop {
         local_token: address,
         recipient: address,
         amount: u64
@@ -119,7 +110,6 @@ module ccip_token_pool::token_pool {
             rate_limiter_config: token_pool_rate_limiter::new(event_account),
             locked_events: account::new_event_handle(event_account),
             released_events: account::new_event_handle(event_account),
-            minted_events: account::new_event_handle(event_account),
             remote_pool_added_events: account::new_event_handle(event_account),
             remote_pool_removed_events: account::new_event_handle(event_account),
             chain_added_events: account::new_event_handle(event_account)
@@ -418,27 +408,15 @@ module ccip_token_pool::token_pool {
     // |                           Events                             |
     // ================================================================
 
-    public fun emit_released(
+    public fun emit_released_or_minted(
         state: &mut TokenPoolState, recipient: address, amount: u64
     ) {
         let local_token = object::object_address(&state.fa_metadata);
 
-        event::emit(Released { local_token, recipient, amount });
+        event::emit(ReleasedOrMinted { local_token, recipient, amount });
         event::emit_event(
             &mut state.released_events,
-            Released { local_token, recipient, amount }
-        );
-    }
-
-    public fun emit_minted(
-        state: &mut TokenPoolState, recipient: address, amount: u64
-    ) {
-        let local_token = object::object_address(&state.fa_metadata);
-
-        event::emit(Minted { local_token, recipient, amount });
-        event::emit_event(
-            &mut state.minted_events,
-            Minted { local_token, recipient, amount }
+            ReleasedOrMinted { local_token, recipient, amount }
         );
     }
 
@@ -608,7 +586,6 @@ module ccip_token_pool::token_pool {
             rate_limiter_config,
             locked_events,
             released_events,
-            minted_events,
             remote_pool_added_events,
             remote_pool_removed_events,
             chain_added_events
@@ -618,7 +595,6 @@ module ccip_token_pool::token_pool {
         remote_chain_configs.destroy();
         event::destroy_handle(locked_events);
         event::destroy_handle(released_events);
-        event::destroy_handle(minted_events);
         event::destroy_handle(remote_pool_added_events);
         event::destroy_handle(remote_pool_removed_events);
         event::destroy_handle(chain_added_events);

--- a/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool.move
+++ b/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool.move
@@ -24,9 +24,8 @@ module ccip_token_pool::token_pool {
         fa_metadata: Object<Metadata>,
         remote_chain_configs: SmartTable<u64, RemoteChainConfig>,
         rate_limiter_config: token_pool_rate_limiter::RateLimitState,
-        locked_events: EventHandle<Locked>,
+        locked_events: EventHandle<LockedOrBurned>,
         released_events: EventHandle<Released>,
-        burned_events: EventHandle<Burned>,
         minted_events: EventHandle<Minted>,
         remote_pool_added_events: EventHandle<RemotePoolAdded>,
         remote_pool_removed_events: EventHandle<RemotePoolRemoved>,
@@ -42,7 +41,7 @@ module ccip_token_pool::token_pool {
     struct CallbackProof has drop {}
 
     #[event]
-    struct Locked has store, drop {
+    struct LockedOrBurned has store, drop {
         local_token: address,
         amount: u64
     }
@@ -51,12 +50,6 @@ module ccip_token_pool::token_pool {
     struct Released has store, drop {
         local_token: address,
         recipient: address,
-        amount: u64
-    }
-
-    #[event]
-    struct Burned has store, drop {
-        local_token: address,
         amount: u64
     }
 
@@ -126,7 +119,6 @@ module ccip_token_pool::token_pool {
             rate_limiter_config: token_pool_rate_limiter::new(event_account),
             locked_events: account::new_event_handle(event_account),
             released_events: account::new_event_handle(event_account),
-            burned_events: account::new_event_handle(event_account),
             minted_events: account::new_event_handle(event_account),
             remote_pool_added_events: account::new_event_handle(event_account),
             remote_pool_removed_events: account::new_event_handle(event_account),
@@ -450,23 +442,13 @@ module ccip_token_pool::token_pool {
         );
     }
 
-    public fun emit_locked(state: &mut TokenPoolState, amount: u64) {
+    public fun emit_locked_or_burned(state: &mut TokenPoolState, amount: u64) {
         let local_token = object::object_address(&state.fa_metadata);
 
-        event::emit(Locked { local_token, amount });
+        event::emit(LockedOrBurned { local_token, amount });
         event::emit_event(
             &mut state.locked_events,
-            Locked { local_token, amount }
-        );
-    }
-
-    public fun emit_burned(state: &mut TokenPoolState, amount: u64) {
-        let local_token = object::object_address(&state.fa_metadata);
-
-        event::emit(Burned { local_token, amount });
-        event::emit_event(
-            &mut state.burned_events,
-            Burned { local_token, amount }
+            LockedOrBurned { local_token, amount }
         );
     }
 
@@ -626,7 +608,6 @@ module ccip_token_pool::token_pool {
             rate_limiter_config,
             locked_events,
             released_events,
-            burned_events,
             minted_events,
             remote_pool_added_events,
             remote_pool_removed_events,
@@ -637,7 +618,6 @@ module ccip_token_pool::token_pool {
         remote_chain_configs.destroy();
         event::destroy_handle(locked_events);
         event::destroy_handle(released_events);
-        event::destroy_handle(burned_events);
         event::destroy_handle(minted_events);
         event::destroy_handle(remote_pool_added_events);
         event::destroy_handle(remote_pool_removed_events);

--- a/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
@@ -408,7 +408,7 @@ module usdc_token_pool::usdc_token_pool {
 
         let recipient = token_admin_registry::get_release_or_mint_receiver(&input);
 
-        token_pool::emit_minted(
+        token_pool::emit_released_or_minted(
             &mut pool.token_pool_state,
             recipient,
             local_amount

--- a/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
@@ -358,8 +358,9 @@ module usdc_token_pool::usdc_token_pool {
         let remote_chain_selector =
             token_admin_registry::get_lock_or_burn_remote_chain_selector(&input);
 
-
-        token_pool::emit_locked_or_burned(&mut pool.token_pool_state, fa_amount, remote_chain_selector);
+        token_pool::emit_locked_or_burned(
+            &mut pool.token_pool_state, fa_amount, remote_chain_selector
+        );
     }
 
     public fun release_or_mint<T: key>(

--- a/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
@@ -355,7 +355,11 @@ module usdc_token_pool::usdc_token_pool {
             dest_pool_data
         );
 
-        token_pool::emit_locked_or_burned(&mut pool.token_pool_state, fa_amount);
+        let remote_chain_selector =
+            token_admin_registry::get_lock_or_burn_remote_chain_selector(&input);
+
+
+        token_pool::emit_locked_or_burned(&mut pool.token_pool_state, fa_amount, remote_chain_selector);
     }
 
     public fun release_or_mint<T: key>(
@@ -407,11 +411,14 @@ module usdc_token_pool::usdc_token_pool {
         );
 
         let recipient = token_admin_registry::get_release_or_mint_receiver(&input);
+        let remote_chain_selector =
+            token_admin_registry::get_release_or_mint_remote_chain_selector(&input);
 
         token_pool::emit_released_or_minted(
             &mut pool.token_pool_state,
             recipient,
-            local_amount
+            local_amount,
+            remote_chain_selector
         );
 
         let fa_metadata = token_pool::get_fa_metadata(&pool.token_pool_state);

--- a/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
@@ -355,7 +355,7 @@ module usdc_token_pool::usdc_token_pool {
             dest_pool_data
         );
 
-        token_pool::emit_burned(&mut pool.token_pool_state, fa_amount);
+        token_pool::emit_locked_or_burned(&mut pool.token_pool_state, fa_amount);
     }
 
     public fun release_or_mint<T: key>(

--- a/contracts/managed_token/tests/managed_token_tests.move
+++ b/contracts/managed_token/tests/managed_token_tests.move
@@ -23,7 +23,8 @@ module managed_token::managed_token_tests {
         account::create_account_for_test(signer::address_of(owner));
         account::create_account_for_test(signer::address_of(managed_token));
 
-        let constructor_ref = &object::create_named_object(owner, b"managed_token_token_tests");
+        let constructor_ref =
+            &object::create_named_object(owner, b"managed_token_token_tests");
 
         let object_address =
             object::create_object_address(
@@ -56,7 +57,9 @@ module managed_token::managed_token_tests {
     }
 
     #[test_only]
-    public fun initialize_managed_token(owner: &signer, max_supply: Option<u128>) {
+    public fun initialize_managed_token(
+        owner: &signer, max_supply: Option<u128>
+    ) {
         managed_token::initialize(
             owner,
             max_supply,
@@ -69,7 +72,9 @@ module managed_token::managed_token_tests {
     }
 
     #[test(owner = @0x999, managed_token = @managed_token)]
-    public fun test_initialize_managed_token(owner: &signer, managed_token: &signer) {
+    public fun test_initialize_managed_token(
+        owner: &signer, managed_token: &signer
+    ) {
         setup(owner, managed_token);
 
         initialize_managed_token(owner, option::some(MAX_SUPPLY));
@@ -180,9 +185,14 @@ module managed_token::managed_token_tests {
         managed_token::burn(user, signer::address_of(user), 1000000);
     }
 
-    #[test(
-        owner = @0x999, recipient1 = @0xface, recipient2 = @0xbeef, managed_token = @managed_token
-    )]
+    #[
+        test(
+            owner = @0x999,
+            recipient1 = @0xface,
+            recipient2 = @0xbeef,
+            managed_token = @managed_token
+        )
+    ]
     public fun test_token_transfer(
         owner: &signer,
         recipient1: &signer,


### PR DESCRIPTION
Merging these events is planned work for EVM so might as well do it while we can on Aptos. 

Simplifies the code, lookups, and observability. The new events also include the remote chain selector, which is needed for offchain systems.