### PR TITLE
Add custom token registrars to TokenAdminRegistry

### DIFF
--- a/bindings/ccip/token_admin_registry/token_admin_registry.go
+++ b/bindings/ccip/token_admin_registry/token_admin_registry.go
@@ -139,6 +139,17 @@ type TokenUnregistered struct {
 	PreviousPoolAddress aptos.AccountAddress `move:"address"`
 }
 
+type TokenRegistrarSet struct {
+	LocalToken             aptos.AccountAddress  `move:"address"`
+	PreviousTokenRegistrar *aptos.AccountAddress `move:"0x1::option::Option<address>"`
+	NewTokenRegistrar      aptos.AccountAddress  `move:"address"`
+}
+
+type TokenRegistrarUnset struct {
+	LocalToken             aptos.AccountAddress `move:"address"`
+	PreviousTokenRegistrar aptos.AccountAddress `move:"address"`
+}
+
 type McmsCallback struct {
 }
 

--- a/bindings/ccip/token_admin_registry/token_admin_registry.go
+++ b/bindings/ccip/token_admin_registry/token_admin_registry.go
@@ -27,9 +27,12 @@ type TokenAdminRegistryInterface interface {
 	GetPool(opts *bind.CallOpts, localToken aptos.AccountAddress) (aptos.AccountAddress, error)
 	GetTokenConfig(opts *bind.CallOpts, localToken aptos.AccountAddress) (aptos.AccountAddress, aptos.AccountAddress, aptos.AccountAddress, error)
 	GetAllConfiguredTokens(opts *bind.CallOpts, startKey aptos.AccountAddress, maxCount uint64) ([]aptos.AccountAddress, aptos.AccountAddress, bool, error)
+	GetTokenRegistrar(opts *bind.CallOpts, localToken aptos.AccountAddress) (aptos.AccountAddress, error)
 	IsAdministrator(opts *bind.CallOpts, localToken aptos.AccountAddress, administrator aptos.AccountAddress) (bool, error)
 
 	UnregisterPool(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error)
+	SetTokenRegistrar(opts *bind.TransactOpts, localToken aptos.AccountAddress, tokenRegistrar aptos.AccountAddress) (*api.PendingTransaction, error)
+	UnsetTokenRegistrar(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error)
 	SetPool(opts *bind.TransactOpts, localToken aptos.AccountAddress, tokenPoolAddress aptos.AccountAddress) (*api.PendingTransaction, error)
 	TransferAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress, newAdmin aptos.AccountAddress) (*api.PendingTransaction, error)
 	AcceptAdminRole(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error)
@@ -44,19 +47,21 @@ type TokenAdminRegistryEncoder interface {
 	GetPool(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetTokenConfig(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetAllConfiguredTokens(startKey aptos.AccountAddress, maxCount uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetTokenRegistrar(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	IsAdministrator(localToken aptos.AccountAddress, administrator aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	UnregisterPool(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetTokenRegistrar(localToken aptos.AccountAddress, tokenRegistrar aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	UnsetTokenRegistrar(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	SetPool(localToken aptos.AccountAddress, tokenPoolAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	TransferAdminRole(localToken aptos.AccountAddress, newAdmin aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	AcceptAdminRole(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
-	AssertCanRegister(registryOwnerAddress aptos.AccountAddress, tokenPoolAddress aptos.AccountAddress, fungibleAssetMetadata aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	StartLockOrBurn(tokenPoolAddress aptos.AccountAddress, sender aptos.AccountAddress, remoteChainSelector uint64, receiver []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	FinishLockOrBurn(tokenPoolAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	FinishReleaseOrMint(tokenPoolAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	MCMSEntrypoint(Metadata aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
 
-const FunctionInfo = `[{"package":"ccip","module":"token_admin_registry","name":"accept_admin_role","parameters":[{"name":"local_token","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"assert_can_register","parameters":[{"name":"registry_owner_address","type":"address"},{"name":"token_pool_address","type":"address"},{"name":"fungible_asset_metadata","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"finish_lock_or_burn","parameters":[{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"finish_release_or_mint","parameters":[{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"mcms_entrypoint","parameters":[{"name":"_metadata","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"set_pool","parameters":[{"name":"local_token","type":"address"},{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"start_lock_or_burn","parameters":[{"name":"token_pool_address","type":"address"},{"name":"sender","type":"address"},{"name":"remote_chain_selector","type":"u64"},{"name":"receiver","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"token_admin_registry","name":"transfer_admin_role","parameters":[{"name":"local_token","type":"address"},{"name":"new_admin","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"unregister_pool","parameters":[{"name":"local_token","type":"address"}]}]`
+const FunctionInfo = `[{"package":"ccip","module":"token_admin_registry","name":"accept_admin_role","parameters":[{"name":"local_token","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"finish_lock_or_burn","parameters":[{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"finish_release_or_mint","parameters":[{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"mcms_entrypoint","parameters":[{"name":"_metadata","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"set_pool","parameters":[{"name":"local_token","type":"address"},{"name":"token_pool_address","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"set_token_registrar","parameters":[{"name":"local_token","type":"address"},{"name":"token_registrar","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"start_lock_or_burn","parameters":[{"name":"token_pool_address","type":"address"},{"name":"sender","type":"address"},{"name":"remote_chain_selector","type":"u64"},{"name":"receiver","type":"vector\u003cu8\u003e"}]},{"package":"ccip","module":"token_admin_registry","name":"transfer_admin_role","parameters":[{"name":"local_token","type":"address"},{"name":"new_admin","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"unregister_pool","parameters":[{"name":"local_token","type":"address"}]},{"package":"ccip","module":"token_admin_registry","name":"unset_token_registrar","parameters":[{"name":"local_token","type":"address"}]}]`
 
 func NewTokenAdminRegistry(address aptos.AccountAddress, client aptos.AptosRpcClient) TokenAdminRegistryInterface {
 	contract := bind.NewBoundContract(address, "ccip", "token_admin_registry", client)
@@ -259,6 +264,27 @@ func (c TokenAdminRegistryContract) GetAllConfiguredTokens(opts *bind.CallOpts, 
 	return r0, r1, r2, nil
 }
 
+func (c TokenAdminRegistryContract) GetTokenRegistrar(opts *bind.CallOpts, localToken aptos.AccountAddress) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.tokenAdminRegistryEncoder.GetTokenRegistrar(localToken)
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	var (
+		r0 aptos.AccountAddress
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+	return r0, nil
+}
+
 func (c TokenAdminRegistryContract) IsAdministrator(opts *bind.CallOpts, localToken aptos.AccountAddress, administrator aptos.AccountAddress) (bool, error) {
 	module, function, typeTags, args, err := c.tokenAdminRegistryEncoder.IsAdministrator(localToken, administrator)
 	if err != nil {
@@ -284,6 +310,24 @@ func (c TokenAdminRegistryContract) IsAdministrator(opts *bind.CallOpts, localTo
 
 func (c TokenAdminRegistryContract) UnregisterPool(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error) {
 	module, function, typeTags, args, err := c.tokenAdminRegistryEncoder.UnregisterPool(localToken)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c TokenAdminRegistryContract) SetTokenRegistrar(opts *bind.TransactOpts, localToken aptos.AccountAddress, tokenRegistrar aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.tokenAdminRegistryEncoder.SetTokenRegistrar(localToken, tokenRegistrar)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c TokenAdminRegistryContract) UnsetTokenRegistrar(opts *bind.TransactOpts, localToken aptos.AccountAddress) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.tokenAdminRegistryEncoder.UnsetTokenRegistrar(localToken)
 	if err != nil {
 		return nil, err
 	}
@@ -361,6 +405,14 @@ func (c tokenAdminRegistryEncoder) GetAllConfiguredTokens(startKey aptos.Account
 	})
 }
 
+func (c tokenAdminRegistryEncoder) GetTokenRegistrar(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_token_registrar", nil, []string{
+		"address",
+	}, []any{
+		localToken,
+	})
+}
+
 func (c tokenAdminRegistryEncoder) IsAdministrator(localToken aptos.AccountAddress, administrator aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("is_administrator", nil, []string{
 		"address",
@@ -373,6 +425,24 @@ func (c tokenAdminRegistryEncoder) IsAdministrator(localToken aptos.AccountAddre
 
 func (c tokenAdminRegistryEncoder) UnregisterPool(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("unregister_pool", nil, []string{
+		"address",
+	}, []any{
+		localToken,
+	})
+}
+
+func (c tokenAdminRegistryEncoder) SetTokenRegistrar(localToken aptos.AccountAddress, tokenRegistrar aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("set_token_registrar", nil, []string{
+		"address",
+		"address",
+	}, []any{
+		localToken,
+		tokenRegistrar,
+	})
+}
+
+func (c tokenAdminRegistryEncoder) UnsetTokenRegistrar(localToken aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("unset_token_registrar", nil, []string{
 		"address",
 	}, []any{
 		localToken,
@@ -404,18 +474,6 @@ func (c tokenAdminRegistryEncoder) AcceptAdminRole(localToken aptos.AccountAddre
 		"address",
 	}, []any{
 		localToken,
-	})
-}
-
-func (c tokenAdminRegistryEncoder) AssertCanRegister(registryOwnerAddress aptos.AccountAddress, tokenPoolAddress aptos.AccountAddress, fungibleAssetMetadata aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("assert_can_register", nil, []string{
-		"address",
-		"address",
-		"address",
-	}, []any{
-		registryOwnerAddress,
-		tokenPoolAddress,
-		fungibleAssetMetadata,
 	})
 }
 

--- a/contracts/ccip/ccip/sources/token_admin_registry.move
+++ b/contracts/ccip/ccip/sources/token_admin_registry.move
@@ -12,7 +12,6 @@ module ccip::token_admin_registry {
     use std::big_ordered_map::{Self, BigOrderedMap};
     use std::string::{Self, String};
     use std::type_info::{Self, TypeInfo};
-    use aptos_std::ordered_map::OrderedMap;
 
     use ccip::auth;
     use ccip::state_object;

--- a/contracts/ccip/ccip/sources/token_admin_registry.move
+++ b/contracts/ccip/ccip/sources/token_admin_registry.move
@@ -409,7 +409,7 @@ module ccip::token_admin_registry {
         registry_owner_address: address,
         token_pool_address: address,
         local_token: address,
-        token_registrars: BigOrderedMap<address,address>
+        token_registrars: BigOrderedMap<address, address>
     ) {
         assert!(
             object::is_object(token_pool_address),
@@ -433,7 +433,7 @@ module ccip::token_admin_registry {
         if (token_pool_object_root_owner_address == fungible_asset_object_owner_address
             || token_pool_object_root_owner_address
                 == fungible_asset_object_root_owner_address) { return };
-        
+
         // Allow registration if a custom token registrar has been set for this local token
         // that matches the token pool (root) owner
         if (token_registrars.contains(&local_token)) {

--- a/contracts/ccip/ccip/sources/token_admin_registry.move
+++ b/contracts/ccip/ccip/sources/token_admin_registry.move
@@ -302,11 +302,16 @@ module ccip::token_admin_registry {
 
         let state = borrow_state_mut();
 
+        let token_registrar = option::none<address>();
+        if (state.token_registrars.contains(&local_token)) {
+            token_registrar.fill(*state.token_registrars.borrow(&local_token))
+        };
+
         assert_can_register(
             auth::owner(),
             signer::address_of(token_pool_account),
             local_token,
-            state.token_registrars
+            token_registrar
         );
 
         assert!(
@@ -408,7 +413,7 @@ module ccip::token_admin_registry {
         registry_owner_address: address,
         token_pool_address: address,
         local_token: address,
-        token_registrars: BigOrderedMap<address, address>
+        token_registrar: Option<address>
     ) {
         assert!(
             object::is_object(token_pool_address),
@@ -435,8 +440,8 @@ module ccip::token_admin_registry {
 
         // Allow registration if a custom token registrar has been set for this local token
         // that matches the token pool (root) owner
-        if (token_registrars.contains(&local_token)) {
-            let token_registrar = *token_registrars.borrow(&local_token);
+        if (token_registrar.is_some()) {
+            let token_registrar = *token_registrar.borrow();
             if (token_registrar == token_pool_object_owner_address
                 || token_registrar == token_pool_object_root_owner_address) { return };
         };
@@ -501,7 +506,7 @@ module ccip::token_admin_registry {
         auth::assert_only_owner(signer::address_of(caller));
 
         let state = borrow_state_mut();
-        state.token_registrars.remove(&local_token)
+        state.token_registrars.remove(&local_token);
     }
 
     #[view]

--- a/contracts/ccip/ccip/sources/token_admin_registry.move
+++ b/contracts/ccip/ccip/sources/token_admin_registry.move
@@ -121,6 +121,7 @@ module ccip::token_admin_registry {
         new_token_registrar: address
     }
 
+    #[event]
     struct TokenRegistrarUnset has store, drop {
         local_token: address,
         previous_token_registrar: address
@@ -529,9 +530,7 @@ module ccip::token_admin_registry {
         let state = borrow_state_mut();
         let previous_token_registrar = state.token_registrars.remove(&local_token);
 
-        event::emit(
-            TokenRegistrarUnset { local_token, previous_token_registrar }
-        );
+        event::emit(TokenRegistrarUnset { local_token, previous_token_registrar });
     }
 
     #[view]

--- a/contracts/ccip/ccip/sources/token_admin_registry.move
+++ b/contracts/ccip/ccip/sources/token_admin_registry.move
@@ -12,6 +12,7 @@ module ccip::token_admin_registry {
     use std::big_ordered_map::{Self, BigOrderedMap};
     use std::string::{Self, String};
     use std::type_info::{Self, TypeInfo};
+    use aptos_std::ordered_map::OrderedMap;
 
     use ccip::auth;
     use ccip::state_object;
@@ -33,6 +34,8 @@ module ccip::token_admin_registry {
 
         // fungible asset metadata address -> TokenConfig
         token_configs: BigOrderedMap<address, TokenConfig>,
+        // local token address -> token registrar address
+        token_registrars: BigOrderedMap<address, address>,
         pool_set_events: EventHandle<PoolSet>,
         administrator_transfer_requested_events: EventHandle<AdministratorTransferRequested>,
         administrator_transferred_events: EventHandle<AdministratorTransferred>
@@ -163,6 +166,7 @@ module ccip::token_admin_registry {
             extend_ref,
             transfer_ref,
             token_configs: big_ordered_map::new(),
+            token_registrars: big_ordered_map::new(),
             pool_set_events: account::new_event_handle(&state_object_signer),
             administrator_transfer_requested_events: account::new_event_handle(
                 &state_object_signer
@@ -302,7 +306,8 @@ module ccip::token_admin_registry {
         assert_can_register(
             auth::owner(),
             signer::address_of(token_pool_account),
-            object::address_to_object<Metadata>(local_token)
+            local_token,
+            state.token_registrars
         );
 
         assert!(
@@ -403,13 +408,15 @@ module ccip::token_admin_registry {
     fun assert_can_register(
         registry_owner_address: address,
         token_pool_address: address,
-        fungible_asset_metadata: Object<Metadata>
+        local_token: address,
+        token_registrars: BigOrderedMap<address,address>
     ) {
         assert!(
             object::is_object(token_pool_address),
             error::invalid_argument(E_TOKEN_POOL_NOT_OBJECT)
         );
         let token_pool_object = object::address_to_object<ObjectCore>(token_pool_address);
+        let fungible_asset_metadata = object::address_to_object<Metadata>(local_token);
 
         let fungible_asset_object_owner_address = object::owner(fungible_asset_metadata);
         let fungible_asset_object_root_owner_address =
@@ -426,6 +433,14 @@ module ccip::token_admin_registry {
         if (token_pool_object_root_owner_address == fungible_asset_object_owner_address
             || token_pool_object_root_owner_address
                 == fungible_asset_object_root_owner_address) { return };
+        
+        // Allow registration if a custom token registrar has been set for this local token
+        // that matches the token pool (root) owner
+        if (token_registrars.contains(&local_token)) {
+            let token_registrar = *token_registrars.borrow(&local_token);
+            if (token_registrar == token_pool_object_owner_address
+                || token_registrar == token_pool_object_root_owner_address) { return };
+        };
 
         abort error::permission_denied(E_NOT_FUNGIBLE_ASSET_OWNER)
     }
@@ -470,6 +485,30 @@ module ccip::token_admin_registry {
                 previous_pool_address: token_config.token_pool_address
             }
         );
+    }
+
+    public entry fun set_token_registrar(
+        caller: &signer, local_token: address, token_registrar: address
+    ) acquires TokenAdminRegistryState {
+        auth::assert_only_owner(signer::address_of(caller));
+
+        let state = borrow_state_mut();
+        state.token_registrars.add(local_token, token_registrar)
+    }
+
+    public entry fun unset_token_registrar(
+        caller: &signer, local_token: address
+    ) acquires TokenAdminRegistryState {
+        auth::assert_only_owner(signer::address_of(caller));
+
+        let state = borrow_state_mut();
+        state.token_registrars.remove(&local_token)
+    }
+
+    #[view]
+    public fun get_token_registrar(local_token: address): address acquires TokenAdminRegistryState {
+        let state = borrow_state_mut();
+        *state.token_registrars.borrow(&local_token)
     }
 
     public entry fun set_pool(
@@ -1036,6 +1075,15 @@ module ccip::token_admin_registry {
             let local_token = bcs_stream::deserialize_address(&mut stream);
             bcs_stream::assert_is_consumed(&stream);
             accept_admin_role(&caller, local_token)
+        } else if (function_bytes == b"set_token_registrar") {
+            let local_token = bcs_stream::deserialize_address(&mut stream);
+            let token_registrar = bcs_stream::deserialize_address(&mut stream);
+            bcs_stream::assert_is_consumed(&stream);
+            set_token_registrar(&caller, local_token, token_registrar)
+        } else if (function_bytes == b"unset_token_registrar") {
+            let local_token = bcs_stream::deserialize_address(&mut stream);
+            bcs_stream::assert_is_consumed(&stream);
+            unset_token_registrar(&caller, local_token)
         } else {
             abort error::invalid_argument(E_UNKNOWN_FUNCTION)
         };

--- a/contracts/ccip/ccip/sources/token_admin_registry.move
+++ b/contracts/ccip/ccip/sources/token_admin_registry.move
@@ -114,6 +114,18 @@ module ccip::token_admin_registry {
         previous_pool_address: address
     }
 
+    #[event]
+    struct TokenRegistrarSet has store, drop {
+        local_token: address,
+        previous_token_registrar: Option<address>,
+        new_token_registrar: address
+    }
+
+    struct TokenRegistrarUnset has store, drop {
+        local_token: address,
+        previous_token_registrar: address
+    }
+
     const E_INVALID_FUNGIBLE_ASSET: u64 = 1;
     const E_NOT_FUNGIBLE_ASSET_OWNER: u64 = 2;
     const E_INVALID_TOKEN_POOL: u64 = 3;
@@ -497,7 +509,16 @@ module ccip::token_admin_registry {
         auth::assert_only_owner(signer::address_of(caller));
 
         let state = borrow_state_mut();
-        state.token_registrars.add(local_token, token_registrar)
+        let previous_token_registrar =
+            state.token_registrars.upsert(local_token, token_registrar);
+
+        event::emit(
+            TokenRegistrarSet {
+                local_token,
+                previous_token_registrar,
+                new_token_registrar: token_registrar
+            }
+        );
     }
 
     public entry fun unset_token_registrar(
@@ -506,7 +527,11 @@ module ccip::token_admin_registry {
         auth::assert_only_owner(signer::address_of(caller));
 
         let state = borrow_state_mut();
-        state.token_registrars.remove(&local_token);
+        let previous_token_registrar = state.token_registrars.remove(&local_token);
+
+        event::emit(
+            TokenRegistrarUnset { local_token, previous_token_registrar }
+        );
     }
 
     #[view]


### PR DESCRIPTION
We need to be able toe deploy token pools independently from tokens, i.e. to separate objects.
This currently leads to issues when deploying token pools via mcms, as each object will have a different resource account owner, failing both current checks that:
1. The token is owned by the same (root) owner as the token pool
2. CCIP is owned by the same (root) owner as the token pool

To mitigate this, we're adding an additional (optional) mapping of registrars that can be used to allow an arbitrary address to register a token pool.
In practice this allows us to:
1. Calculate the mcms owner address of the to-be-deployed token pool
2. Add this owner address as an additional registrar for the token that a token pool should be deployed to, by calling `set_token_registrar(local_token, owner_address)`
3. Use mcms to deploy the token pool, this will now pass `assert_can_register`