### PR TITLE
Add view helper methods

### DIFF
--- a/bindings/ccip_router/router/router.go
+++ b/bindings/ccip_router/router/router.go
@@ -28,6 +28,8 @@ type RouterInterface interface {
 	GetOnRamp(opts *bind.CallOpts, destChainSelector uint64) (aptos.AccountAddress, error)
 	GetFee(opts *bind.CallOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (uint64, error)
 	GetOnRampVersions(opts *bind.CallOpts, destChainSelectors []uint64) ([][]byte, error)
+	GetOnRampForVersion(opts *bind.CallOpts, onRampVersion []byte) (aptos.AccountAddress, error)
+	GetDestChains(opts *bind.CallOpts) ([]uint64, error)
 	Owner(opts *bind.CallOpts) (aptos.AccountAddress, error)
 
 	CCIPSend(opts *bind.TransactOpts, destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (*api.PendingTransaction, error)
@@ -47,6 +49,8 @@ type RouterEncoder interface {
 	GetOnRamp(destChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetFee(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetOnRampVersions(destChainSelectors []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetOnRampForVersion(onRampVersion []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetDestChains() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	Owner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	CCIPSend(destChainSelector uint64, receiver []byte, data []byte, tokenAddresses []aptos.AccountAddress, tokenAmounts []uint64, tokenStoreAddresses []aptos.AccountAddress, feeToken aptos.AccountAddress, feeTokenStore aptos.AccountAddress, extraArgs []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	SetOnRampVersions(destChainSelectors []uint64, onRampVersions [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
@@ -220,6 +224,48 @@ func (c RouterContract) GetOnRampVersions(opts *bind.CallOpts, destChainSelector
 	return r0, nil
 }
 
+func (c RouterContract) GetOnRampForVersion(opts *bind.CallOpts, onRampVersion []byte) (aptos.AccountAddress, error) {
+	module, function, typeTags, args, err := c.routerEncoder.GetOnRampForVersion(onRampVersion)
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+
+	var (
+		r0 aptos.AccountAddress
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(aptos.AccountAddress), err
+	}
+	return r0, nil
+}
+
+func (c RouterContract) GetDestChains(opts *bind.CallOpts) ([]uint64, error) {
+	module, function, typeTags, args, err := c.routerEncoder.GetDestChains()
+	if err != nil {
+		return *new([]uint64), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new([]uint64), err
+	}
+
+	var (
+		r0 []uint64
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new([]uint64), err
+	}
+	return r0, nil
+}
+
 func (c RouterContract) Owner(opts *bind.CallOpts) (aptos.AccountAddress, error) {
 	module, function, typeTags, args, err := c.routerEncoder.Owner()
 	if err != nil {
@@ -347,6 +393,18 @@ func (c routerEncoder) GetOnRampVersions(destChainSelectors []uint64) (bind.Modu
 	}, []any{
 		destChainSelectors,
 	})
+}
+
+func (c routerEncoder) GetOnRampForVersion(onRampVersion []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_on_ramp_for_version", nil, []string{
+		"vector<u8>",
+	}, []any{
+		onRampVersion,
+	})
+}
+
+func (c routerEncoder) GetDestChains() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_dest_chains", nil, []string{}, []any{})
 }
 
 func (c routerEncoder) Owner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {

--- a/bindings/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool/burn_mint_token_pool.go
+++ b/bindings/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool/burn_mint_token_pool.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aptos-labs/aptos-go-sdk/api"
 
 	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	module_rate_limiter "github.com/smartcontractkit/chainlink-aptos/bindings/ccip_token_pools/token_pool/rate_limiter"
 	"github.com/smartcontractkit/chainlink-aptos/relayer/codec"
 )
 
@@ -33,6 +34,8 @@ type BurnMintTokenPoolInterface interface {
 	GetSupportedChains(opts *bind.CallOpts) ([]uint64, error)
 	GetAllowlistEnabled(opts *bind.CallOpts) (bool, error)
 	GetAllowlist(opts *bind.CallOpts) ([]aptos.AccountAddress, error)
+	GetCurrentInboundRateLimiterState(opts *bind.CallOpts, remoteChainSelector uint64) (module_rate_limiter.TokenBucket, error)
+	GetCurrentOutboundRateLimiterState(opts *bind.CallOpts, remoteChainSelector uint64) (module_rate_limiter.TokenBucket, error)
 	GetStoreAddress(opts *bind.CallOpts) (aptos.AccountAddress, error)
 	Owner(opts *bind.CallOpts) (aptos.AccountAddress, error)
 
@@ -40,6 +43,8 @@ type BurnMintTokenPoolInterface interface {
 	RemoveRemotePool(opts *bind.TransactOpts, remoteChainSelector uint64, remotePoolAddress []byte) (*api.PendingTransaction, error)
 	ApplyChainUpdates(opts *bind.TransactOpts, remoteChainSelectorsToRemove []uint64, remoteChainSelectorsToAdd []uint64, remotePoolAddressesToAdd [][][]byte, remoteTokenAddressesToAdd [][]byte) (*api.PendingTransaction, error)
 	ApplyAllowlistUpdates(opts *bind.TransactOpts, removes []aptos.AccountAddress, adds []aptos.AccountAddress) (*api.PendingTransaction, error)
+	SetChainRateLimiterConfigs(opts *bind.TransactOpts, remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (*api.PendingTransaction, error)
+	SetChainRateLimiterConfig(opts *bind.TransactOpts, remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (*api.PendingTransaction, error)
 	TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
 	AcceptOwnership(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 	ExecuteOwnershipTransfer(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
@@ -60,17 +65,19 @@ type BurnMintTokenPoolEncoder interface {
 	GetSupportedChains() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetAllowlistEnabled() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetAllowlist() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetCurrentInboundRateLimiterState(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetCurrentOutboundRateLimiterState(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetStoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	Owner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	AddRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	RemoveRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	ApplyChainUpdates(remoteChainSelectorsToRemove []uint64, remoteChainSelectorsToAdd []uint64, remotePoolAddressesToAdd [][][]byte, remoteTokenAddressesToAdd [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	ApplyAllowlistUpdates(removes []aptos.AccountAddress, adds []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	ExecuteOwnershipTransfer(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
-	SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
-	SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	StoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	AssertCanInitialize(callerAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	MCMSEntrypoint(Metadata aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
@@ -345,6 +352,48 @@ func (c BurnMintTokenPoolContract) GetAllowlist(opts *bind.CallOpts) ([]aptos.Ac
 	return r0, nil
 }
 
+func (c BurnMintTokenPoolContract) GetCurrentInboundRateLimiterState(opts *bind.CallOpts, remoteChainSelector uint64) (module_rate_limiter.TokenBucket, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.GetCurrentInboundRateLimiterState(remoteChainSelector)
+	if err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+
+	var (
+		r0 module_rate_limiter.TokenBucket
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+	return r0, nil
+}
+
+func (c BurnMintTokenPoolContract) GetCurrentOutboundRateLimiterState(opts *bind.CallOpts, remoteChainSelector uint64) (module_rate_limiter.TokenBucket, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.GetCurrentOutboundRateLimiterState(remoteChainSelector)
+	if err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+
+	var (
+		r0 module_rate_limiter.TokenBucket
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+	return r0, nil
+}
+
 func (c BurnMintTokenPoolContract) GetStoreAddress(opts *bind.CallOpts) (aptos.AccountAddress, error) {
 	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.GetStoreAddress()
 	if err != nil {
@@ -418,6 +467,24 @@ func (c BurnMintTokenPoolContract) ApplyChainUpdates(opts *bind.TransactOpts, re
 
 func (c BurnMintTokenPoolContract) ApplyAllowlistUpdates(opts *bind.TransactOpts, removes []aptos.AccountAddress, adds []aptos.AccountAddress) (*api.PendingTransaction, error) {
 	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.ApplyAllowlistUpdates(removes, adds)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c BurnMintTokenPoolContract) SetChainRateLimiterConfigs(opts *bind.TransactOpts, remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.SetChainRateLimiterConfigs(remoteChainSelectors, outboundIsEnableds, outboundCapacities, outboundRates, inboundIsEnableds, inboundCapacities, inboundRates)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c BurnMintTokenPoolContract) SetChainRateLimiterConfig(opts *bind.TransactOpts, remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.burnMintTokenPoolEncoder.SetChainRateLimiterConfig(remoteChainSelector, outboundIsEnabled, outboundCapacity, outboundRate, inboundIsEnabled, inboundCapacity, inboundRate)
 	if err != nil {
 		return nil, err
 	}
@@ -519,6 +586,22 @@ func (c burnMintTokenPoolEncoder) GetAllowlist() (bind.ModuleInformation, string
 	return c.BoundContract.Encode("get_allowlist", nil, []string{}, []any{})
 }
 
+func (c burnMintTokenPoolEncoder) GetCurrentInboundRateLimiterState(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_current_inbound_rate_limiter_state", nil, []string{
+		"u64",
+	}, []any{
+		remoteChainSelector,
+	})
+}
+
+func (c burnMintTokenPoolEncoder) GetCurrentOutboundRateLimiterState(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_current_outbound_rate_limiter_state", nil, []string{
+		"u64",
+	}, []any{
+		remoteChainSelector,
+	})
+}
+
 func (c burnMintTokenPoolEncoder) GetStoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("get_store_address", nil, []string{}, []any{})
 }
@@ -571,26 +654,6 @@ func (c burnMintTokenPoolEncoder) ApplyAllowlistUpdates(removes []aptos.AccountA
 	})
 }
 
-func (c burnMintTokenPoolEncoder) TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("transfer_ownership", nil, []string{
-		"address",
-	}, []any{
-		to,
-	})
-}
-
-func (c burnMintTokenPoolEncoder) AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("accept_ownership", nil, []string{}, []any{})
-}
-
-func (c burnMintTokenPoolEncoder) ExecuteOwnershipTransfer(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("execute_ownership_transfer", nil, []string{
-		"address",
-	}, []any{
-		to,
-	})
-}
-
 func (c burnMintTokenPoolEncoder) SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("set_chain_rate_limiter_configs", nil, []string{
 		"vector<u64>",
@@ -628,6 +691,26 @@ func (c burnMintTokenPoolEncoder) SetChainRateLimiterConfig(remoteChainSelector 
 		inboundIsEnabled,
 		inboundCapacity,
 		inboundRate,
+	})
+}
+
+func (c burnMintTokenPoolEncoder) TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("transfer_ownership", nil, []string{
+		"address",
+	}, []any{
+		to,
+	})
+}
+
+func (c burnMintTokenPoolEncoder) AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("accept_ownership", nil, []string{}, []any{})
+}
+
+func (c burnMintTokenPoolEncoder) ExecuteOwnershipTransfer(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("execute_ownership_transfer", nil, []string{
+		"address",
+	}, []any{
+		to,
 	})
 }
 

--- a/bindings/ccip_token_pools/lock_release_token_pool/lock_release_token_pool/lock_release_token_pool.go
+++ b/bindings/ccip_token_pools/lock_release_token_pool/lock_release_token_pool/lock_release_token_pool.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aptos-labs/aptos-go-sdk/api"
 
 	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	module_rate_limiter "github.com/smartcontractkit/chainlink-aptos/bindings/ccip_token_pools/token_pool/rate_limiter"
 	"github.com/smartcontractkit/chainlink-aptos/relayer/codec"
 )
 
@@ -36,6 +37,8 @@ type LockReleaseTokenPoolInterface interface {
 	GetSupportedChains(opts *bind.CallOpts) ([]uint64, error)
 	GetAllowlistEnabled(opts *bind.CallOpts) (bool, error)
 	GetAllowlist(opts *bind.CallOpts) ([]aptos.AccountAddress, error)
+	GetCurrentInboundRateLimiterState(opts *bind.CallOpts, remoteChainSelector uint64) (module_rate_limiter.TokenBucket, error)
+	GetCurrentOutboundRateLimiterState(opts *bind.CallOpts, remoteChainSelector uint64) (module_rate_limiter.TokenBucket, error)
 	GetRebalancer(opts *bind.CallOpts) (aptos.AccountAddress, error)
 	GetStoreAddress(opts *bind.CallOpts) (aptos.AccountAddress, error)
 	Owner(opts *bind.CallOpts) (aptos.AccountAddress, error)
@@ -44,6 +47,8 @@ type LockReleaseTokenPoolInterface interface {
 	RemoveRemotePool(opts *bind.TransactOpts, remoteChainSelector uint64, remotePoolAddress []byte) (*api.PendingTransaction, error)
 	ApplyChainUpdates(opts *bind.TransactOpts, remoteChainSelectorsToRemove []uint64, remoteChainSelectorsToAdd []uint64, remotePoolAddressesToAdd [][][]byte, remoteTokenAddressesToAdd [][]byte) (*api.PendingTransaction, error)
 	ApplyAllowlistUpdates(opts *bind.TransactOpts, removes []aptos.AccountAddress, adds []aptos.AccountAddress) (*api.PendingTransaction, error)
+	SetChainRateLimiterConfigs(opts *bind.TransactOpts, remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (*api.PendingTransaction, error)
+	SetChainRateLimiterConfig(opts *bind.TransactOpts, remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (*api.PendingTransaction, error)
 	ProvideLiquidity(opts *bind.TransactOpts, amount uint64) (*api.PendingTransaction, error)
 	WithdrawLiquidity(opts *bind.TransactOpts, amount uint64) (*api.PendingTransaction, error)
 	SetRebalancer(opts *bind.TransactOpts, rebalancer aptos.AccountAddress) (*api.PendingTransaction, error)
@@ -70,6 +75,8 @@ type LockReleaseTokenPoolEncoder interface {
 	GetSupportedChains() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetAllowlistEnabled() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetAllowlist() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetCurrentInboundRateLimiterState(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetCurrentOutboundRateLimiterState(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetRebalancer() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetStoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	Owner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
@@ -77,14 +84,14 @@ type LockReleaseTokenPoolEncoder interface {
 	RemoveRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	ApplyChainUpdates(remoteChainSelectorsToRemove []uint64, remoteChainSelectorsToAdd []uint64, remotePoolAddressesToAdd [][][]byte, remoteTokenAddressesToAdd [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	ApplyAllowlistUpdates(removes []aptos.AccountAddress, adds []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	ProvideLiquidity(amount uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	WithdrawLiquidity(amount uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	SetRebalancer(rebalancer aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	ExecuteOwnershipTransfer(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
-	SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
-	SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	StoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	AssertCanInitialize(callerAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	MCMSEntrypoint(Metadata aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
@@ -423,6 +430,48 @@ func (c LockReleaseTokenPoolContract) GetAllowlist(opts *bind.CallOpts) ([]aptos
 	return r0, nil
 }
 
+func (c LockReleaseTokenPoolContract) GetCurrentInboundRateLimiterState(opts *bind.CallOpts, remoteChainSelector uint64) (module_rate_limiter.TokenBucket, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.GetCurrentInboundRateLimiterState(remoteChainSelector)
+	if err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+
+	var (
+		r0 module_rate_limiter.TokenBucket
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+	return r0, nil
+}
+
+func (c LockReleaseTokenPoolContract) GetCurrentOutboundRateLimiterState(opts *bind.CallOpts, remoteChainSelector uint64) (module_rate_limiter.TokenBucket, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.GetCurrentOutboundRateLimiterState(remoteChainSelector)
+	if err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+
+	var (
+		r0 module_rate_limiter.TokenBucket
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+	return r0, nil
+}
+
 func (c LockReleaseTokenPoolContract) GetRebalancer(opts *bind.CallOpts) (aptos.AccountAddress, error) {
 	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.GetRebalancer()
 	if err != nil {
@@ -517,6 +566,24 @@ func (c LockReleaseTokenPoolContract) ApplyChainUpdates(opts *bind.TransactOpts,
 
 func (c LockReleaseTokenPoolContract) ApplyAllowlistUpdates(opts *bind.TransactOpts, removes []aptos.AccountAddress, adds []aptos.AccountAddress) (*api.PendingTransaction, error) {
 	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.ApplyAllowlistUpdates(removes, adds)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c LockReleaseTokenPoolContract) SetChainRateLimiterConfigs(opts *bind.TransactOpts, remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.SetChainRateLimiterConfigs(remoteChainSelectors, outboundIsEnableds, outboundCapacities, outboundRates, inboundIsEnableds, inboundCapacities, inboundRates)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c LockReleaseTokenPoolContract) SetChainRateLimiterConfig(opts *bind.TransactOpts, remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.lockReleaseTokenPoolEncoder.SetChainRateLimiterConfig(remoteChainSelector, outboundIsEnabled, outboundCapacity, outboundRate, inboundIsEnabled, inboundCapacity, inboundRate)
 	if err != nil {
 		return nil, err
 	}
@@ -657,6 +724,22 @@ func (c lockReleaseTokenPoolEncoder) GetAllowlist() (bind.ModuleInformation, str
 	return c.BoundContract.Encode("get_allowlist", nil, []string{}, []any{})
 }
 
+func (c lockReleaseTokenPoolEncoder) GetCurrentInboundRateLimiterState(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_current_inbound_rate_limiter_state", nil, []string{
+		"u64",
+	}, []any{
+		remoteChainSelector,
+	})
+}
+
+func (c lockReleaseTokenPoolEncoder) GetCurrentOutboundRateLimiterState(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_current_outbound_rate_limiter_state", nil, []string{
+		"u64",
+	}, []any{
+		remoteChainSelector,
+	})
+}
+
 func (c lockReleaseTokenPoolEncoder) GetRebalancer() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("get_rebalancer", nil, []string{}, []any{})
 }
@@ -713,6 +796,46 @@ func (c lockReleaseTokenPoolEncoder) ApplyAllowlistUpdates(removes []aptos.Accou
 	})
 }
 
+func (c lockReleaseTokenPoolEncoder) SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("set_chain_rate_limiter_configs", nil, []string{
+		"vector<u64>",
+		"vector<bool>",
+		"vector<u64>",
+		"vector<u64>",
+		"vector<bool>",
+		"vector<u64>",
+		"vector<u64>",
+	}, []any{
+		remoteChainSelectors,
+		outboundIsEnableds,
+		outboundCapacities,
+		outboundRates,
+		inboundIsEnableds,
+		inboundCapacities,
+		inboundRates,
+	})
+}
+
+func (c lockReleaseTokenPoolEncoder) SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("set_chain_rate_limiter_config", nil, []string{
+		"u64",
+		"bool",
+		"u64",
+		"u64",
+		"bool",
+		"u64",
+		"u64",
+	}, []any{
+		remoteChainSelector,
+		outboundIsEnabled,
+		outboundCapacity,
+		outboundRate,
+		inboundIsEnabled,
+		inboundCapacity,
+		inboundRate,
+	})
+}
+
 func (c lockReleaseTokenPoolEncoder) ProvideLiquidity(amount uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("provide_liquidity", nil, []string{
 		"u64",
@@ -754,46 +877,6 @@ func (c lockReleaseTokenPoolEncoder) ExecuteOwnershipTransfer(to aptos.AccountAd
 		"address",
 	}, []any{
 		to,
-	})
-}
-
-func (c lockReleaseTokenPoolEncoder) SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("set_chain_rate_limiter_configs", nil, []string{
-		"vector<u64>",
-		"vector<bool>",
-		"vector<u64>",
-		"vector<u64>",
-		"vector<bool>",
-		"vector<u64>",
-		"vector<u64>",
-	}, []any{
-		remoteChainSelectors,
-		outboundIsEnableds,
-		outboundCapacities,
-		outboundRates,
-		inboundIsEnableds,
-		inboundCapacities,
-		inboundRates,
-	})
-}
-
-func (c lockReleaseTokenPoolEncoder) SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("set_chain_rate_limiter_config", nil, []string{
-		"u64",
-		"bool",
-		"u64",
-		"u64",
-		"bool",
-		"u64",
-		"u64",
-	}, []any{
-		remoteChainSelector,
-		outboundIsEnabled,
-		outboundCapacity,
-		outboundRate,
-		inboundIsEnabled,
-		inboundCapacity,
-		inboundRate,
 	})
 }
 

--- a/bindings/ccip_token_pools/managed_token_pool/managed_token_pool/managed_token_pool.go
+++ b/bindings/ccip_token_pools/managed_token_pool/managed_token_pool/managed_token_pool.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aptos-labs/aptos-go-sdk/api"
 
 	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	module_rate_limiter "github.com/smartcontractkit/chainlink-aptos/bindings/ccip_token_pools/token_pool/rate_limiter"
 	"github.com/smartcontractkit/chainlink-aptos/relayer/codec"
 )
 
@@ -33,6 +34,8 @@ type ManagedTokenPoolInterface interface {
 	GetSupportedChains(opts *bind.CallOpts) ([]uint64, error)
 	GetAllowlistEnabled(opts *bind.CallOpts) (bool, error)
 	GetAllowlist(opts *bind.CallOpts) ([]aptos.AccountAddress, error)
+	GetCurrentInboundRateLimiterState(opts *bind.CallOpts, remoteChainSelector uint64) (module_rate_limiter.TokenBucket, error)
+	GetCurrentOutboundRateLimiterState(opts *bind.CallOpts, remoteChainSelector uint64) (module_rate_limiter.TokenBucket, error)
 	GetStoreAddress(opts *bind.CallOpts) (aptos.AccountAddress, error)
 	Owner(opts *bind.CallOpts) (aptos.AccountAddress, error)
 
@@ -40,6 +43,8 @@ type ManagedTokenPoolInterface interface {
 	RemoveRemotePool(opts *bind.TransactOpts, remoteChainSelector uint64, remotePoolAddress []byte) (*api.PendingTransaction, error)
 	ApplyChainUpdates(opts *bind.TransactOpts, remoteChainSelectorsToRemove []uint64, remoteChainSelectorsToAdd []uint64, remotePoolAddressesToAdd [][][]byte, remoteTokenAddressesToAdd [][]byte) (*api.PendingTransaction, error)
 	ApplyAllowlistUpdates(opts *bind.TransactOpts, removes []aptos.AccountAddress, adds []aptos.AccountAddress) (*api.PendingTransaction, error)
+	SetChainRateLimiterConfigs(opts *bind.TransactOpts, remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (*api.PendingTransaction, error)
+	SetChainRateLimiterConfig(opts *bind.TransactOpts, remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (*api.PendingTransaction, error)
 	TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
 	AcceptOwnership(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 
@@ -59,16 +64,18 @@ type ManagedTokenPoolEncoder interface {
 	GetSupportedChains() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetAllowlistEnabled() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetAllowlist() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetCurrentInboundRateLimiterState(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetCurrentOutboundRateLimiterState(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetStoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	Owner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	AddRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	RemoveRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	ApplyChainUpdates(remoteChainSelectorsToRemove []uint64, remoteChainSelectorsToAdd []uint64, remotePoolAddressesToAdd [][][]byte, remoteTokenAddressesToAdd [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	ApplyAllowlistUpdates(removes []aptos.AccountAddress, adds []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
-	TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
-	AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	StoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	MCMSEntrypoint(Metadata aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 }
@@ -339,6 +346,48 @@ func (c ManagedTokenPoolContract) GetAllowlist(opts *bind.CallOpts) ([]aptos.Acc
 	return r0, nil
 }
 
+func (c ManagedTokenPoolContract) GetCurrentInboundRateLimiterState(opts *bind.CallOpts, remoteChainSelector uint64) (module_rate_limiter.TokenBucket, error) {
+	module, function, typeTags, args, err := c.managedTokenPoolEncoder.GetCurrentInboundRateLimiterState(remoteChainSelector)
+	if err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+
+	var (
+		r0 module_rate_limiter.TokenBucket
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+	return r0, nil
+}
+
+func (c ManagedTokenPoolContract) GetCurrentOutboundRateLimiterState(opts *bind.CallOpts, remoteChainSelector uint64) (module_rate_limiter.TokenBucket, error) {
+	module, function, typeTags, args, err := c.managedTokenPoolEncoder.GetCurrentOutboundRateLimiterState(remoteChainSelector)
+	if err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+
+	var (
+		r0 module_rate_limiter.TokenBucket
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+	return r0, nil
+}
+
 func (c ManagedTokenPoolContract) GetStoreAddress(opts *bind.CallOpts) (aptos.AccountAddress, error) {
 	module, function, typeTags, args, err := c.managedTokenPoolEncoder.GetStoreAddress()
 	if err != nil {
@@ -412,6 +461,24 @@ func (c ManagedTokenPoolContract) ApplyChainUpdates(opts *bind.TransactOpts, rem
 
 func (c ManagedTokenPoolContract) ApplyAllowlistUpdates(opts *bind.TransactOpts, removes []aptos.AccountAddress, adds []aptos.AccountAddress) (*api.PendingTransaction, error) {
 	module, function, typeTags, args, err := c.managedTokenPoolEncoder.ApplyAllowlistUpdates(removes, adds)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c ManagedTokenPoolContract) SetChainRateLimiterConfigs(opts *bind.TransactOpts, remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.managedTokenPoolEncoder.SetChainRateLimiterConfigs(remoteChainSelectors, outboundIsEnableds, outboundCapacities, outboundRates, inboundIsEnableds, inboundCapacities, inboundRates)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c ManagedTokenPoolContract) SetChainRateLimiterConfig(opts *bind.TransactOpts, remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.managedTokenPoolEncoder.SetChainRateLimiterConfig(remoteChainSelector, outboundIsEnabled, outboundCapacity, outboundRate, inboundIsEnabled, inboundCapacity, inboundRate)
 	if err != nil {
 		return nil, err
 	}
@@ -504,6 +571,22 @@ func (c managedTokenPoolEncoder) GetAllowlist() (bind.ModuleInformation, string,
 	return c.BoundContract.Encode("get_allowlist", nil, []string{}, []any{})
 }
 
+func (c managedTokenPoolEncoder) GetCurrentInboundRateLimiterState(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_current_inbound_rate_limiter_state", nil, []string{
+		"u64",
+	}, []any{
+		remoteChainSelector,
+	})
+}
+
+func (c managedTokenPoolEncoder) GetCurrentOutboundRateLimiterState(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_current_outbound_rate_limiter_state", nil, []string{
+		"u64",
+	}, []any{
+		remoteChainSelector,
+	})
+}
+
 func (c managedTokenPoolEncoder) GetStoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("get_store_address", nil, []string{}, []any{})
 }
@@ -556,18 +639,6 @@ func (c managedTokenPoolEncoder) ApplyAllowlistUpdates(removes []aptos.AccountAd
 	})
 }
 
-func (c managedTokenPoolEncoder) TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("transfer_ownership", nil, []string{
-		"address",
-	}, []any{
-		to,
-	})
-}
-
-func (c managedTokenPoolEncoder) AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("accept_ownership", nil, []string{}, []any{})
-}
-
 func (c managedTokenPoolEncoder) SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("set_chain_rate_limiter_configs", nil, []string{
 		"vector<u64>",
@@ -606,6 +677,18 @@ func (c managedTokenPoolEncoder) SetChainRateLimiterConfig(remoteChainSelector u
 		inboundCapacity,
 		inboundRate,
 	})
+}
+
+func (c managedTokenPoolEncoder) TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("transfer_ownership", nil, []string{
+		"address",
+	}, []any{
+		to,
+	})
+}
+
+func (c managedTokenPoolEncoder) AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("accept_ownership", nil, []string{}, []any{})
 }
 
 func (c managedTokenPoolEncoder) StoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {

--- a/bindings/ccip_token_pools/usdc_token_pool/usdc_token_pool/usdc_token_pool.go
+++ b/bindings/ccip_token_pools/usdc_token_pool/usdc_token_pool/usdc_token_pool.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aptos-labs/aptos-go-sdk/api"
 
 	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	module_rate_limiter "github.com/smartcontractkit/chainlink-aptos/bindings/ccip_token_pools/token_pool/rate_limiter"
 	"github.com/smartcontractkit/chainlink-aptos/relayer/codec"
 )
 
@@ -34,6 +35,8 @@ type USDCTokenPoolInterface interface {
 	GetAllowlistEnabled(opts *bind.CallOpts) (bool, error)
 	GetAllowlist(opts *bind.CallOpts) ([]aptos.AccountAddress, error)
 	GetDomain(opts *bind.CallOpts, chainSelector uint64) (Domain, error)
+	GetCurrentInboundRateLimiterState(opts *bind.CallOpts, remoteChainSelector uint64) (module_rate_limiter.TokenBucket, error)
+	GetCurrentOutboundRateLimiterState(opts *bind.CallOpts, remoteChainSelector uint64) (module_rate_limiter.TokenBucket, error)
 	GetStoreAddress(opts *bind.CallOpts) (aptos.AccountAddress, error)
 	Owner(opts *bind.CallOpts) (aptos.AccountAddress, error)
 
@@ -41,6 +44,8 @@ type USDCTokenPoolInterface interface {
 	RemoveRemotePool(opts *bind.TransactOpts, remoteChainSelector uint64, remotePoolAddress []byte) (*api.PendingTransaction, error)
 	ApplyChainUpdates(opts *bind.TransactOpts, remoteChainSelectorsToRemove []uint64, remoteChainSelectorsToAdd []uint64, remotePoolAddressesToAdd [][][]byte, remoteTokenAddressesToAdd [][]byte) (*api.PendingTransaction, error)
 	ApplyAllowlistUpdates(opts *bind.TransactOpts, removes []aptos.AccountAddress, adds []aptos.AccountAddress) (*api.PendingTransaction, error)
+	SetChainRateLimiterConfigs(opts *bind.TransactOpts, remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (*api.PendingTransaction, error)
+	SetChainRateLimiterConfig(opts *bind.TransactOpts, remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (*api.PendingTransaction, error)
 	TransferOwnership(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
 	AcceptOwnership(opts *bind.TransactOpts) (*api.PendingTransaction, error)
 	ExecuteOwnershipTransfer(opts *bind.TransactOpts, to aptos.AccountAddress) (*api.PendingTransaction, error)
@@ -62,12 +67,16 @@ type USDCTokenPoolEncoder interface {
 	GetAllowlistEnabled() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetAllowlist() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetDomain(chainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetCurrentInboundRateLimiterState(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	GetCurrentOutboundRateLimiterState(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	GetStoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	Owner() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	AddRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	RemoveRemotePool(remoteChainSelector uint64, remotePoolAddress []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	ApplyChainUpdates(remoteChainSelectorsToRemove []uint64, remoteChainSelectorsToAdd []uint64, remotePoolAddressesToAdd [][][]byte, remoteTokenAddressesToAdd [][]byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	ApplyAllowlistUpdates(removes []aptos.AccountAddress, adds []aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+	SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	TransferOwnership(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	AcceptOwnership() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	ExecuteOwnershipTransfer(to aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
@@ -76,8 +85,6 @@ type USDCTokenPoolEncoder interface {
 	EncodeDestPoolData(localDomainIdentifier uint32, nonce uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	DecodeDestPoolData(destPoolData []byte) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	SetDomains(remoteChainSelectors []uint64, remoteDomainIdentifiers []uint32, allowedRemoteCallers [][]byte, enableds []bool) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
-	SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
-	SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	StoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	AssertCanInitialize(callerAddress aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
 	MCMSEntrypoint(Metadata aptos.AccountAddress) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
@@ -387,6 +394,48 @@ func (c USDCTokenPoolContract) GetDomain(opts *bind.CallOpts, chainSelector uint
 	return r0, nil
 }
 
+func (c USDCTokenPoolContract) GetCurrentInboundRateLimiterState(opts *bind.CallOpts, remoteChainSelector uint64) (module_rate_limiter.TokenBucket, error) {
+	module, function, typeTags, args, err := c.usdcTokenPoolEncoder.GetCurrentInboundRateLimiterState(remoteChainSelector)
+	if err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+
+	var (
+		r0 module_rate_limiter.TokenBucket
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+	return r0, nil
+}
+
+func (c USDCTokenPoolContract) GetCurrentOutboundRateLimiterState(opts *bind.CallOpts, remoteChainSelector uint64) (module_rate_limiter.TokenBucket, error) {
+	module, function, typeTags, args, err := c.usdcTokenPoolEncoder.GetCurrentOutboundRateLimiterState(remoteChainSelector)
+	if err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+
+	callData, err := c.Call(opts, module, function, typeTags, args)
+	if err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+
+	var (
+		r0 module_rate_limiter.TokenBucket
+	)
+
+	if err := codec.DecodeAptosJsonArray(callData, &r0); err != nil {
+		return *new(module_rate_limiter.TokenBucket), err
+	}
+	return r0, nil
+}
+
 func (c USDCTokenPoolContract) GetStoreAddress(opts *bind.CallOpts) (aptos.AccountAddress, error) {
 	module, function, typeTags, args, err := c.usdcTokenPoolEncoder.GetStoreAddress()
 	if err != nil {
@@ -460,6 +509,24 @@ func (c USDCTokenPoolContract) ApplyChainUpdates(opts *bind.TransactOpts, remote
 
 func (c USDCTokenPoolContract) ApplyAllowlistUpdates(opts *bind.TransactOpts, removes []aptos.AccountAddress, adds []aptos.AccountAddress) (*api.PendingTransaction, error) {
 	module, function, typeTags, args, err := c.usdcTokenPoolEncoder.ApplyAllowlistUpdates(removes, adds)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c USDCTokenPoolContract) SetChainRateLimiterConfigs(opts *bind.TransactOpts, remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.usdcTokenPoolEncoder.SetChainRateLimiterConfigs(remoteChainSelectors, outboundIsEnableds, outboundCapacities, outboundRates, inboundIsEnableds, inboundCapacities, inboundRates)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BoundContract.Transact(opts, module, function, typeTags, args)
+}
+
+func (c USDCTokenPoolContract) SetChainRateLimiterConfig(opts *bind.TransactOpts, remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (*api.PendingTransaction, error) {
+	module, function, typeTags, args, err := c.usdcTokenPoolEncoder.SetChainRateLimiterConfig(remoteChainSelector, outboundIsEnabled, outboundCapacity, outboundRate, inboundIsEnabled, inboundCapacity, inboundRate)
 	if err != nil {
 		return nil, err
 	}
@@ -569,6 +636,22 @@ func (c usdcTokenPoolEncoder) GetDomain(chainSelector uint64) (bind.ModuleInform
 	})
 }
 
+func (c usdcTokenPoolEncoder) GetCurrentInboundRateLimiterState(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_current_inbound_rate_limiter_state", nil, []string{
+		"u64",
+	}, []any{
+		remoteChainSelector,
+	})
+}
+
+func (c usdcTokenPoolEncoder) GetCurrentOutboundRateLimiterState(remoteChainSelector uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("get_current_outbound_rate_limiter_state", nil, []string{
+		"u64",
+	}, []any{
+		remoteChainSelector,
+	})
+}
+
 func (c usdcTokenPoolEncoder) GetStoreAddress() (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
 	return c.BoundContract.Encode("get_store_address", nil, []string{}, []any{})
 }
@@ -618,6 +701,46 @@ func (c usdcTokenPoolEncoder) ApplyAllowlistUpdates(removes []aptos.AccountAddre
 	}, []any{
 		removes,
 		adds,
+	})
+}
+
+func (c usdcTokenPoolEncoder) SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("set_chain_rate_limiter_configs", nil, []string{
+		"vector<u64>",
+		"vector<bool>",
+		"vector<u64>",
+		"vector<u64>",
+		"vector<bool>",
+		"vector<u64>",
+		"vector<u64>",
+	}, []any{
+		remoteChainSelectors,
+		outboundIsEnableds,
+		outboundCapacities,
+		outboundRates,
+		inboundIsEnableds,
+		inboundCapacities,
+		inboundRates,
+	})
+}
+
+func (c usdcTokenPoolEncoder) SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
+	return c.BoundContract.Encode("set_chain_rate_limiter_config", nil, []string{
+		"u64",
+		"bool",
+		"u64",
+		"u64",
+		"bool",
+		"u64",
+		"u64",
+	}, []any{
+		remoteChainSelector,
+		outboundIsEnabled,
+		outboundCapacity,
+		outboundRate,
+		inboundIsEnabled,
+		inboundCapacity,
+		inboundRate,
 	})
 }
 
@@ -682,46 +805,6 @@ func (c usdcTokenPoolEncoder) SetDomains(remoteChainSelectors []uint64, remoteDo
 		remoteDomainIdentifiers,
 		allowedRemoteCallers,
 		enableds,
-	})
-}
-
-func (c usdcTokenPoolEncoder) SetChainRateLimiterConfigs(remoteChainSelectors []uint64, outboundIsEnableds []bool, outboundCapacities []uint64, outboundRates []uint64, inboundIsEnableds []bool, inboundCapacities []uint64, inboundRates []uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("set_chain_rate_limiter_configs", nil, []string{
-		"vector<u64>",
-		"vector<bool>",
-		"vector<u64>",
-		"vector<u64>",
-		"vector<bool>",
-		"vector<u64>",
-		"vector<u64>",
-	}, []any{
-		remoteChainSelectors,
-		outboundIsEnableds,
-		outboundCapacities,
-		outboundRates,
-		inboundIsEnableds,
-		inboundCapacities,
-		inboundRates,
-	})
-}
-
-func (c usdcTokenPoolEncoder) SetChainRateLimiterConfig(remoteChainSelector uint64, outboundIsEnabled bool, outboundCapacity uint64, outboundRate uint64, inboundIsEnabled bool, inboundCapacity uint64, inboundRate uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error) {
-	return c.BoundContract.Encode("set_chain_rate_limiter_config", nil, []string{
-		"u64",
-		"bool",
-		"u64",
-		"u64",
-		"bool",
-		"u64",
-		"u64",
-	}, []any{
-		remoteChainSelector,
-		outboundIsEnabled,
-		outboundCapacity,
-		outboundRate,
-		inboundIsEnabled,
-		inboundCapacity,
-		inboundRate,
 	})
 }
 

--- a/bindings/helpers/fungible_asset.go
+++ b/bindings/helpers/fungible_asset.go
@@ -45,3 +45,78 @@ func GetFungibleAssetBalance(
 	}
 	return balance, nil
 }
+
+type FungibleAssetMetadata struct {
+	Name       string
+	Symbol     string
+	Decimals   uint8
+	IconURI    string
+	ProjectURI string
+}
+
+func GetFungibleAssetMetadata(
+	client aptos.AptosRpcClient,
+	faMetadataAddress aptos.AccountAddress,
+) (FungibleAssetMetadata, error) {
+	bc := bind.NewBoundContract(
+		aptos.AccountOne,
+		"std",
+		"fungible_asset",
+		client,
+	)
+	module, function, typeTags, args, err := bc.Encode(
+		"metadata",
+		[]string{
+			"0x1::fungible_asset::Metadata",
+		},
+		[]string{
+			"address",
+		}, []any{
+			faMetadataAddress,
+		})
+	callData, err := bc.Call(nil, module, function, typeTags, args)
+	if err != nil {
+		return FungibleAssetMetadata{}, err
+	}
+
+	var metadata FungibleAssetMetadata
+	if err := codec.DecodeAptosJsonArray(callData, &metadata); err != nil {
+		return FungibleAssetMetadata{}, err
+	}
+	return metadata, nil
+}
+
+func GetFungibleAssetSupply(
+	client aptos.AptosRpcClient,
+	faMetadataAddress aptos.AccountAddress,
+) (uint64, error) {
+	bc := bind.NewBoundContract(
+		aptos.AccountOne,
+		"std",
+		"fungible_asset",
+		client,
+	)
+	module, function, typeTags, args, err := bc.Encode(
+		"supply",
+		[]string{
+			"0x1::fungible_asset::Metadata",
+		},
+		[]string{
+			"address",
+		}, []any{
+			faMetadataAddress,
+		})
+	if err != nil {
+		return 0, err
+	}
+	callData, err := bc.Call(nil, module, function, typeTags, args)
+	if err != nil {
+		return 0, err
+	}
+
+	var supply bind.StdOption[uint64]
+	if err := codec.DecodeAptosJsonArray(callData, &supply); err != nil {
+		return 0, err
+	}
+	return *supply.Value(), nil
+}

--- a/bindings/helpers/object.go
+++ b/bindings/helpers/object.go
@@ -1,0 +1,40 @@
+package helpers
+
+import (
+	"github.com/aptos-labs/aptos-go-sdk"
+
+	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	"github.com/smartcontractkit/chainlink-aptos/relayer/codec"
+)
+
+func GetObjectOwner(
+	client aptos.AptosRpcClient,
+	objectAddress aptos.AccountAddress,
+) (aptos.AccountAddress, error) {
+	bc := bind.NewBoundContract(
+		aptos.AccountOne,
+		"std",
+		"object",
+		client,
+	)
+	module, function, typeTags, args, err := bc.Encode(
+		"owner",
+		[]string{
+			"0x1::object::ObjectCore",
+		},
+		[]string{
+			"address",
+		}, []any{
+			objectAddress,
+		})
+	callData, err := bc.Call(nil, module, function, typeTags, args)
+	if err != nil {
+		return aptos.AccountAddress{}, err
+	}
+
+	var owner aptos.AccountAddress
+	if err := codec.DecodeAptosJsonArray(callData, &owner); err != nil {
+		return aptos.AccountAddress{}, err
+	}
+	return owner, nil
+}

--- a/contracts/ccip/ccip_router/sources/router.move
+++ b/contracts/ccip/ccip_router/sources/router.move
@@ -263,8 +263,7 @@ module ccip_router::router {
     #[view]
     /// Returns a list of configured destination chain selectors.
     public fun get_dest_chains(): vector<u64> acquires RouterState {
-        let state = borrow_state();
-        state.on_ramp_versions.keys()
+        borrow_state().on_ramp_versions.keys()
     }
 
     /// Sets the onRamp versions for the given destination chains.

--- a/contracts/ccip/ccip_router/sources/router.move
+++ b/contracts/ccip/ccip_router/sources/router.move
@@ -250,6 +250,23 @@ module ccip_router::router {
         }))
     }
 
+    #[view]
+    /// Returns the address of the onRamp that's set for the specified version.
+    /// Aborts if an invalid or unknown version is specified.
+    public fun get_on_ramp_for_version(on_ramp_version: vector<u8>): address {
+        if (on_ramp_version == vector[1, 6, 0]) {
+            return @ccip_onramp;
+        };
+        abort error::invalid_argument(E_INVALID_ON_RAMP_VERSION)
+    }
+
+    #[view]
+    /// Returns a list of configured destination chain selectors.
+    public fun get_dest_chains(): vector<u64> acquires RouterState {
+        let state = borrow_state();
+        state.on_ramp_versions.keys()
+    }
+
     /// Sets the onRamp versions for the given destination chains.
     /// This function will overwrite the existing versions.
     /// This function can only be called by the owner of the contract.

--- a/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
@@ -11,6 +11,7 @@ module burn_mint_token_pool::burn_mint_token_pool {
 
     use ccip::ownable;
     use ccip::token_admin_registry;
+    use ccip_token_pool::rate_limiter;
     use ccip_token_pool::token_pool;
 
     use mcms::mcms_registry;
@@ -361,7 +362,7 @@ module burn_mint_token_pool::burn_mint_token_pool {
     // |                    Rate limit config                         |
     // ================================================================
 
-    public fun set_chain_rate_limiter_configs(
+    public entry fun set_chain_rate_limiter_configs(
         caller: &signer,
         remote_chain_selectors: vector<u64>,
         outbound_is_enableds: vector<bool>,
@@ -400,7 +401,7 @@ module burn_mint_token_pool::burn_mint_token_pool {
         };
     }
 
-    public fun set_chain_rate_limiter_config(
+    public entry fun set_chain_rate_limiter_config(
         caller: &signer,
         remote_chain_selector: u64,
         outbound_is_enabled: bool,
@@ -423,6 +424,24 @@ module burn_mint_token_pool::burn_mint_token_pool {
             inbound_capacity,
             inbound_rate
         );
+    }
+
+    #[view]
+    public fun get_current_inbound_rate_limiter_state(
+        remote_chain_selector: u64
+    ): rate_limiter::TokenBucket acquires BurnMintTokenPoolState {
+        token_pool::get_current_inbound_rate_limiter_state(
+            &borrow_pool().token_pool_state, remote_chain_selector
+        )
+    }
+
+    #[view]
+    public fun get_current_outbound_rate_limiter_state(
+        remote_chain_selector: u64
+    ): rate_limiter::TokenBucket acquires BurnMintTokenPoolState {
+        token_pool::get_current_outbound_rate_limiter_state(
+            &borrow_pool().token_pool_state, remote_chain_selector
+        )
     }
 
     // ================================================================

--- a/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
@@ -11,6 +11,7 @@ module lock_release_token_pool::lock_release_token_pool {
 
     use ccip::ownable;
     use ccip::token_admin_registry;
+    use ccip_token_pool::rate_limiter;
     use ccip_token_pool::token_pool;
 
     use mcms::mcms_registry;
@@ -424,7 +425,7 @@ module lock_release_token_pool::lock_release_token_pool {
     // |                    Rate limit config                         |
     // ================================================================
 
-    public fun set_chain_rate_limiter_configs(
+    public entry fun set_chain_rate_limiter_configs(
         caller: &signer,
         remote_chain_selectors: vector<u64>,
         outbound_is_enableds: vector<bool>,
@@ -463,7 +464,7 @@ module lock_release_token_pool::lock_release_token_pool {
         };
     }
 
-    public fun set_chain_rate_limiter_config(
+    public entry fun set_chain_rate_limiter_config(
         caller: &signer,
         remote_chain_selector: u64,
         outbound_is_enabled: bool,
@@ -486,6 +487,24 @@ module lock_release_token_pool::lock_release_token_pool {
             inbound_capacity,
             inbound_rate
         );
+    }
+
+    #[view]
+    public fun get_current_inbound_rate_limiter_state(
+        remote_chain_selector: u64
+    ): rate_limiter::TokenBucket acquires LockReleaseTokenPoolState {
+        token_pool::get_current_inbound_rate_limiter_state(
+            &borrow_pool().token_pool_state, remote_chain_selector
+        )
+    }
+
+    #[view]
+    public fun get_current_outbound_rate_limiter_state(
+        remote_chain_selector: u64
+    ): rate_limiter::TokenBucket acquires LockReleaseTokenPoolState {
+        token_pool::get_current_outbound_rate_limiter_state(
+            &borrow_pool().token_pool_state, remote_chain_selector
+        )
     }
 
     // ================================================================

--- a/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
@@ -3,7 +3,7 @@ module managed_token_pool::managed_token_pool {
     use std::error;
     use std::fungible_asset::{Self, FungibleAsset, Metadata, TransferRef};
     use std::primary_fungible_store;
-    use std::object::{Self, Object, ObjectCore};
+    use std::object::{Self, Object};
     use std::option;
     use std::signer;
     use std::string::{Self, String};
@@ -12,6 +12,7 @@ module managed_token_pool::managed_token_pool {
 
     use ccip::ownable;
     use ccip::token_admin_registry;
+    use ccip_token_pool::rate_limiter;
     use ccip_token_pool::token_pool;
 
     use mcms::mcms_registry;
@@ -326,7 +327,7 @@ module managed_token_pool::managed_token_pool {
     // |                    Rate limit config                         |
     // ================================================================
 
-    public fun set_chain_rate_limiter_configs(
+    public entry fun set_chain_rate_limiter_configs(
         caller: &signer,
         remote_chain_selectors: vector<u64>,
         outbound_is_enableds: vector<bool>,
@@ -365,7 +366,7 @@ module managed_token_pool::managed_token_pool {
         };
     }
 
-    public fun set_chain_rate_limiter_config(
+    public entry fun set_chain_rate_limiter_config(
         caller: &signer,
         remote_chain_selector: u64,
         outbound_is_enabled: bool,
@@ -388,6 +389,24 @@ module managed_token_pool::managed_token_pool {
             inbound_capacity,
             inbound_rate
         );
+    }
+
+    #[view]
+    public fun get_current_inbound_rate_limiter_state(
+        remote_chain_selector: u64
+    ): rate_limiter::TokenBucket acquires ManagedTokenPoolState {
+        token_pool::get_current_inbound_rate_limiter_state(
+            &borrow_pool().token_pool_state, remote_chain_selector
+        )
+    }
+
+    #[view]
+    public fun get_current_outbound_rate_limiter_state(
+        remote_chain_selector: u64
+    ): rate_limiter::TokenBucket acquires ManagedTokenPoolState {
+        token_pool::get_current_outbound_rate_limiter_state(
+            &borrow_pool().token_pool_state, remote_chain_selector
+        )
     }
 
     // ================================================================

--- a/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool.move
+++ b/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool.move
@@ -12,6 +12,7 @@ module ccip_token_pool::token_pool {
     use ccip::rmn_remote;
     use ccip::allowlist;
 
+    use ccip_token_pool::rate_limiter;
     use ccip_token_pool::token_pool_rate_limiter;
 
     const STORE_OBJECT_SEED: vector<u8> = b"CCIPTokenPool";
@@ -620,6 +621,22 @@ module ccip_token_pool::token_pool {
             inbound_capacity,
             inbound_rate
         );
+    }
+
+    public fun get_current_inbound_rate_limiter_state(
+        state: &TokenPoolState, remote_chain_selector: u64
+    ): rate_limiter::TokenBucket {
+        token_pool_rate_limiter::get_current_inbound_rate_limiter_state(
+            &state.rate_limiter_config, remote_chain_selector
+        )
+    }
+
+    public fun get_current_outbound_rate_limiter_state(
+        state: &TokenPoolState, remote_chain_selector: u64
+    ): rate_limiter::TokenBucket {
+        token_pool_rate_limiter::get_current_outbound_rate_limiter_state(
+            &state.rate_limiter_config, remote_chain_selector
+        )
     }
 
     // ================================================================

--- a/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool_rate_limiter.move
+++ b/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool_rate_limiter.move
@@ -151,6 +151,22 @@ module ccip_token_pool::token_pool_rate_limiter {
         );
     }
 
+    public fun get_current_inbound_rate_limiter_state(
+        state: &RateLimitState, remote_chain_selector: u64
+    ): rate_limiter::TokenBucket {
+        rate_limiter::get_current_token_bucket_state(
+            state.inbound_rate_limiter_config.borrow(remote_chain_selector)
+        )
+    }
+
+    public fun get_current_outbound_rate_limiter_state(
+        state: &RateLimitState, remote_chain_selector: u64
+    ): rate_limiter::TokenBucket {
+        rate_limiter::get_current_token_bucket_state(
+            state.outbound_rate_limiter_config.borrow(remote_chain_selector)
+        )
+    }
+
     public fun destroy_rate_limiter(state: RateLimitState) {
         let RateLimitState {
             outbound_rate_limiter_config,

--- a/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
@@ -15,6 +15,7 @@ module usdc_token_pool::usdc_token_pool {
     use ccip::eth_abi;
     use ccip::ownable;
     use ccip::token_admin_registry;
+    use ccip_token_pool::rate_limiter;
     use ccip_token_pool::token_pool;
 
     use mcms::bcs_stream;
@@ -571,7 +572,7 @@ module usdc_token_pool::usdc_token_pool {
     // |                    Rate limit config                         |
     // ================================================================
 
-    public fun set_chain_rate_limiter_configs(
+    public entry fun set_chain_rate_limiter_configs(
         caller: &signer,
         remote_chain_selectors: vector<u64>,
         outbound_is_enableds: vector<bool>,
@@ -610,7 +611,7 @@ module usdc_token_pool::usdc_token_pool {
         };
     }
 
-    public fun set_chain_rate_limiter_config(
+    public entry fun set_chain_rate_limiter_config(
         caller: &signer,
         remote_chain_selector: u64,
         outbound_is_enabled: bool,
@@ -633,6 +634,24 @@ module usdc_token_pool::usdc_token_pool {
             inbound_capacity,
             inbound_rate
         );
+    }
+
+    #[view]
+    public fun get_current_inbound_rate_limiter_state(
+        remote_chain_selector: u64
+    ): rate_limiter::TokenBucket acquires USDCTokenPoolState {
+        token_pool::get_current_inbound_rate_limiter_state(
+            &borrow_pool().token_pool_state, remote_chain_selector
+        )
+    }
+
+    #[view]
+    public fun get_current_outbound_rate_limiter_state(
+        remote_chain_selector: u64
+    ): rate_limiter::TokenBucket acquires USDCTokenPoolState {
+        token_pool::get_current_outbound_rate_limiter_state(
+            &borrow_pool().token_pool_state, remote_chain_selector
+        )
     }
 
     // ================================================================

--- a/gen.go
+++ b/gen.go
@@ -19,10 +19,10 @@ package aptos
 //go:generate go run ./cmd/bindgen --input ./contracts/ccip/ccip_router/sources/router.move --output ./bindings/ccip_router/router
 //go:generate go run ./cmd/bindgen --input ./contracts/ccip/ccip_dummy_receiver/sources/dummy_receiver.move --output ./bindings/ccip_dummy_receiver/dummy_receiver
 
-//go:generate go run ./cmd/bindgen --input ./contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move --output ./bindings/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool
-//go:generate go run ./cmd/bindgen --input ./contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move --output ./bindings/ccip_token_pools/lock_release_token_pool/lock_release_token_pool
-//go:generate go run ./cmd/bindgen --input ./contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move --output ./bindings/ccip_token_pools/usdc_token_pool/usdc_token_pool
-//go:generate go run ./cmd/bindgen --input ./contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move --output ./bindings/ccip_token_pools/managed_token_pool/managed_token_pool
+//go:generate go run ./cmd/bindgen --input ./contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move --output ./bindings/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool --externalStructs ccip_token_pool::rate_limiter::TokenBucket=github.com/smartcontractkit/chainlink-aptos/bindings/ccip_token_pools/token_pool/rate_limiter
+//go:generate go run ./cmd/bindgen --input ./contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move --output ./bindings/ccip_token_pools/lock_release_token_pool/lock_release_token_pool --externalStructs ccip_token_pool::rate_limiter::TokenBucket=github.com/smartcontractkit/chainlink-aptos/bindings/ccip_token_pools/token_pool/rate_limiter
+//go:generate go run ./cmd/bindgen --input ./contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move --output ./bindings/ccip_token_pools/usdc_token_pool/usdc_token_pool --externalStructs ccip_token_pool::rate_limiter::TokenBucket=github.com/smartcontractkit/chainlink-aptos/bindings/ccip_token_pools/token_pool/rate_limiter
+//go:generate go run ./cmd/bindgen --input ./contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move --output ./bindings/ccip_token_pools/managed_token_pool/managed_token_pool --externalStructs ccip_token_pool::rate_limiter::TokenBucket=github.com/smartcontractkit/chainlink-aptos/bindings/ccip_token_pools/token_pool/rate_limiter
 
 //go:generate go run ./cmd/bindgen --input ./contracts/ccip/ccip_token_pools/token_pool/sources/rate_limiter.move --output ./bindings/ccip_token_pools/token_pool/rate_limiter
 //go:generate go run ./cmd/bindgen --input ./contracts/ccip/ccip_token_pools/token_pool/sources/token_pool.move --output ./bindings/ccip_token_pools/token_pool/token_pool


### PR DESCRIPTION
This:
- Adds view helper functions to be able to query onramps and rate limiter states
- Changes the `set_chain_rate_limiter_configs` and `set_chain_rate_limiter_config` methods on the token pool implementations to entry funcs