### PR TITLE
Consume source amount when rate limiting on release/mint

### DIFF
--- a/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
@@ -329,9 +329,7 @@ module burn_mint_token_pool::burn_mint_token_pool {
         let local_amount =
             token_pool::calculate_release_or_mint_amount(&pool.token_pool_state, &input);
 
-        token_pool::validate_release_or_mint(
-            &mut pool.token_pool_state, &input, local_amount
-        );
+        token_pool::validate_release_or_mint(&mut pool.token_pool_state, &input);
 
         // Mint the amount for release.
         assert!(pool.mint_ref.is_some(), E_MINT_REF_NOT_SET);

--- a/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
@@ -382,9 +382,7 @@ module lock_release_token_pool::lock_release_token_pool {
         let local_amount =
             token_pool::calculate_release_or_mint_amount(&pool.token_pool_state, &input);
 
-        token_pool::validate_release_or_mint(
-            &mut pool.token_pool_state, &input, local_amount
-        );
+        token_pool::validate_release_or_mint(&mut pool.token_pool_state, &input);
 
         let store_signer = account::create_signer_with_capability(&pool.store_signer_cap);
         let metadata = token_pool::get_fa_metadata(&pool.token_pool_state);

--- a/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
@@ -287,9 +287,7 @@ module managed_token_pool::managed_token_pool {
         let local_amount =
             token_pool::calculate_release_or_mint_amount(&pool.token_pool_state, &input);
 
-        token_pool::validate_release_or_mint(
-            &mut pool.token_pool_state, &input, local_amount
-        );
+        token_pool::validate_release_or_mint(&mut pool.token_pool_state, &input);
 
         // Mint the amount for release.
         let local_token = token_admin_registry::get_release_or_mint_local_token(&input);

--- a/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool.move
+++ b/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool.move
@@ -393,9 +393,7 @@ module ccip_token_pool::token_pool {
     }
 
     public fun validate_release_or_mint(
-        state: &mut TokenPoolState,
-        input: &token_admin_registry::ReleaseOrMintInputV1,
-        local_amount: u64
+        state: &mut TokenPoolState, input: &token_admin_registry::ReleaseOrMintInputV1
     ) {
         // Validate the fungible asset
         let local_token = token_admin_registry::get_release_or_mint_local_token(input);
@@ -424,8 +422,15 @@ module ccip_token_pool::token_pool {
             error::invalid_argument(E_UNKNOWN_REMOTE_POOL)
         );
 
+        let source_amount_u256 =
+            token_admin_registry::get_release_or_mint_source_amount(input);
+        assert!(
+            source_amount_u256 <= MAX_U64,
+            error::invalid_argument(E_INVALID_ENCODED_AMOUNT)
+        );
+        let source_amount = source_amount_u256 as u64;
         token_pool_rate_limiter::consume_inbound(
-            &mut state.rate_limiter_config, remote_chain_selector, local_amount
+            &mut state.rate_limiter_config, remote_chain_selector, source_amount
         );
     }
 

--- a/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
@@ -382,9 +382,7 @@ module usdc_token_pool::usdc_token_pool {
         let local_amount =
             token_admin_registry::get_release_or_mint_source_amount(&input) as u64;
 
-        token_pool::validate_release_or_mint(
-            &mut pool.token_pool_state, &input, local_amount
-        );
+        token_pool::validate_release_or_mint(&mut pool.token_pool_state, &input);
 
         let store_signer = account::create_signer_with_capability(&pool.store_signer_cap);
 


### PR DESCRIPTION
## Desc
Consume source amount when rate limiting on release/mint. 
- Source amount can  be `u256` so must check for overflow/underflow