### PR TITLE
Data Feeds Add Revert To Get Reports

### DIFF
--- a/bindings/data_feeds/registry/registry.go
+++ b/bindings/data_feeds/registry/registry.go
@@ -156,6 +156,10 @@ type StaleReport struct {
 	ReportTimestamp *big.Int `move:"u256"`
 }
 
+type WriteSkippedFeedNotSet struct {
+	FeedId []byte `move:"vector<u8>"`
+}
+
 type OwnershipTransferRequested struct {
 	From aptos.AccountAddress `move:"address"`
 	To   aptos.AccountAddress `move:"address"`

--- a/bindings/data_feeds/router/router.go
+++ b/bindings/data_feeds/router/router.go
@@ -69,6 +69,10 @@ type OwnershipTransferred struct {
 	To   aptos.AccountAddress `move:"address"`
 }
 
+type FeedRead struct {
+	FeedIds [][]byte `move:"vector<vector<u8>>"`
+}
+
 type RouterContract struct {
 	*bind.BoundContract
 	routerEncoder

--- a/contracts/data-feeds/scripts/test_registry_deploy_e2e.sh
+++ b/contracts/data-feeds/scripts/test_registry_deploy_e2e.sh
@@ -89,6 +89,8 @@ run() {
 # ──────────────────────────────────────────────────────────────────────────────
 #  Constants / Inputs
 # ──────────────────────────────────────────────────────────────────────────────
+DATA_FEEDS_PACKAGE_NAME="data-feeds"
+
 ORACLE_PUBKEYS=(
       "247d0189f65f58be83a4e7d87ff338aaf8956e9acb9fcc783f34f9edc29d1b40"
       "ba20d3da9b07663f1e8039081a514649fd61a48be2d241bc63537ee47d028fcd"
@@ -363,7 +365,7 @@ run "Set config on Forwarder 2" _out \
 run "Deploy data-feeds (supports benchmark reports & 2 forwarders)" OUT_DF \
   aptos move create-object-and-publish-package \
     --profile "$PUBLISHER_PROFILE" \
-    --package-dir "$CONTRACTS_ROOT/data-feeds" \
+    --package-dir "$CONTRACTS_ROOT/$DATA_FEEDS_PACKAGE_NAME" \
     --address-name data_feeds \
     --named-addresses platform="$PLATFORM_FORWARDER_ADDR",owner="$PUBLISHER_ADDR",platform_secondary="$PLATFORM_SECONDARY_FORWARDER_ADDR",owner_secondary="$PUBLISHER_ADDR" \
     --max-gas 50000 --assume-yes

--- a/contracts/data-feeds/scripts/test_registry_migration_e2e.sh
+++ b/contracts/data-feeds/scripts/test_registry_migration_e2e.sh
@@ -89,6 +89,8 @@ run() {
 # ──────────────────────────────────────────────────────────────────────────────
 #  Constants / Inputs
 # ──────────────────────────────────────────────────────────────────────────────
+DATA_FEEDS_PACKAGE_NAME="data-feeds"
+
 ORACLE_PUBKEYS=(
       "247d0189f65f58be83a4e7d87ff338aaf8956e9acb9fcc783f34f9edc29d1b40"
       "ba20d3da9b07663f1e8039081a514649fd61a48be2d241bc63537ee47d028fcd"
@@ -363,7 +365,7 @@ run "Set config on Forwarder 2" _out \
 run "Deploy data-feeds (legacy, pre-migration)" OUT_DF_LEGACY \
   aptos move create-object-and-publish-package \
     --profile "$PUBLISHER_PROFILE" \
-    --package-dir "$CONTRACTS_ROOT/data-feeds/legacy/data-feeds-pre-migration" \
+    --package-dir "$CONTRACTS_ROOT/$DATA_FEEDS_PACKAGE_NAME/legacy/data-feeds-pre-migration" \
     --address-name data_feeds \
     --named-addresses platform="$PLATFORM_FORWARDER_ADDR",owner="$PUBLISHER_ADDR" \
     --max-gas 50000 --assume-yes
@@ -421,7 +423,7 @@ BENCHMARK_1=$(print "$OUT_REPORT1_READ" | jq -r '.Result[0][0].feed.benchmark')
 run "Upgrade registry contract (supports benchmark reports & 2 forwarders)" _out \
   aptos move upgrade-object \
     --profile "$PUBLISHER_PROFILE" \
-    --package-dir "$CONTRACTS_ROOT/data-feeds" \
+    --package-dir "$CONTRACTS_ROOT/$DATA_FEEDS_PACKAGE_NAME" \
     --object-address "$DATA_FEEDS_ADDR" \
     --address-name data_feeds \
     --named-addresses data_feeds="$DATA_FEEDS_ADDR",platform="$PLATFORM_FORWARDER_ADDR",owner="$PUBLISHER_ADDR",platform_secondary="$PLATFORM_SECONDARY_FORWARDER_ADDR",owner_secondary="$PUBLISHER_ADDR" \

--- a/contracts/data-feeds/sources/registry.move
+++ b/contracts/data-feeds/sources/registry.move
@@ -99,6 +99,11 @@ module data_feeds::registry {
     }
 
     #[event]
+    struct WriteSkippedFeedNotSet has drop, store {
+        feed_id: vector<u8>
+    }
+
+    #[event]
     struct OwnershipTransferRequested has drop, store {
         from: address,
         to: address
@@ -491,6 +496,8 @@ module data_feeds::registry {
         }
     }
 
+    // N.B. This FeedConfig type has a report field. These report fields are now being
+    // set to an empty vector<u8> on the on_report path(s).
     #[view]
     public fun get_feeds(): vector<FeedConfig> acquires Registry {
         let registry = borrow_global<Registry>(get_state_addr());
@@ -600,7 +607,11 @@ module data_feeds::registry {
     fun perform_update(
         registry: &mut Registry, feed_id: vector<u8>, report_data: vector<u8>
     ) {
-        if (!simple_map::contains_key(&registry.feeds, &feed_id)) { return };
+        if (!simple_map::contains_key(&registry.feeds, &feed_id)) {
+            event::emit(WriteSkippedFeedNotSet { feed_id });
+
+            return
+        };
 
         let feed = simple_map::borrow_mut(&mut registry.feeds, &feed_id);
 

--- a/contracts/data-feeds/sources/registry.move
+++ b/contracts/data-feeds/sources/registry.move
@@ -35,7 +35,7 @@ module data_feeds::registry {
         observation_timestamp: u256
     }
 
-    struct Benchmark has store, drop {
+    struct Benchmark has store, drop, copy {
         benchmark: u256,
         observation_timestamp: u256
     }
@@ -215,8 +215,7 @@ module data_feeds::registry {
         );
 
         let registry = borrow_global_mut<Registry>(get_state_addr());
-        let extend_ref = &registry.extend_ref;
-        let object_signer = object::generate_signer_for_extending(extend_ref);
+        let object_signer = object::generate_signer_for_extending(&registry.extend_ref);
 
         // callback for on_report_secondary function
         let cb_secondary =
@@ -601,10 +600,10 @@ module data_feeds::registry {
     fun perform_update(
         registry: &mut Registry, feed_id: vector<u8>, report_data: vector<u8>
     ) {
-        assert!(
-            simple_map::contains_key(&registry.feeds, &feed_id),
-            error::invalid_argument(EFEED_NOT_CONFIGURED)
-        );
+        if (!simple_map::contains_key(&registry.feeds, &feed_id)) {
+            return
+        };
+
         let feed = simple_map::borrow_mut(&mut registry.feeds, &feed_id);
 
         let is_v03 = vector::length(&report_data) == 9 * 32; // 288 bytes
@@ -977,6 +976,77 @@ module data_feeds::registry {
         assert!(benchmark.observation_timestamp == expected_timestamp, 1);
     }
 
+    #[
+        test(
+            owner = @owner,
+            publisher = @data_feeds,
+            platform = @platform,
+            platform_secondary = @platform_secondary
+        )
+    ]
+    #[expected_failure(abort_code = 65540, location = data_feeds::registry)]
+    fun test_perform_update_not_set(
+        owner: &signer,
+        publisher: &signer,
+        platform: &signer,
+        platform_secondary: &signer
+    ) acquires Registry {
+        set_up_test(publisher, platform, platform_secondary);
+
+        let report_data =
+            x"0000000000000000000000000000000000000000000000000000000066c2e36c00000000000000000000000000000000000000000000000000000000000494a8";
+
+        // Feed ID not stored in this report format
+        let feed_id = x"0003111111111111111100000000000000000000000000000000000000000000";
+        let expected_timestamp = 0x000066c2e36c;
+        let expected_benchmark = 0x0000000494a8;
+
+        let config_id = vector[1];
+
+        let report_data_not_set =
+            x"0003acdb4fce42f65d6032b18aee53efdf526cc734ad296cb57565979d883bdd0000000000000000000000000000000000000000000000000000000066ed173e0000000000000000000000000000000000000000000000000000000066ed174200000000000000007fffffffffffffffffffffffffffffffffffffffffffffff00000000000000007fffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000066ee68c2000000000000000000000000000000000000000000000d808cc35e6ed670bd00000000000000000000000000000000000000000000000d808590c35425347980000000000000000000000000000000000000000000000d8093f5f989878e7c00";
+        let feed_id_not_set  = x"0003222222222222222200000000000000000000000000000000000000000000";
+
+        // Only set one of the feed configs
+        set_feeds(
+            owner,
+            vector[feed_id],
+            vector[string::utf8(b"description")],
+            config_id
+        );
+
+        let registry = borrow_global_mut<Registry>(get_state_addr());
+
+        // Test this doesn't block the next update
+        perform_update(registry, feed_id_not_set, report_data_not_set);
+
+        perform_update(registry, feed_id, report_data);
+
+        let benchmarks = get_benchmarks(owner, vector[feed_id]);
+        assert!(vector::length(&benchmarks) == 1, 1);
+
+        let benchmark = vector::borrow(&benchmarks, 0);
+
+        assert!(benchmark.benchmark == expected_benchmark, 1);
+        assert!(benchmark.observation_timestamp == expected_timestamp, 1);
+
+        registry = borrow_global_mut<Registry>(get_state_addr());
+
+        // Test this doesn't undo the previous update
+        perform_update(registry, feed_id_not_set, report_data_not_set);
+
+        benchmarks = get_benchmarks(owner, vector[feed_id]);
+        assert!(vector::length(&benchmarks) == 1, 1);
+
+        benchmark = vector::borrow(&benchmarks, 0);
+
+        assert!(benchmark.benchmark == expected_benchmark, 1);
+        assert!(benchmark.observation_timestamp == expected_timestamp, 1);
+
+        // Fail on attempting to fetch benchmark for feed_id_not_set
+        get_benchmarks(owner, vector[feed_id_not_set]);
+    }
+
     #[test]
     fun test_parse_raw_report_v3() {
         // request_context = 00018463f564e082c55b7237add2a03bd6b3c35789d38be0f6964d9aba82f1a8000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000
@@ -1016,8 +1086,6 @@ module data_feeds::registry {
             x"00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000001c000031111111111111111000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000012000031111111111111111000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000066b3a12c0000000000000000000000000000000000000000000000000000000066b3a12c00000000000000000000000000000000000000000000000000000000000494a800000000000000000000000000000000000000000000000000000000000494a80000000000000000000000000000000000000000000000000000000066c2e36c00000000000000000000000000000000000000000000000000000000000494a800000000000000000000000000000000000000000000000000000000000494a800000000000000000000000000000000000000000000000000000000000494a800032222222222222222000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000012000032222222222222222000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000066b3a12c0000000000000000000000000000000000000000000000000000000066b3a12c00000000000000000000000000000000000000000000000000000000000494a800000000000000000000000000000000000000000000000000000000000494a80000000000000000000000000000000000000000000000000000000066c2e36c00000000000000000000000000000000000000000000000000000000000494a800000000000000000000000000000000000000000000000000000000000494a800000000000000000000000000000000000000000000000000000000000494a8";
 
         let (feed_ids, reports) = parse_raw_report(&data);
-        std::debug::print(&feed_ids);
-        std::debug::print(&reports);
 
         assert!(
             feed_ids
@@ -1076,6 +1144,75 @@ module data_feeds::registry {
 
         assert!(benchmark.benchmark == expected_benchmark, 1);
         assert!(benchmark.observation_timestamp == expected_timestamp, 1);
+    }
+
+    #[
+        test(
+            owner = @owner,
+            publisher = @data_feeds,
+            platform = @platform,
+            platform_secondary = @platform_secondary
+        )
+    ]
+    #[expected_failure(abort_code = 65540, location = data_feeds::registry)]
+    fun test_perform_update_v3_feed_not_set(
+        owner: &signer,
+        publisher: &signer,
+        platform: &signer,
+        platform_secondary: &signer
+    ) acquires Registry {
+        set_up_test(publisher, platform, platform_secondary);
+
+        let report_data =
+            x"0003fbba4fce42f65d6032b18aee53efdf526cc734ad296cb57565979d883bdd0000000000000000000000000000000000000000000000000000000066ed173e0000000000000000000000000000000000000000000000000000000066ed174200000000000000007fffffffffffffffffffffffffffffffffffffffffffffff00000000000000007fffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000066ee68c2000000000000000000000000000000000000000000000d808cc35e6ed670bd00000000000000000000000000000000000000000000000d808590c35425347980000000000000000000000000000000000000000000000d8093f5f989878e7c00";
+        let feed_id = vector::slice(&report_data, 0, 32);
+        let expected_timestamp = 0x000066ed1742;
+        let expected_benchmark = 0x000d808cc35e6ed670bd00;
+
+        let config_id = vector[1];
+
+        let report_data_not_set =
+            x"0003acdb4fce42f65d6032b18aee53efdf526cc734ad296cb57565979d883bdd0000000000000000000000000000000000000000000000000000000076ed173e0000000000000000000000000000000000000000000000000000000076ed174200000000000000004affffffffffffffffffffffffffffffffffffffffffffff00000000000000004affffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000076ee68c2000000000000000000000000000000000000000000000e808cc35e6ed670bd00000000000000000000000000000000000000000000000e808590c35425347980000000000000000000000000000000000000000000000e8093f5f989878e7c00";
+        let feed_id_not_set = vector::slice(&report_data_not_set, 0, 32);
+
+        // Only set one of the feed configs
+        set_feeds(
+            owner,
+            vector[feed_id],
+            vector[string::utf8(b"description")],
+            config_id
+        );
+
+        let registry = borrow_global_mut<Registry>(get_state_addr());
+
+        // Test this doesn't block the next update
+        perform_update(registry, feed_id_not_set, report_data_not_set);
+
+        perform_update(registry, feed_id, report_data);
+
+        let benchmarks = get_benchmarks(owner, vector[feed_id]);
+        assert!(vector::length(&benchmarks) == 1, 1);
+
+        let benchmark = vector::borrow(&benchmarks, 0);
+
+        assert!(benchmark.benchmark == expected_benchmark, 1);
+        assert!(benchmark.observation_timestamp == expected_timestamp, 1);
+
+        registry = borrow_global_mut<Registry>(get_state_addr());
+
+        // Test this doesn't undo the previous update
+        perform_update(registry, feed_id_not_set, report_data_not_set);
+
+        benchmarks = get_benchmarks(owner, vector[feed_id]);
+        assert!(vector::length(&benchmarks) == 1, 1);
+
+        benchmark = vector::borrow(&benchmarks, 0);
+
+        assert!(benchmark.benchmark == expected_benchmark, 1);
+        assert!(benchmark.observation_timestamp == expected_timestamp, 1);
+
+        // Fail on attempting to fetch benchmark for feed_id_not_set
+        get_benchmarks(owner, vector[feed_id_not_set]);
     }
 
     #[

--- a/contracts/data-feeds/sources/registry.move
+++ b/contracts/data-feeds/sources/registry.move
@@ -27,6 +27,8 @@ module data_feeds::registry {
         callback_registered: bool
     }
 
+    // The report field is now unused, and will be an empty
+    // vector<u8> in all future writes
     struct Feed has key, store, drop, copy {
         description: String,
         config_id: vector<u8>,
@@ -83,6 +85,8 @@ module data_feeds::registry {
         feed_id: vector<u8>
     }
 
+    // The report field is now unused, and will be an empty
+    // vector<u8> in all future writes
     #[event]
     struct FeedUpdated has drop, store {
         feed_id: vector<u8>,

--- a/contracts/data-feeds/sources/registry.move
+++ b/contracts/data-feeds/sources/registry.move
@@ -600,9 +600,7 @@ module data_feeds::registry {
     fun perform_update(
         registry: &mut Registry, feed_id: vector<u8>, report_data: vector<u8>
     ) {
-        if (!simple_map::contains_key(&registry.feeds, &feed_id)) {
-            return
-        };
+        if (!simple_map::contains_key(&registry.feeds, &feed_id)) { return };
 
         let feed = simple_map::borrow_mut(&mut registry.feeds, &feed_id);
 
@@ -1005,7 +1003,8 @@ module data_feeds::registry {
 
         let report_data_not_set =
             x"0003acdb4fce42f65d6032b18aee53efdf526cc734ad296cb57565979d883bdd0000000000000000000000000000000000000000000000000000000066ed173e0000000000000000000000000000000000000000000000000000000066ed174200000000000000007fffffffffffffffffffffffffffffffffffffffffffffff00000000000000007fffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000066ee68c2000000000000000000000000000000000000000000000d808cc35e6ed670bd00000000000000000000000000000000000000000000000d808590c35425347980000000000000000000000000000000000000000000000d8093f5f989878e7c00";
-        let feed_id_not_set  = x"0003222222222222222200000000000000000000000000000000000000000000";
+        let feed_id_not_set =
+            x"0003222222222222222200000000000000000000000000000000000000000000";
 
         // Only set one of the feed configs
         set_feeds(

--- a/contracts/data-feeds/sources/registry.move
+++ b/contracts/data-feeds/sources/registry.move
@@ -645,7 +645,11 @@ module data_feeds::registry {
 
         feed.observation_timestamp = observation_timestamp;
         feed.benchmark = benchmark_price;
-        feed.report = report_data;
+
+        if (vector::length(&feed.report) != 0) {
+            // Set to empty as value, as reports are deprecated.
+            feed.report = vector::empty<u8>();
+        };
 
         event::emit(
             FeedUpdated {

--- a/contracts/data-feeds/sources/registry.move
+++ b/contracts/data-feeds/sources/registry.move
@@ -664,7 +664,7 @@ module data_feeds::registry {
                 feed_id,
                 timestamp: observation_timestamp,
                 benchmark: benchmark_price,
-                report: report_data
+                report: vector::empty<u8>()
             }
         );
     }

--- a/contracts/data-feeds/sources/router.move
+++ b/contracts/data-feeds/sources/router.move
@@ -33,6 +33,7 @@ module data_feeds::router {
     const ENOT_OWNER: u64 = 0;
     const ECANNOT_TRANSFER_TO_SELF: u64 = 1;
     const ENOT_PROPOSED_OWNER: u64 = 2;
+    const EREPORTS_DEPRECATED: u64 = 3;
 
     fun assert_is_owner(router: &Router, target_address: address) {
         assert!(
@@ -74,10 +75,11 @@ module data_feeds::router {
 
     public fun get_reports(
         _authority: &signer, feed_ids: vector<vector<u8>>, _billing_data: vector<u8>
-    ): vector<Report> acquires Router {
-        let _router = borrow_global<Router>(get_state_addr());
+    ): vector<Report> {
 
-        registry::get_reports_unchecked(feed_ids)
+        abort error::not_implemented(EREPORTS_DEPRECATED);
+
+        vector::empty<Report>() /* unreachable */
     }
 
     #[view]
@@ -193,5 +195,17 @@ module data_feeds::router {
 
         transfer_ownership(owner, @0xfeeb);
         accept_ownership(new_owner);
+    }
+
+    #[test(owner = @owner, publisher = @data_feeds, new_owner = @0xbeef)]
+    #[expected_failure(abort_code = 786435, location = data_feeds::router)]
+    fun test_get_reports_failure_deprecated_call(
+        owner: &signer, publisher: &signer, new_owner: &signer
+    ) acquires Router {
+        set_up_test(publisher);
+
+        assert!(get_owner() == @owner, 1);
+
+        get_reports(owner, vector::empty<vector<u8>>(), vector::empty<u8>());
     }
 }

--- a/contracts/data-feeds/sources/router.move
+++ b/contracts/data-feeds/sources/router.move
@@ -30,6 +30,12 @@ module data_feeds::router {
         to: address
     }
 
+    #[event]
+    struct FeedRead has drop, store {
+        feed_ids: vector<vector<u8>>,
+        benchmarks: vector<Benchmark>
+    }
+
     const ENOT_OWNER: u64 = 0;
     const ECANNOT_TRANSFER_TO_SELF: u64 = 1;
     const ENOT_PROPOSED_OWNER: u64 = 2;
@@ -67,10 +73,14 @@ module data_feeds::router {
 
     public fun get_benchmarks(
         _authority: &signer, feed_ids: vector<vector<u8>>, _billing_data: vector<u8>
-    ): vector<Benchmark> acquires Router {
-        let _router = borrow_global<Router>(get_state_addr());
+    ): vector<Benchmark> {
+        let benchmarks = registry::get_benchmarks_unchecked(feed_ids);
 
-        registry::get_benchmarks_unchecked(feed_ids)
+        event::emit(
+            FeedRead { feed_ids: feed_ids, benchmarks: benchmarks }
+        );
+
+        benchmarks
     }
 
     // @deprecated This function is no longer supported

--- a/contracts/data-feeds/sources/router.move
+++ b/contracts/data-feeds/sources/router.move
@@ -81,7 +81,7 @@ module data_feeds::router {
         benchmarks
     }
 
-    // @deprecated This function is no longer supported
+    // This function has been disabled
     public fun get_reports(
         _authority: &signer, feed_ids: vector<vector<u8>>, _billing_data: vector<u8>
     ): vector<Report> {

--- a/contracts/data-feeds/sources/router.move
+++ b/contracts/data-feeds/sources/router.move
@@ -73,7 +73,9 @@ module data_feeds::router {
 
     public fun get_benchmarks(
         _authority: &signer, feed_ids: vector<vector<u8>>, _billing_data: vector<u8>
-    ): vector<Benchmark> {
+    ): vector<Benchmark> acquires Router {
+        let _router = borrow_global<Router>(get_state_addr());
+
         let benchmarks = registry::get_benchmarks_unchecked(feed_ids);
 
         event::emit(FeedRead { feed_ids: feed_ids, benchmarks: benchmarks });

--- a/contracts/data-feeds/sources/router.move
+++ b/contracts/data-feeds/sources/router.move
@@ -76,9 +76,7 @@ module data_feeds::router {
     ): vector<Benchmark> {
         let benchmarks = registry::get_benchmarks_unchecked(feed_ids);
 
-        event::emit(
-            FeedRead { feed_ids: feed_ids, benchmarks: benchmarks }
-        );
+        event::emit(FeedRead { feed_ids: feed_ids, benchmarks: benchmarks });
 
         benchmarks
     }

--- a/contracts/data-feeds/sources/router.move
+++ b/contracts/data-feeds/sources/router.move
@@ -73,6 +73,7 @@ module data_feeds::router {
         registry::get_benchmarks_unchecked(feed_ids)
     }
 
+    // @deprecated This function is no longer supported
     public fun get_reports(
         _authority: &signer, feed_ids: vector<vector<u8>>, _billing_data: vector<u8>
     ): vector<Report> {

--- a/contracts/data-feeds/sources/router.move
+++ b/contracts/data-feeds/sources/router.move
@@ -207,6 +207,10 @@ module data_feeds::router {
 
         assert!(get_owner() == @owner, 1);
 
-        get_reports(owner, vector::empty<vector<u8>>(), vector::empty<u8>());
+        get_reports(
+            owner,
+            vector::empty<vector<u8>>(),
+            vector::empty<u8>()
+        );
     }
 }


### PR DESCRIPTION
New features:

-Adding a revert to `data_feeds::router::get_reports`, as we are proposing to disbale this function.
-Removing the writing of the report_data as part of the Feed structure.
-Zeroing it out existing report values
-Adding a read event in the Router to help onchain tracking

IMPORTANT:
This PR must be reviewed as a contract **_upgrade_** with upgrade policy 'upgrade', to an already deployed Data Feeds Package.