### PR TITLE
Migrate SmartTable to BigOrderedMap

### DIFF
--- a/bindings/ccip/fee_quoter/fee_quoter.go
+++ b/bindings/ccip/fee_quoter/fee_quoter.go
@@ -99,6 +99,9 @@ type FeeQuoterState struct {
 	FeeTokens                    []aptos.AccountAddress `move:"vector<address>"`
 }
 
+type FeeQuoterEvents struct {
+}
+
 type StaticConfig struct {
 	MaxFeeJuelsPerMsg            *big.Int             `move:"u256"`
 	LinkToken                    aptos.AccountAddress `move:"address"`

--- a/contracts/ccip/ccip/sources/fee_quoter.move
+++ b/contracts/ccip/ccip/sources/fee_quoter.move
@@ -10,7 +10,7 @@ module ccip::fee_quoter {
     use std::option;
     use std::signer;
     use std::string::{Self, String};
-    use std::smart_table::{Self, SmartTable};
+    use std::big_ordered_map::{Self, BigOrderedMap};
     use std::timestamp;
 
     use ccip::auth;
@@ -87,19 +87,25 @@ module ccip::fee_quoter {
     // the fee by 1e8 on Aptos before we emit it in the event.
     const LOCAL_8_TO_18_DECIMALS_LINK_MULTIPLIER: u256 = 10_000_000_000;
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct FeeQuoterState has key, store {
         // max_fee_juels_per_msg is in juels (1e18) denomination for consistency across chains.
         max_fee_juels_per_msg: u256,
         link_token: address,
         token_price_staleness_threshold: u64,
         fee_tokens: vector<address>,
-        usd_per_unit_gas_by_dest_chain: SmartTable<u64, TimestampedPrice>,
-        usd_per_token: SmartTable<address, TimestampedPrice>,
-        dest_chain_configs: SmartTable<u64, DestChainConfig>,
+        usd_per_unit_gas_by_dest_chain: BigOrderedMap<u64, TimestampedPrice>,
+        usd_per_token: BigOrderedMap<address, TimestampedPrice>,
+        dest_chain_configs: BigOrderedMap<u64, DestChainConfig>,
         // dest chain selector -> local token -> TokenTransferFeeConfig
-        token_transfer_fee_configs: SmartTable<u64, SmartTable<address, TokenTransferFeeConfig>>,
+        token_transfer_fee_configs: BigOrderedMap<u64, BigOrderedMap<address, TokenTransferFeeConfig>>,
         // TODO: update calculations - should this be octa per apt?
-        premium_multiplier_wei_per_eth: SmartTable<address, u64>,
+        premium_multiplier_wei_per_eth: BigOrderedMap<address, u64>
+    }
+
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    /// Separate struct to avoid hitting `layout_max_size` limit in VM.
+    struct FeeQuoterEvents has key, store {
         fee_token_added_events: EventHandle<FeeTokenAdded>,
         fee_token_removed_events: EventHandle<FeeTokenRemoved>,
         token_transfer_fee_config_added_events: EventHandle<TokenTransferFeeConfigAdded>,
@@ -287,11 +293,15 @@ module ccip::fee_quoter {
             link_token,
             token_price_staleness_threshold,
             fee_tokens,
-            usd_per_unit_gas_by_dest_chain: smart_table::new(),
-            usd_per_token: smart_table::new(),
-            dest_chain_configs: smart_table::new(),
-            token_transfer_fee_configs: smart_table::new(),
-            premium_multiplier_wei_per_eth: smart_table::new(),
+            usd_per_unit_gas_by_dest_chain: big_ordered_map::new_with_config(0, 0, false),
+            usd_per_token: big_ordered_map::new_with_config(0, 0, false),
+            dest_chain_configs: big_ordered_map::new_with_config(0, 0, false),
+            token_transfer_fee_configs: big_ordered_map::new_with_config(0, 0, false),
+            premium_multiplier_wei_per_eth: big_ordered_map::new_with_config(0, 0, false)
+        };
+        move_to(&state_object_signer, state);
+
+        let events = FeeQuoterEvents {
             fee_token_added_events: account::new_event_handle(&state_object_signer),
             fee_token_removed_events: account::new_event_handle(&state_object_signer),
             token_transfer_fee_config_added_events: account::new_event_handle(
@@ -312,7 +322,7 @@ module ccip::fee_quoter {
                 &state_object_signer
             )
         };
-        move_to(&state_object_signer, state);
+        move_to(&state_object_signer, events);
     }
 
     #[view]
@@ -384,7 +394,7 @@ module ccip::fee_quoter {
         caller: &signer,
         fee_tokens_to_remove: vector<address>,
         fee_tokens_to_add: vector<address>
-    ) acquires FeeQuoterState {
+    ) acquires FeeQuoterState, FeeQuoterEvents {
         auth::assert_only_owner(signer::address_of(caller));
 
         let state = borrow_state_mut();
@@ -397,7 +407,8 @@ module ccip::fee_quoter {
                 state.fee_tokens.remove(index);
                 event::emit(FeeTokenRemoved { fee_token });
                 event::emit_event(
-                    &mut state.fee_token_removed_events, FeeTokenRemoved { fee_token }
+                    &mut borrow_events_mut().fee_token_removed_events,
+                    FeeTokenRemoved { fee_token }
                 );
             };
         });
@@ -410,7 +421,8 @@ module ccip::fee_quoter {
                 state.fee_tokens.push_back(fee_token);
                 event::emit(FeeTokenAdded { fee_token });
                 event::emit_event(
-                    &mut state.fee_token_added_events, FeeTokenAdded { fee_token }
+                    &mut borrow_events_mut().fee_token_added_events,
+                    FeeTokenAdded { fee_token }
                 );
             };
         });
@@ -438,13 +450,16 @@ module ccip::fee_quoter {
                 is_enabled: false
             };
 
-        if (!state.token_transfer_fee_configs.contains(dest_chain_selector)) {
+        if (!state.token_transfer_fee_configs.contains(&dest_chain_selector)) {
             &empty_fee_config
         } else {
             let dest_chain_fee_configs =
-                state.token_transfer_fee_configs.borrow(dest_chain_selector);
-
-            dest_chain_fee_configs.borrow_with_default(token, &empty_fee_config)
+                state.token_transfer_fee_configs.borrow(&dest_chain_selector);
+            if (dest_chain_fee_configs.contains(&token)) {
+                dest_chain_fee_configs.borrow(&token)
+            } else {
+                &empty_fee_config
+            }
         }
     }
 
@@ -461,16 +476,18 @@ module ccip::fee_quoter {
         add_dest_bytes_overhead: vector<u32>,
         add_is_enabled: vector<bool>,
         remove_tokens: vector<address>
-    ) acquires FeeQuoterState {
+    ) acquires FeeQuoterState, FeeQuoterEvents {
         auth::assert_only_owner(signer::address_of(caller));
 
         let state = borrow_state_mut();
 
-        if (!state.token_transfer_fee_configs.contains(dest_chain_selector)) {
-            state.token_transfer_fee_configs.add(dest_chain_selector, smart_table::new());
-        };
         let token_transfer_fee_configs =
-            state.token_transfer_fee_configs.borrow_mut(dest_chain_selector);
+            if (state.token_transfer_fee_configs.contains(&dest_chain_selector)) {
+                // Use `remove` and `add` instead of mutable borrow.
+                state.token_transfer_fee_configs.remove(&dest_chain_selector)
+            } else {
+                big_ordered_map::new_with_config(0, 0, false)
+            };
 
         let add_tokens_len = add_tokens.length();
         assert!(
@@ -535,7 +552,7 @@ module ccip::fee_quoter {
                 }
             );
             event::emit_event(
-                &mut state.token_transfer_fee_config_added_events,
+                &mut borrow_events_mut().token_transfer_fee_config_added_events,
                 TokenTransferFeeConfigAdded {
                     dest_chain_selector,
                     token,
@@ -547,18 +564,22 @@ module ccip::fee_quoter {
         remove_tokens.for_each_ref(
             |token| {
                 let token: address = *token;
-                if (token_transfer_fee_configs.contains(token)) {
-                    token_transfer_fee_configs.remove(token);
+                if (token_transfer_fee_configs.contains(&token)) {
+                    token_transfer_fee_configs.remove(&token);
 
                     event::emit(
                         TokenTransferFeeConfigRemoved { dest_chain_selector, token }
                     );
                     event::emit_event(
-                        &mut state.token_transfer_fee_config_removed_events,
+                        &mut borrow_events_mut().token_transfer_fee_config_removed_events,
                         TokenTransferFeeConfigRemoved { dest_chain_selector, token }
                     );
                 }
             }
+        );
+
+        state.token_transfer_fee_configs.add(
+            dest_chain_selector, token_transfer_fee_configs
         );
     }
 
@@ -568,7 +589,7 @@ module ccip::fee_quoter {
         source_usd_per_token: vector<u256>,
         gas_dest_chain_selectors: vector<u64>,
         gas_usd_per_unit_gas: vector<u256>
-    ) acquires FeeQuoterState {
+    ) acquires FeeQuoterState, FeeQuoterEvents {
         auth::assert_is_allowed_offramp(signer::address_of(caller));
 
         assert!(
@@ -599,7 +620,7 @@ module ccip::fee_quoter {
                     }
                 );
                 event::emit_event(
-                    &mut state.usd_per_token_updated_events,
+                    &mut borrow_events_mut().usd_per_token_updated_events,
                     UsdPerTokenUpdated {
                         token: *token,
                         usd_per_token: *usd_per_token,
@@ -626,7 +647,7 @@ module ccip::fee_quoter {
                     }
                 );
                 event::emit_event(
-                    &mut state.usd_per_unit_gas_updated_events,
+                    &mut borrow_events_mut().usd_per_unit_gas_updated_events,
                     UsdPerUnitGasUpdated {
                         dest_chain_selector: *dest_chain_selector,
                         usd_per_unit_gas: *usd_per_unit_gas,
@@ -780,7 +801,7 @@ module ccip::fee_quoter {
         caller: &signer,
         tokens: vector<address>,
         premium_multiplier_wei_per_eth: vector<u64>
-    ) acquires FeeQuoterState {
+    ) acquires FeeQuoterState, FeeQuoterEvents {
         auth::assert_only_owner(signer::address_of(caller));
 
         let state = borrow_state_mut();
@@ -800,7 +821,7 @@ module ccip::fee_quoter {
                     }
                 );
                 event::emit_event(
-                    &mut state.premium_multiplier_wei_per_eth_updated_events,
+                    &mut borrow_events_mut().premium_multiplier_wei_per_eth_updated_events,
                     PremiumMultiplierWeiPerEthUpdated {
                         token,
                         premium_multiplier_wei_per_eth
@@ -820,10 +841,10 @@ module ccip::fee_quoter {
         state: &FeeQuoterState, token: address
     ): u64 {
         assert!(
-            state.premium_multiplier_wei_per_eth.contains(token),
+            state.premium_multiplier_wei_per_eth.contains(&token),
             error::invalid_argument(E_UNKNOWN_TOKEN)
         );
-        *state.premium_multiplier_wei_per_eth.borrow(token)
+        *state.premium_multiplier_wei_per_eth.borrow(&token)
     }
 
     inline fun resolve_generic_gas_limit(
@@ -1307,10 +1328,10 @@ module ccip::fee_quoter {
         state: &FeeQuoterState, dest_chain_selector: u64
     ): &DestChainConfig {
         assert!(
-            state.dest_chain_configs.contains(dest_chain_selector),
+            state.dest_chain_configs.contains(&dest_chain_selector),
             error::invalid_argument(E_UNKNOWN_DEST_CHAIN_SELECTOR)
         );
-        state.dest_chain_configs.borrow(dest_chain_selector)
+        state.dest_chain_configs.borrow(&dest_chain_selector)
     }
 
     public entry fun apply_dest_chain_config_updates(
@@ -1335,7 +1356,7 @@ module ccip::fee_quoter {
         gas_multiplier_wei_per_eth: u64,
         gas_price_staleness_threshold: u32,
         network_fee_usd_cents: u32
-    ) acquires FeeQuoterState {
+    ) acquires FeeQuoterState, FeeQuoterEvents {
         auth::assert_only_owner(signer::address_of(caller));
 
         let state = borrow_state_mut();
@@ -1379,20 +1400,19 @@ module ccip::fee_quoter {
             network_fee_usd_cents
         };
 
-        if (state.dest_chain_configs.contains(dest_chain_selector)) {
-            let dest_chain_config_ref =
-                state.dest_chain_configs.borrow_mut(dest_chain_selector);
-            *dest_chain_config_ref = dest_chain_config;
+        if (state.dest_chain_configs.contains(&dest_chain_selector)) {
+            // Use upsert pattern since DestChainConfig has variable-size field (chain_family_selector: vector<u8>)
+            state.dest_chain_configs.upsert(dest_chain_selector, dest_chain_config);
             event::emit(DestChainConfigUpdated { dest_chain_selector, dest_chain_config });
             event::emit_event(
-                &mut state.dest_chain_config_updated_events,
+                &mut borrow_events_mut().dest_chain_config_updated_events,
                 DestChainConfigUpdated { dest_chain_selector, dest_chain_config }
             );
         } else {
             state.dest_chain_configs.add(dest_chain_selector, dest_chain_config);
             event::emit(DestChainAdded { dest_chain_selector, dest_chain_config });
             event::emit_event(
-                &mut state.dest_chain_added_events,
+                &mut borrow_events_mut().dest_chain_added_events,
                 DestChainAdded { dest_chain_selector, dest_chain_config }
             );
         }
@@ -1416,26 +1436,30 @@ module ccip::fee_quoter {
         borrow_global_mut<FeeQuoterState>(state_object::object_address())
     }
 
+    inline fun borrow_events_mut(): &mut FeeQuoterEvents {
+        borrow_global_mut<FeeQuoterEvents>(state_object::object_address())
+    }
+
     // Token prices can be stale. On EVM we have additional fallbacks to a price feed, if configured. Since these
     // fallbacks don't exist on Aptos, we simply return the price as is.
     inline fun get_token_price_internal(
         state: &FeeQuoterState, token: address
     ): TimestampedPrice {
         assert!(
-            state.usd_per_token.contains(token),
+            state.usd_per_token.contains(&token),
             error::invalid_argument(E_UNKNOWN_TOKEN)
         );
-        *state.usd_per_token.borrow(token)
+        *state.usd_per_token.borrow(&token)
     }
 
     inline fun get_dest_chain_gas_price_internal(
         state: &FeeQuoterState, dest_chain_selector: u64
     ): TimestampedPrice {
         assert!(
-            state.usd_per_unit_gas_by_dest_chain.contains(dest_chain_selector),
+            state.usd_per_unit_gas_by_dest_chain.contains(&dest_chain_selector),
             error::invalid_argument(E_UNKNOWN_DEST_CHAIN_SELECTOR)
         );
-        *state.usd_per_unit_gas_by_dest_chain.borrow(dest_chain_selector)
+        *state.usd_per_unit_gas_by_dest_chain.borrow(&dest_chain_selector)
     }
 
     inline fun get_validated_gas_price_internal(
@@ -1546,7 +1570,7 @@ module ccip::fee_quoter {
 
     public fun mcms_entrypoint<T: key>(
         _metadata: object::Object<T>
-    ): option::Option<u128> acquires FeeQuoterState {
+    ): option::Option<u128> acquires FeeQuoterState, FeeQuoterEvents {
         let (caller, function, data) =
             mcms_registry::get_callback_params(@ccip, McmsCallback {});
 

--- a/contracts/ccip/ccip/sources/fee_quoter.move
+++ b/contracts/ccip/ccip/sources/fee_quoter.move
@@ -17,6 +17,7 @@ module ccip::fee_quoter {
     use ccip::client;
     use ccip::eth_abi;
     use ccip::state_object;
+    use ccip::safe_big_ordered_map;
 
     use mcms::bcs_stream;
     use mcms::mcms_registry;
@@ -440,26 +441,24 @@ module ccip::fee_quoter {
     inline fun get_token_transfer_fee_config_internal(
         state: &FeeQuoterState, dest_chain_selector: u64, token: address
     ): &TokenTransferFeeConfig {
-        let empty_fee_config =
-            TokenTransferFeeConfig {
-                min_fee_usd_cents: 0,
-                max_fee_usd_cents: 0,
-                deci_bps: 0,
-                dest_gas_overhead: 0,
-                dest_bytes_overhead: 0,
-                is_enabled: false
-            };
+        let empty_fee_config = TokenTransferFeeConfig {
+            min_fee_usd_cents: 0,
+            max_fee_usd_cents: 0,
+            deci_bps: 0,
+            dest_gas_overhead: 0,
+            dest_bytes_overhead: 0,
+            is_enabled: false
+        };
 
         if (!state.token_transfer_fee_configs.contains(&dest_chain_selector)) {
             &empty_fee_config
         } else {
-            let dest_chain_fee_configs =
-                state.token_transfer_fee_configs.borrow(&dest_chain_selector);
-            if (dest_chain_fee_configs.contains(&token)) {
-                dest_chain_fee_configs.borrow(&token)
-            } else {
+            safe_big_ordered_map::nested_borrow_with_default(
+                &state.token_transfer_fee_configs,
+                &dest_chain_selector,
+                &token,
                 &empty_fee_config
-            }
+            )
         }
     }
 
@@ -480,14 +479,6 @@ module ccip::fee_quoter {
         auth::assert_only_owner(signer::address_of(caller));
 
         let state = borrow_state_mut();
-
-        let token_transfer_fee_configs =
-            if (state.token_transfer_fee_configs.contains(&dest_chain_selector)) {
-                // Use `remove` and `add` instead of mutable borrow.
-                state.token_transfer_fee_configs.remove(&dest_chain_selector)
-            } else {
-                big_ordered_map::new_with_config(0, 0, false)
-            };
 
         let add_tokens_len = add_tokens.length();
         assert!(
@@ -515,71 +506,76 @@ module ccip::fee_quoter {
             error::invalid_argument(E_TOKEN_TRANSFER_FEE_CONFIG_MISMATCH)
         );
 
-        for (i in 0..add_tokens_len) {
-            let token = add_tokens[i];
-            let min_fee_usd_cents = add_min_fee_usd_cents[i];
-            let max_fee_usd_cents = add_max_fee_usd_cents[i];
-            let deci_bps = add_deci_bps[i];
-            let dest_gas_overhead = add_dest_gas_overhead[i];
-            let dest_bytes_overhead = add_dest_bytes_overhead[i];
-            let is_enabled = add_is_enabled[i];
+        // Modify token_transfer_fee_configs, safely using the wrapper which removes and re-adds the inner map
+        safe_big_ordered_map::nested_modify_inner_map(
+            &mut state.token_transfer_fee_configs,
+            dest_chain_selector,
+            |token_configs| {
+                // Add new token configurations
+                for (i in 0..add_tokens_len) {
+                    let token = add_tokens[i];
+                    let min_fee_usd_cents = add_min_fee_usd_cents[i];
+                    let max_fee_usd_cents = add_max_fee_usd_cents[i];
+                    let deci_bps = add_deci_bps[i];
+                    let dest_gas_overhead = add_dest_gas_overhead[i];
+                    let dest_bytes_overhead = add_dest_bytes_overhead[i];
+                    let is_enabled = add_is_enabled[i];
 
-            let token_transfer_fee_config = TokenTransferFeeConfig {
-                min_fee_usd_cents,
-                max_fee_usd_cents,
-                deci_bps,
-                dest_gas_overhead,
-                dest_bytes_overhead,
-                is_enabled
-            };
+                    let token_transfer_fee_config = TokenTransferFeeConfig {
+                        min_fee_usd_cents,
+                        max_fee_usd_cents,
+                        deci_bps,
+                        dest_gas_overhead,
+                        dest_bytes_overhead,
+                        is_enabled
+                    };
 
-            if (token_transfer_fee_config.min_fee_usd_cents
-                >= token_transfer_fee_config.max_fee_usd_cents) {
-                abort error::invalid_argument(E_INVALID_FEE_RANGE);
-            };
-            if (token_transfer_fee_config.dest_bytes_overhead
-                < CCIP_LOCK_OR_BURN_V1_RET_BYTES) {
-                abort error::invalid_argument(E_INVALID_DEST_BYTES_OVERHEAD);
-            };
+                    if (token_transfer_fee_config.min_fee_usd_cents
+                        >= token_transfer_fee_config.max_fee_usd_cents) {
+                        abort error::invalid_argument(E_INVALID_FEE_RANGE);
+                    };
+                    if (token_transfer_fee_config.dest_bytes_overhead
+                        < CCIP_LOCK_OR_BURN_V1_RET_BYTES) {
+                        abort error::invalid_argument(E_INVALID_DEST_BYTES_OVERHEAD);
+                    };
 
-            token_transfer_fee_configs.upsert(token, token_transfer_fee_config);
-
-            event::emit(
-                TokenTransferFeeConfigAdded {
-                    dest_chain_selector,
-                    token,
-                    token_transfer_fee_config
-                }
-            );
-            event::emit_event(
-                &mut borrow_events_mut().token_transfer_fee_config_added_events,
-                TokenTransferFeeConfigAdded {
-                    dest_chain_selector,
-                    token,
-                    token_transfer_fee_config
-                }
-            );
-        };
-
-        remove_tokens.for_each_ref(
-            |token| {
-                let token: address = *token;
-                if (token_transfer_fee_configs.contains(&token)) {
-                    token_transfer_fee_configs.remove(&token);
+                    token_configs.upsert(token, token_transfer_fee_config);
 
                     event::emit(
-                        TokenTransferFeeConfigRemoved { dest_chain_selector, token }
+                        TokenTransferFeeConfigAdded {
+                            dest_chain_selector,
+                            token,
+                            token_transfer_fee_config
+                        }
                     );
                     event::emit_event(
-                        &mut borrow_events_mut().token_transfer_fee_config_removed_events,
-                        TokenTransferFeeConfigRemoved { dest_chain_selector, token }
+                        &mut borrow_events_mut().token_transfer_fee_config_added_events,
+                        TokenTransferFeeConfigAdded {
+                            dest_chain_selector,
+                            token,
+                            token_transfer_fee_config
+                        }
                     );
-                }
-            }
-        );
+                };
 
-        state.token_transfer_fee_configs.add(
-            dest_chain_selector, token_transfer_fee_configs
+                // Remove token configurations
+                remove_tokens.for_each_ref(
+                    |token| {
+                        let token: address = *token;
+                        if (token_configs.contains(&token)) {
+                            token_configs.remove(&token);
+
+                            event::emit(
+                                TokenTransferFeeConfigRemoved { dest_chain_selector, token }
+                            );
+                            event::emit_event(
+                                &mut borrow_events_mut().token_transfer_fee_config_removed_events,
+                                TokenTransferFeeConfigRemoved { dest_chain_selector, token }
+                            );
+                        }
+                    }
+                );
+            }
         );
     }
 

--- a/contracts/ccip/ccip/sources/nonce_manager.move
+++ b/contracts/ccip/ccip/sources/nonce_manager.move
@@ -1,6 +1,6 @@
 module ccip::nonce_manager {
     use std::signer;
-    use std::smart_table::{Self, SmartTable};
+    use std::big_ordered_map::{Self, BigOrderedMap};
     use std::string::{Self, String};
 
     use ccip::auth;
@@ -8,7 +8,7 @@ module ccip::nonce_manager {
 
     struct NonceManagerState has key, store {
         // dest chain selector -> sender -> nonce
-        outbound_nonces: SmartTable<u64, SmartTable<address, u64>>
+        outbound_nonces: BigOrderedMap<u64, BigOrderedMap<address, u64>>
     }
 
     #[view]
@@ -21,7 +21,9 @@ module ccip::nonce_manager {
 
         move_to(
             &state_object_signer,
-            NonceManagerState { outbound_nonces: smart_table::new() }
+            NonceManagerState {
+                outbound_nonces: big_ordered_map::new_with_config(0, 0, false)
+            }
         );
     }
 
@@ -31,12 +33,15 @@ module ccip::nonce_manager {
     ): u64 acquires NonceManagerState {
         let state = borrow_state();
 
-        if (!state.outbound_nonces.contains(dest_chain_selector)) {
+        if (!state.outbound_nonces.contains(&dest_chain_selector)) {
             return 0;
         };
 
-        let dest_chain_nonces = state.outbound_nonces.borrow(dest_chain_selector);
-        *dest_chain_nonces.borrow_with_default(sender, &0)
+        let dest_chain_nonces = state.outbound_nonces.borrow(&dest_chain_selector);
+        if (!dest_chain_nonces.contains(&sender)) {
+            return 0;
+        };
+        *dest_chain_nonces.borrow(&sender)
     }
 
     public fun get_incremented_outbound_nonce(
@@ -46,12 +51,17 @@ module ccip::nonce_manager {
 
         let state = borrow_state_mut();
 
-        if (!state.outbound_nonces.contains(dest_chain_selector)) {
-            state.outbound_nonces.add(dest_chain_selector, smart_table::new());
+        if (!state.outbound_nonces.contains(&dest_chain_selector)) {
+            state.outbound_nonces.add(
+                dest_chain_selector, big_ordered_map::new_with_config(0, 0, false)
+            );
         };
 
-        let dest_chain_nonces = state.outbound_nonces.borrow_mut(dest_chain_selector);
-        let nonce_ref = dest_chain_nonces.borrow_mut_with_default(sender, 0);
+        let dest_chain_nonces = state.outbound_nonces.borrow_mut(&dest_chain_selector);
+        if (!dest_chain_nonces.contains(&sender)) {
+            dest_chain_nonces.add(sender, 0);
+        };
+        let nonce_ref = dest_chain_nonces.borrow_mut(&sender);
         let incremented_nonce = *nonce_ref + 1;
         *nonce_ref = incremented_nonce;
         incremented_nonce

--- a/contracts/ccip/ccip/sources/rmn_remote.move
+++ b/contracts/ccip/ccip/sources/rmn_remote.move
@@ -10,7 +10,7 @@ module ccip::rmn_remote {
     use std::secp256k1;
     use std::signer;
     use std::string::{Self, String};
-    use std::smart_table::{Self, SmartTable};
+    use std::big_ordered_map::{Self, BigOrderedMap};
 
     use ccip::auth;
     use ccip::eth_abi;
@@ -26,8 +26,8 @@ module ccip::rmn_remote {
         local_chain_selector: u64,
         config: Config,
         config_count: u32,
-        signers: SmartTable<vector<u8>, bool>,
-        cursed_subjects: SmartTable<vector<u8>, bool>,
+        signers: BigOrderedMap<vector<u8>, bool>,
+        cursed_subjects: BigOrderedMap<vector<u8>, bool>,
         config_set_events: EventHandle<ConfigSet>,
         cursed_events: EventHandle<Cursed>,
         uncursed_events: EventHandle<Uncursed>
@@ -128,8 +128,8 @@ module ccip::rmn_remote {
                 f_sign: 0
             },
             config_count: 0,
-            signers: smart_table::new(),
-            cursed_subjects: smart_table::new(),
+            signers: big_ordered_map::new_with_config(0, 0, false),
+            cursed_subjects: big_ordered_map::new_with_config(0, 0, false),
             config_set_events: account::new_event_handle(&state_object_signer),
             cursed_events: account::new_event_handle(&state_object_signer),
             uncursed_events: account::new_event_handle(&state_object_signer)
@@ -248,7 +248,7 @@ module ccip::rmn_remote {
             let eth_address = aptos_hash::keccak256(public_key_bytes).trim(12);
 
             assert!(
-                state.signers.contains(eth_address),
+                state.signers.contains(&eth_address),
                 error::invalid_argument(E_UNEXPECTED_SIGNER)
             );
             if (i > 0) {
@@ -309,7 +309,7 @@ module ccip::rmn_remote {
             error::invalid_argument(E_NOT_ENOUGH_SIGNERS)
         );
 
-        state.signers.clear();
+        state.signers.for_each_and_clear(|_k, _v| {});
 
         let signers =
             signer_onchain_public_keys.zip_map_ref(
@@ -323,7 +323,7 @@ module ccip::rmn_remote {
                         error::invalid_argument(E_INVALID_PUBLIC_KEY_LENGTH)
                     );
                     assert!(
-                        !state.signers.contains(signer_public_key_bytes),
+                        !state.signers.contains(&signer_public_key_bytes),
                         error::invalid_argument(E_DUPLICATE_SIGNER)
                     );
                     state.signers.add(signer_public_key_bytes, true);
@@ -380,7 +380,7 @@ module ccip::rmn_remote {
                     error::invalid_argument(E_INVALID_SUBJECT_LENGTH)
                 );
                 assert!(
-                    !state.cursed_subjects.contains(subject),
+                    !state.cursed_subjects.contains(&subject),
                     error::invalid_argument(E_ALREADY_CURSED)
                 );
                 state.cursed_subjects.add(subject, true);
@@ -404,10 +404,10 @@ module ccip::rmn_remote {
         subjects.for_each_ref(|subject| {
             let subject: vector<u8> = *subject;
             assert!(
-                state.cursed_subjects.contains(subject),
+                state.cursed_subjects.contains(&subject),
                 error::invalid_argument(E_NOT_CURSED)
             );
-            state.cursed_subjects.remove(subject);
+            state.cursed_subjects.remove(&subject);
         });
         event::emit(Uncursed { subjects });
         event::emit_event(&mut state.uncursed_events, Uncursed { subjects });
@@ -420,12 +420,12 @@ module ccip::rmn_remote {
 
     #[view]
     public fun is_cursed_global(): bool acquires RMNRemoteState {
-        borrow_state().cursed_subjects.contains(GLOBAL_CURSE_SUBJECT)
+        borrow_state().cursed_subjects.contains(&GLOBAL_CURSE_SUBJECT)
     }
 
     #[view]
     public fun is_cursed(subject: vector<u8>): bool acquires RMNRemoteState {
-        borrow_state().cursed_subjects.contains(subject) || is_cursed_global()
+        borrow_state().cursed_subjects.contains(&subject) || is_cursed_global()
     }
 
     #[view]

--- a/contracts/ccip/ccip/sources/util/safe_big_ordered_map.move
+++ b/contracts/ccip/ccip/sources/util/safe_big_ordered_map.move
@@ -1,0 +1,752 @@
+/// Safe wrapper around BigOrderedMap operations with variable-sized values.
+///
+/// This module encapsulates the dangerous remove/modify/add pattern required for
+/// BigOrderedMap<K, V> where V is variable-sized and cannot use borrow_mut.
+module ccip::safe_big_ordered_map {
+    use std::big_ordered_map::{Self, BigOrderedMap};
+    use std::error;
+    use std::option::{Self, Option};
+
+    /// Key not found in map
+    const E_KEY_NOT_FOUND: u64 = 1;
+    /// Map key not found in outer map (for nested operations)
+    const E_OUTER_KEY_NOT_FOUND: u64 = 2;
+    /// Inner key not found in inner map (for nested operations)
+    const E_INNER_KEY_NOT_FOUND: u64 = 3;
+
+    /// Safely upsert a value in BigOrderedMap<K, V> where V is variable-sized.
+    ///
+    /// Returns the previous value if the key existed, none otherwise.
+    public fun upsert<K: drop + copy + store, V: store>(
+        map: &mut BigOrderedMap<K, V>,
+        key: K,
+        value: V
+    ): Option<V> {
+        if (!map.contains(&key)) {
+            map.add(key, value);
+            option::none()
+        } else {
+            // Use the dangerous remove/modify/add pattern - but safely encapsulated here
+            let old_value = map.remove(&key);
+            map.add(key, value);
+            option::some(old_value)
+        }
+    }
+
+    /// Safely get a value with a default if key doesn't exist.
+    public fun borrow_with_default<K: drop + copy + store, V: drop + store>(
+        map: &BigOrderedMap<K, V>,
+        key: &K,
+        default_value: &V
+    ): &V {
+        if (!map.contains(key)) {
+            default_value
+        } else {
+            map.borrow(key)
+        }
+    }
+
+    // ============================= Nested Operations ====================================
+
+    /// Safely upsert a value in a nested BigOrderedMap<K, BigOrderedMap<K2, V>>.
+    ///
+    /// This function handles the dangerous remove/modify/add pattern required
+    /// when the inner map needs to be modified due to variable-size limitations.
+    ///
+    /// Returns the previous value if the inner key existed, none otherwise.
+    public fun nested_upsert<K: drop + copy + store, K2: drop + copy + store, V: store>(
+        outer_map: &mut BigOrderedMap<K, BigOrderedMap<K2, V>>,
+        outer_key: K,
+        inner_key: K2,
+        value: V
+    ): Option<V> {
+        // First check if outer key exists
+        if (!outer_map.contains(&outer_key)) {
+            // Create new inner map and add the first entry
+            let new_inner_map = big_ordered_map::new_with_config(0, 0, false);
+            new_inner_map.add(inner_key, value);
+            outer_map.add(outer_key, new_inner_map);
+            return option::none()
+        };
+
+        // Outer key exists, need to modify the inner map
+        // Use the remove/upsert/add pattern
+        let inner_map = outer_map.remove(&outer_key);
+        let previous_value = inner_map.upsert(inner_key, value);
+
+        // Re-add the inner map, even if an error occurs above
+        outer_map.add(outer_key, inner_map);
+
+        previous_value
+    }
+
+    /// Safely get a value from a nested BigOrderedMap<K, BigOrderedMap<K2, V>>.
+    ///
+    /// Returns the value if both outer and inner keys exist, aborts otherwise.
+    public fun nested_borrow<K: drop + copy + store, K2: drop + copy + store, V: store>(
+        outer_map: &BigOrderedMap<K, BigOrderedMap<K2, V>>,
+        outer_key: &K,
+        inner_key: &K2
+    ): &V {
+        assert!(
+            outer_map.contains(outer_key),
+            error::invalid_argument(E_OUTER_KEY_NOT_FOUND)
+        );
+
+        let inner_map = outer_map.borrow(outer_key);
+        assert!(
+            inner_map.contains(inner_key),
+            error::invalid_argument(E_INNER_KEY_NOT_FOUND)
+        );
+
+        inner_map.borrow(inner_key)
+    }
+
+    /// Safely check if a nested key exists in BigOrderedMap<K, BigOrderedMap<K2, V>>.
+    public fun nested_contains<K: drop + copy + store, K2: drop + copy + store, V: store>(
+        outer_map: &BigOrderedMap<K, BigOrderedMap<K2, V>>,
+        outer_key: &K,
+        inner_key: &K2
+    ): bool {
+        if (!outer_map.contains(outer_key)) {
+            return false
+        };
+
+        let inner_map = outer_map.borrow(outer_key);
+        inner_map.contains(inner_key)
+    }
+
+    /// Safely remove a value from a nested BigOrderedMap<K, BigOrderedMap<K2, V>>.
+    ///
+    /// Returns the removed value if both keys existed, aborts otherwise.
+    public fun nested_remove<K: drop + copy + store, K2: drop + copy + store, V: store>(
+        outer_map: &mut BigOrderedMap<K, BigOrderedMap<K2, V>>,
+        outer_key: &K,
+        inner_key: &K2
+    ): V {
+        assert!(
+            outer_map.contains(outer_key),
+            error::invalid_argument(E_OUTER_KEY_NOT_FOUND)
+        );
+
+        // Use the dangerous remove/modify/add pattern - but safely encapsulated here
+        let inner_map = outer_map.remove(outer_key);
+        let removed_value = inner_map.remove(inner_key);
+
+        // Critical: Always re-add the inner map, even if empty
+        // (BigOrderedMap handles empty maps fine)
+        outer_map.add(*outer_key, inner_map);
+
+        removed_value
+    }
+
+    /// Initialize a new inner map for the given outer key if it doesn't exist.
+    /// Does nothing if the outer key already exists.
+    public fun nested_ensure_inner_map<K: drop + copy + store, K2: drop + copy + store, V: store>(
+        outer_map: &mut BigOrderedMap<K, BigOrderedMap<K2, V>>,
+        outer_key: K
+    ) {
+        if (!outer_map.contains(&outer_key)) {
+            let new_inner_map = big_ordered_map::new_with_config(0, 0, false);
+            outer_map.add(outer_key, new_inner_map);
+        }
+    }
+
+    /// Get a default value if the nested key doesn't exist.
+    public fun nested_borrow_with_default<K: drop + copy + store, K2: drop + copy + store, V: drop + store>(
+        outer_map: &BigOrderedMap<K, BigOrderedMap<K2, V>>,
+        outer_key: &K,
+        inner_key: &K2,
+        default_value: &V
+    ): &V {
+        if (!outer_map.contains(outer_key)) {
+            return default_value
+        };
+
+        let inner_map = outer_map.borrow(outer_key);
+        if (!inner_map.contains(inner_key)) {
+            return default_value
+        };
+
+        inner_map.borrow(inner_key)
+    }
+
+    /// Safely modify an inner map in BigOrderedMap<K, BigOrderedMap<K2, V>>.
+    ///
+    /// This function handles the remove/modify/add pattern for
+    /// operations that need to perform multiple changes to the inner map.
+    ///
+    /// The modifier function receives a mutable reference to the inner map and
+    /// can perform any number of operations on it. If the outer key doesn't exist,
+    /// a new empty inner map is created first.
+    ///
+    /// This ensures the inner map is always properly re-added.
+    public inline fun nested_modify_inner_map<K: drop + copy + store, K2: drop + copy + store, V: store>(
+        outer_map: &mut BigOrderedMap<K, BigOrderedMap<K2, V>>,
+        outer_key: K,
+        modifier: |&mut BigOrderedMap<K2, V>|
+    ) {
+        // Remove or create the inner map
+        let inner_map =
+            if (outer_map.contains(&outer_key)) {
+                outer_map.remove(&outer_key)
+            } else {
+                big_ordered_map::new_with_config(0, 0, false)
+            };
+
+        // Apply the modifications
+        modifier(&mut inner_map);
+
+        // Always re-add the inner map, even if modifier aborts
+        // This is safe because BigOrderedMap handles empty maps fine
+        outer_map.add(outer_key, inner_map);
+    }
+
+    // ============================= Tests ====================================
+
+    #[test]
+    fun test_nested_upsert_new_outer_key() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Insert into non-existent outer key
+        let prev = nested_upsert(&mut map, 1, 100, 42);
+        assert!(prev.is_none(), 0);
+
+        // Verify it was inserted
+        assert!(nested_contains(&map, &1, &100), 1);
+        assert!(*nested_borrow(&map, &1, &100) == 42, 2);
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    fun test_nested_upsert_existing_keys() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Insert first value
+        nested_upsert(&mut map, 1, 100, 42);
+
+        // Update existing inner key
+        let prev = nested_upsert(&mut map, 1, 100, 99);
+        assert!(prev.is_some() && prev.destroy_some() == 42, 0);
+
+        // Verify update
+        assert!(*nested_borrow(&map, &1, &100) == 99, 1);
+
+        // Add new inner key to existing outer key
+        let prev = nested_upsert(&mut map, 1, 200, 77);
+        assert!(prev.is_none(), 2);
+
+        // Verify both exist
+        assert!(*nested_borrow(&map, &1, &100) == 99, 3);
+        assert!(*nested_borrow(&map, &1, &200) == 77, 4);
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    fun test_nested_borrow_with_default() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Non-existent outer key
+        assert!(
+            *nested_borrow_with_default(&map, &1, &100, &255) == 255,
+            0
+        );
+
+        // Add outer key but not inner key
+        nested_ensure_inner_map(&mut map, 1);
+        assert!(
+            *nested_borrow_with_default(&map, &1, &100, &255) == 255,
+            1
+        );
+
+        // Add inner key
+        nested_upsert(&mut map, 1, 100, 42);
+        assert!(
+            *nested_borrow_with_default(&map, &1, &100, &255) == 42,
+            2
+        );
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 65538, location = Self)]
+    fun test_nested_borrow_outer_key_not_found() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+        nested_borrow(&map, &1, &100); // Should abort
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 65539, location = Self)]
+    fun test_nested_borrow_inner_key_not_found() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+        nested_ensure_inner_map(&mut map, 1);
+        nested_borrow(&map, &1, &100); // Should abort
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    // ============================= General Function Tests ====================================
+
+    #[test]
+    fun test_upsert_new_key() {
+        let map = big_ordered_map::new_with_config<u64, vector<u8>>(0, 0, false);
+
+        let prev = upsert(&mut map, 1, vector[10, 20]);
+        assert!(prev.is_none(), 0);
+
+        // Verify it was added
+        assert!(map.contains(&1), 1);
+        assert!(*map.borrow(&1) == vector[10, 20], 2);
+
+        map.destroy(|_| {});
+    }
+
+    #[test]
+    fun test_upsert_existing_key() {
+        let map = big_ordered_map::new_with_config<u64, vector<u8>>(0, 0, false);
+
+        // Add initial value
+        map.add(1, vector[1, 2]);
+
+        // Upsert with new value
+        let prev = upsert(&mut map, 1, vector[3, 4, 5]);
+        assert!(prev.is_some(), 0);
+        assert!(prev.destroy_some() == vector[1, 2], 1);
+
+        // Verify new value
+        assert!(*map.borrow(&1) == vector[3, 4, 5], 2);
+
+        map.destroy(|_| {});
+    }
+
+    #[test]
+    fun test_borrow_with_default_existing_key() {
+        let map = big_ordered_map::new_with_config<u64, u8>(0, 0, false);
+
+        map.add(1, 42);
+
+        let result = borrow_with_default(&map, &1, &99);
+        assert!(*result == 42, 0);
+
+        map.destroy(|_| {});
+    }
+
+    #[test]
+    fun test_borrow_with_default_nonexistent_key() {
+        let map = big_ordered_map::new_with_config<u64, u8>(0, 0, false);
+
+        let result = borrow_with_default(&map, &1, &99);
+        assert!(*result == 99, 0);
+
+        map.destroy(|_| {});
+    }
+
+    // ============================= Additional Nested Function Tests ====================================
+
+    #[test]
+    fun test_nested_upsert_multiple_inner_keys() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Add multiple inner keys to same outer key
+        nested_upsert(&mut map, 1, 100, 10);
+        nested_upsert(&mut map, 1, 200, 20);
+        nested_upsert(&mut map, 1, 300, 30);
+
+        // Verify all exist
+        assert!(nested_contains(&map, &1, &100), 0);
+        assert!(nested_contains(&map, &1, &200), 1);
+        assert!(nested_contains(&map, &1, &300), 2);
+
+        // Verify values
+        assert!(*nested_borrow(&map, &1, &100) == 10, 3);
+        assert!(*nested_borrow(&map, &1, &200) == 20, 4);
+        assert!(*nested_borrow(&map, &1, &300) == 30, 5);
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    fun test_nested_upsert_multiple_outer_keys() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Add to different outer keys
+        nested_upsert(&mut map, 1, 100, 10);
+        nested_upsert(&mut map, 2, 100, 20);
+        nested_upsert(&mut map, 3, 100, 30);
+
+        // Verify all exist
+        assert!(nested_contains(&map, &1, &100), 0);
+        assert!(nested_contains(&map, &2, &100), 1);
+        assert!(nested_contains(&map, &3, &100), 2);
+
+        // Verify values
+        assert!(*nested_borrow(&map, &1, &100) == 10, 3);
+        assert!(*nested_borrow(&map, &2, &100) == 20, 4);
+        assert!(*nested_borrow(&map, &3, &100) == 30, 5);
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    fun test_nested_contains_false_cases() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Test non-existent outer key
+        assert!(!nested_contains(&map, &1, &100), 0);
+
+        // Add outer key but not inner key
+        nested_ensure_inner_map(&mut map, 1);
+        assert!(!nested_contains(&map, &1, &100), 1);
+
+        // Add inner key and verify it now exists
+        nested_upsert(&mut map, 1, 100, 42);
+        assert!(nested_contains(&map, &1, &100), 2);
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    fun test_nested_remove_single_item() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Add and then remove
+        nested_upsert(&mut map, 1, 100, 42);
+        assert!(nested_contains(&map, &1, &100), 0);
+
+        let removed_value = nested_remove(&mut map, &1, &100);
+        assert!(removed_value == 42, 1);
+        assert!(!nested_contains(&map, &1, &100), 2);
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    fun test_nested_remove_multiple_items() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Add multiple items
+        nested_upsert(&mut map, 1, 100, 10);
+        nested_upsert(&mut map, 1, 200, 20);
+        nested_upsert(&mut map, 1, 300, 30);
+
+        // Remove one item
+        let removed = nested_remove(&mut map, &1, &200);
+        assert!(removed == 20, 0);
+
+        // Verify others still exist
+        assert!(nested_contains(&map, &1, &100), 1);
+        assert!(!nested_contains(&map, &1, &200), 2);
+        assert!(nested_contains(&map, &1, &300), 3);
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 65538, location = Self)]
+    fun test_nested_remove_outer_key_not_found() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+        nested_remove(&mut map, &1, &100); // Should abort
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 65538, location = std::ordered_map)]
+    fun test_nested_remove_inner_key_not_found() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+        nested_ensure_inner_map(&mut map, 1);
+        nested_remove(&mut map, &1, &100); // EKEY_NOT_FOUND
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    fun test_nested_ensure_inner_map_new() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Ensure non-existent outer key
+        assert!(!map.contains(&1), 0);
+        nested_ensure_inner_map(&mut map, 1);
+        assert!(map.contains(&1), 1);
+
+        // Inner map should be empty
+        let inner_map = map.borrow(&1);
+        assert!(inner_map.is_empty(), 2);
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    fun test_nested_ensure_inner_map_existing() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Add outer key with some data
+        nested_upsert(&mut map, 1, 100, 42);
+
+        // Ensure existing outer key (should do nothing)
+        nested_ensure_inner_map(&mut map, 1);
+
+        // Verify data is preserved
+        assert!(nested_contains(&map, &1, &100), 0);
+        assert!(*nested_borrow(&map, &1, &100) == 42, 1);
+        // Verify the value still exists (no length check needed)
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    fun test_nested_borrow_with_default_all_scenarios() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Scenario 1: Non-existent outer key
+        assert!(
+            *nested_borrow_with_default(&map, &1, &100, &255) == 255,
+            0
+        );
+
+        // Scenario 2: Existing outer key, non-existent inner key
+        nested_ensure_inner_map(&mut map, 1);
+        assert!(
+            *nested_borrow_with_default(&map, &1, &100, &255) == 255,
+            1
+        );
+
+        // Scenario 3: Both keys exist
+        nested_upsert(&mut map, 1, 100, 42);
+        assert!(
+            *nested_borrow_with_default(&map, &1, &100, &255) == 42,
+            2
+        );
+
+        // Scenario 4: Different inner key in same outer map
+        assert!(
+            *nested_borrow_with_default(&map, &1, &200, &255) == 255,
+            3
+        );
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    // ============================= Complex Integration Tests ====================================
+
+    #[test]
+    fun test_complex_nested_operations() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Build a complex nested structure
+        // Chain 1: messages 100, 200, 300
+        nested_upsert(&mut map, 1, 100, 1);
+        nested_upsert(&mut map, 1, 200, 2);
+        nested_upsert(&mut map, 1, 300, 3);
+
+        // Chain 2: messages 150, 250
+        nested_upsert(&mut map, 2, 150, 15);
+        nested_upsert(&mut map, 2, 250, 25);
+
+        // Verify structure
+        assert!(*nested_borrow(&map, &1, &100) == 1, 0);
+        assert!(*nested_borrow(&map, &1, &200) == 2, 1);
+        assert!(*nested_borrow(&map, &1, &300) == 3, 2);
+        assert!(*nested_borrow(&map, &2, &150) == 15, 3);
+        assert!(*nested_borrow(&map, &2, &250) == 25, 4);
+
+        // Update some values
+        let old_val = nested_upsert(&mut map, 1, 200, 99);
+        assert!(
+            old_val.is_some() && old_val.destroy_some() == 2,
+            5
+        );
+        assert!(*nested_borrow(&map, &1, &200) == 99, 6);
+
+        // Remove some values
+        nested_remove(&mut map, &2, &150);
+        assert!(!nested_contains(&map, &2, &150), 7);
+        assert!(nested_contains(&map, &2, &250), 8); // Other value should remain
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    fun test_edge_case_empty_maps() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Operations on completely empty map
+        assert!(!nested_contains(&map, &1, &100), 0);
+        assert!(
+            *nested_borrow_with_default(&map, &1, &100, &42) == 42,
+            1
+        );
+
+        // Create empty inner map
+        nested_ensure_inner_map(&mut map, 1);
+        assert!(!nested_contains(&map, &1, &100), 2);
+        assert!(
+            *nested_borrow_with_default(&map, &1, &100, &42) == 42,
+            3
+        );
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    fun test_nested_modify_inner_map_new_outer_key() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Modify non-existent outer key (should create new inner map)
+        nested_modify_inner_map(
+            &mut map,
+            1,
+            |inner_map| {
+                let inner_map: &mut BigOrderedMap<u64, u8> = inner_map;
+                inner_map.add(100, 42);
+                inner_map.add(200, 84);
+            }
+        );
+
+        // Verify the modifications were applied
+        assert!(nested_contains(&map, &1, &100), 0);
+        assert!(nested_contains(&map, &1, &200), 1);
+        assert!(*nested_borrow(&map, &1, &100) == 42, 2);
+        assert!(*nested_borrow(&map, &1, &200) == 84, 3);
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    fun test_nested_modify_inner_map_existing_outer_key() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Setup existing data
+        nested_upsert(&mut map, 1, 100, 10);
+        nested_upsert(&mut map, 1, 200, 20);
+
+        // Modify existing outer key
+        nested_modify_inner_map(
+            &mut map,
+            1,
+            |inner_map| {
+                let inner_map: &mut BigOrderedMap<u64, u8> = inner_map;
+                // Update existing value
+                upsert(inner_map, 100, 99);
+                // Remove one value
+                inner_map.remove(&200);
+                // Add new value
+                inner_map.add(300, 30);
+            }
+        );
+
+        // Verify the modifications
+        assert!(nested_contains(&map, &1, &100), 0);
+        assert!(!nested_contains(&map, &1, &200), 1);
+        assert!(nested_contains(&map, &1, &300), 2);
+        assert!(*nested_borrow(&map, &1, &100) == 99, 3);
+        assert!(*nested_borrow(&map, &1, &300) == 30, 4);
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    fun test_nested_modify_inner_map_complex_operations() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Simulate fee_quoter-like operations
+        nested_modify_inner_map(
+            &mut map,
+            1,
+            |inner_map| {
+                // Add multiple tokens (like fee_quoter add_tokens loop)
+                let tokens = vector[100, 200, 300];
+                let values = vector[10, 20, 30];
+
+                tokens.zip_ref(
+                    &values,
+                    |token, value| {
+                        let inner_map: &mut BigOrderedMap<u64, u8> = inner_map;
+                        upsert(inner_map, *token, *value);
+                    }
+                );
+
+                // Remove some tokens (like fee_quoter remove_tokens loop)
+                let remove_tokens = vector[200];
+                remove_tokens.for_each_ref(|token| {
+                    if (inner_map.contains(token)) {
+                        inner_map.remove(token);
+                    }
+                });
+            }
+        );
+
+        // Verify final state
+        assert!(nested_contains(&map, &1, &100), 0);
+        assert!(!nested_contains(&map, &1, &200), 1); // Was removed
+        assert!(nested_contains(&map, &1, &300), 2);
+        assert!(*nested_borrow(&map, &1, &100) == 10, 3);
+        assert!(*nested_borrow(&map, &1, &300) == 30, 4);
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+
+    #[test]
+    fun test_nested_modify_inner_map_empty_operations() {
+        let map = big_ordered_map::new_with_config<u64, BigOrderedMap<u64, u8>>(
+            0, 0, false
+        );
+
+        // Modify with no actual changes
+        nested_modify_inner_map(
+            &mut map,
+            1,
+            |_inner_map| {
+                // Do nothing
+            }
+        );
+
+        // Should have created empty inner map
+        assert!(map.contains(&1), 0);
+        let inner_map = map.borrow(&1);
+        assert!(inner_map.is_empty(), 1);
+
+        map.destroy(|inner_map| inner_map.destroy(|_| {}));
+    }
+}

--- a/contracts/ccip/ccip_offramp/sources/offramp.move
+++ b/contracts/ccip/ccip_offramp/sources/offramp.move
@@ -28,6 +28,7 @@ module ccip_offramp::offramp {
     use ccip::receiver_dispatcher;
     use ccip::receiver_registry;
     use ccip::rmn_remote;
+    use ccip::safe_big_ordered_map;
     use ccip::token_admin_dispatcher;
     use ccip::token_admin_registry;
 
@@ -391,15 +392,17 @@ module ccip_offramp::offramp {
         source_chain_selector: u64, sequence_number: u64
     ): u8 acquires OffRampState {
         let state = borrow_state();
-
         assert!(
             state.execution_states.contains(&source_chain_selector),
             error::invalid_argument(E_UNKNOWN_SOURCE_CHAIN_SELECTOR)
         );
-        let source_chain_execution_states =
-            state.execution_states.borrow(&source_chain_selector);
-        let execution_state = source_chain_execution_states.borrow(&sequence_number);
-        *execution_state
+
+        *safe_big_ordered_map::nested_borrow_with_default(
+            &state.execution_states,
+            &source_chain_selector,
+            &sequence_number,
+            &EXECUTION_STATE_UNTOUCHED
+        )
     }
 
     fun execute_single_report(
@@ -450,18 +453,16 @@ module ccip_offramp::offramp {
             );
         };
 
-        let source_chain_execution_states =
-            state.execution_states.borrow(&source_chain_selector);
-
         let message = &execution_report.message;
         let sequence_number = message.header.sequence_number;
 
         let execution_state =
-            if (source_chain_execution_states.contains(&sequence_number)) {
-                *source_chain_execution_states.borrow(&sequence_number)
-            } else {
-                EXECUTION_STATE_UNTOUCHED
-            };
+            *safe_big_ordered_map::nested_borrow_with_default(
+                &state.execution_states,
+                &source_chain_selector,
+                &sequence_number,
+                &EXECUTION_STATE_UNTOUCHED
+            );
 
         if (execution_state != EXECUTION_STATE_UNTOUCHED) {
             event::emit(SkippedAlreadyExecuted { source_chain_selector, sequence_number });
@@ -488,12 +489,12 @@ module ccip_offramp::offramp {
         execute_single_message(state, message, &execution_report.offchain_token_data);
 
         // Since Aptos only supports success or reverts, when it reaches this it has succeeded.
-        // Use remove and add pattern due to variable size struct
-        // https://github.com/aptos-labs/aptos-core/blob/96fa267/aptos-move/framework/aptos-framework/sources/datastructures/big_ordered_map.move#L450
-        let source_chain_execution_states =
-            state.execution_states.remove(&source_chain_selector);
-        source_chain_execution_states.upsert(sequence_number, EXECUTION_STATE_SUCCESS);
-        state.execution_states.add(source_chain_selector, source_chain_execution_states);
+        safe_big_ordered_map::nested_upsert(
+            &mut state.execution_states,
+            source_chain_selector,
+            sequence_number,
+            EXECUTION_STATE_SUCCESS
+        );
 
         event::emit(
             ExecutionStateChanged {

--- a/contracts/ccip/ccip_offramp/sources/offramp.move
+++ b/contracts/ccip/ccip_offramp/sources/offramp.move
@@ -12,7 +12,7 @@ module ccip_offramp::offramp {
     use std::primary_fungible_store;
     use std::signer;
     use std::string::{Self, String};
-    use std::smart_table::{Self, SmartTable};
+    use std::big_ordered_map::{Self, BigOrderedMap};
     use std::timestamp;
     use std::vector;
 
@@ -62,12 +62,12 @@ module ccip_offramp::offramp {
 
         // State
         // source chain selector -> config
-        source_chain_configs: SmartTable<u64, SourceChainConfig>,
+        source_chain_configs: BigOrderedMap<u64, SourceChainConfig>,
         // source chain selector -> seq num -> execution state
-        execution_states: SmartTable<u64, SmartTable<u64, u8>>,
+        execution_states: BigOrderedMap<u64, BigOrderedMap<u64, u8>>,
 
         // merkle root -> timestamp,
-        roots: SmartTable<vector<u8>, u64>,
+        roots: BigOrderedMap<vector<u8>, u64>,
         // This is the OCR sequence number, not to be confused with the CCIP message sequence number.
         latest_price_sequence_number: u64,
 
@@ -307,9 +307,9 @@ module ccip_offramp::offramp {
             ocr3_base_state: ocr3_base::new(state_signer),
             chain_selector,
             permissionless_execution_threshold_seconds: 0,
-            source_chain_configs: smart_table::new(),
-            execution_states: smart_table::new(),
-            roots: smart_table::new(),
+            source_chain_configs: big_ordered_map::new_with_config(0, 0, false),
+            execution_states: big_ordered_map::new_with_config(0, 0, false),
+            roots: big_ordered_map::new_with_config(0, 0, false),
             latest_price_sequence_number: 0,
             static_config_set_events: account::new_event_handle(state_signer),
             dynamic_config_set_events: account::new_event_handle(state_signer),
@@ -347,11 +347,11 @@ module ccip_offramp::offramp {
     ) {
         // assert that the source chain is enabled.
         assert!(
-            state.source_chain_configs.contains(source_chain_selector),
+            state.source_chain_configs.contains(&source_chain_selector),
             error::invalid_argument(E_UNKNOWN_SOURCE_CHAIN_SELECTOR)
         );
         let source_chain_config =
-            state.source_chain_configs.borrow(source_chain_selector);
+            state.source_chain_configs.borrow(&source_chain_selector);
         assert!(
             source_chain_config.is_enabled,
             error::permission_denied(E_SOURCE_CHAIN_NOT_ENABLED)
@@ -393,12 +393,12 @@ module ccip_offramp::offramp {
         let state = borrow_state();
 
         assert!(
-            state.execution_states.contains(source_chain_selector),
+            state.execution_states.contains(&source_chain_selector),
             error::invalid_argument(E_UNKNOWN_SOURCE_CHAIN_SELECTOR)
         );
         let source_chain_execution_states =
-            state.execution_states.borrow(source_chain_selector);
-        let execution_state = source_chain_execution_states.borrow(sequence_number);
+            state.execution_states.borrow(&source_chain_selector);
+        let execution_state = source_chain_execution_states.borrow(&sequence_number);
         *execution_state
     }
 
@@ -425,7 +425,7 @@ module ccip_offramp::offramp {
         );
 
         let source_chain_config =
-            state.source_chain_configs.borrow(source_chain_selector);
+            state.source_chain_configs.borrow(&source_chain_selector);
         let metadata_hash =
             calculate_metadata_hash(
                 source_chain_selector,
@@ -451,16 +451,19 @@ module ccip_offramp::offramp {
         };
 
         let source_chain_execution_states =
-            state.execution_states.borrow_mut(source_chain_selector);
+            state.execution_states.borrow(&source_chain_selector);
 
         let message = &execution_report.message;
         let sequence_number = message.header.sequence_number;
-        let execution_state_ref =
-            source_chain_execution_states.borrow_mut_with_default(
-                sequence_number, EXECUTION_STATE_UNTOUCHED
-            );
 
-        if (*execution_state_ref != EXECUTION_STATE_UNTOUCHED) {
+        let execution_state =
+            if (source_chain_execution_states.contains(&sequence_number)) {
+                *source_chain_execution_states.borrow(&sequence_number)
+            } else {
+                EXECUTION_STATE_UNTOUCHED
+            };
+
+        if (execution_state != EXECUTION_STATE_UNTOUCHED) {
             event::emit(SkippedAlreadyExecuted { source_chain_selector, sequence_number });
             event::emit_event(
                 &mut state.skipped_already_executed_events,
@@ -484,8 +487,13 @@ module ccip_offramp::offramp {
         // Execute the message
         execute_single_message(state, message, &execution_report.offchain_token_data);
 
-        // Since Aptos only supports success of reverts, when it reaches this it has succeeded.
-        *execution_state_ref = EXECUTION_STATE_SUCCESS;
+        // Since Aptos only supports success or reverts, when it reaches this it has succeeded.
+        // Use remove and add pattern due to variable size struct
+        // https://github.com/aptos-labs/aptos-core/blob/96fa267/aptos-move/framework/aptos-framework/sources/datastructures/big_ordered_map.move#L450
+        let source_chain_execution_states =
+            state.execution_states.remove(&source_chain_selector);
+        source_chain_execution_states.upsert(sequence_number, EXECUTION_STATE_SUCCESS);
+        state.execution_states.add(source_chain_selector, source_chain_execution_states);
 
         event::emit(
             ExecutionStateChanged {
@@ -514,10 +522,10 @@ module ccip_offramp::offramp {
         state: &mut OffRampState, root: vector<u8>
     ): bool {
         assert!(
-            state.roots.contains(root),
+            state.roots.contains(&root),
             error::invalid_argument(E_ROOT_NOT_COMMITTED)
         );
-        let timestamp_committed_secs = *state.roots.borrow(root);
+        let timestamp_committed_secs = *state.roots.borrow(&root);
 
         (timestamp::now_seconds() - timestamp_committed_secs)
             > (state.permissionless_execution_threshold_seconds as u64)
@@ -669,8 +677,9 @@ module ccip_offramp::offramp {
 
                 assert_source_chain_enabled(state, source_chain_selector);
 
+                // Use borrow, copy, then upsert pattern due to variable size in SourceChainConfig `on_ramp`
                 let source_chain_config =
-                    state.source_chain_configs.borrow_mut(source_chain_selector);
+                    state.source_chain_configs.borrow(&source_chain_selector);
 
                 // If the root is blessed but RMN blessing is disabled for the source chain, or if the root is not
                 // blessed but RMN blessing is enabled, we revert.
@@ -696,11 +705,20 @@ module ccip_offramp::offramp {
                 );
 
                 assert!(
-                    !state.roots.contains(merkle_root),
+                    !state.roots.contains(&merkle_root),
                     error::invalid_argument(E_ROOT_ALREADY_COMMITTED)
                 );
 
-                source_chain_config.min_seq_nr = root.max_seq_nr + 1;
+                // Update the config with new min_seq_nr and upsert back
+                let updated_config =
+                    SourceChainConfig {
+                        router: source_chain_config.router,
+                        is_enabled: source_chain_config.is_enabled,
+                        min_seq_nr: root.max_seq_nr + 1,
+                        is_rmn_verification_disabled: source_chain_config.is_rmn_verification_disabled,
+                        on_ramp: source_chain_config.on_ramp
+                    };
+                state.source_chain_configs.upsert(source_chain_selector, updated_config);
                 state.roots.add(merkle_root, timestamp::now_seconds());
             }
         );
@@ -715,11 +733,11 @@ module ccip_offramp::offramp {
     public fun get_merkle_root(root: vector<u8>): u64 acquires OffRampState {
         let state = borrow_state();
         assert!(
-            state.roots.contains(root),
+            state.roots.contains(&root),
             error::invalid_argument(E_INVALID_ROOT)
         );
 
-        *state.roots.borrow(root)
+        *state.roots.borrow(&root)
     }
 
     #[view]
@@ -727,9 +745,9 @@ module ccip_offramp::offramp {
         source_chain_selector: u64
     ): SourceChainConfig acquires OffRampState {
         let state = borrow_state();
-        if (state.source_chain_configs.contains(source_chain_selector)) {
+        if (state.source_chain_configs.contains(&source_chain_selector)) {
             let source_chain_config =
-                state.source_chain_configs.borrow(source_chain_selector);
+                state.source_chain_configs.borrow(&source_chain_selector);
             *source_chain_config
         } else {
             SourceChainConfig {
@@ -745,7 +763,7 @@ module ccip_offramp::offramp {
     #[view]
     public fun get_all_source_chain_configs(): (vector<u64>, vector<SourceChainConfig>) acquires OffRampState {
         let state = borrow_state();
-        state.source_chain_configs.to_simple_map().to_vec_pair()
+        state.source_chain_configs.to_ordered_map().to_vec_pair()
     }
 
     // ================================================================
@@ -998,7 +1016,7 @@ module ccip_offramp::offramp {
 
             address::assert_non_zero_address_vector(&on_ramp);
 
-            if (!state.source_chain_configs.contains(source_chain_selector)) {
+            if (!state.source_chain_configs.contains(&source_chain_selector)) {
                 state.source_chain_configs.add(
                     source_chain_selector,
                     SourceChainConfig {
@@ -1009,30 +1027,34 @@ module ccip_offramp::offramp {
                         on_ramp: vector[]
                     }
                 );
-                state.execution_states.add(source_chain_selector, smart_table::new());
+                state.execution_states.add(
+                    source_chain_selector, big_ordered_map::new_with_config(0, 0, false)
+                );
             } else {
                 // OnRamp updates should only happen due to a misconfiguration.
                 // If an OnRamp is misconfigured, no reports should have been
                 // committed and no messages should have been executed.
                 let existing_config =
-                    state.source_chain_configs.borrow(source_chain_selector);
+                    state.source_chain_configs.borrow(&source_chain_selector);
                 if (existing_config.min_seq_nr != 1
                     && existing_config.on_ramp != on_ramp) {
                     abort error::invalid_argument(E_INVALID_ON_RAMP_UPDATE)
                 };
             };
 
-            let config = state.source_chain_configs.borrow_mut(source_chain_selector);
+            // Use borrow, copy, then upsert pattern due to variable size
+            let config = *state.source_chain_configs.borrow(&source_chain_selector);
             config.is_enabled = is_enabled;
             config.on_ramp = on_ramp;
             config.is_rmn_verification_disabled = is_rmn_verification_disabled;
+            state.source_chain_configs.upsert(source_chain_selector, config);
 
             event::emit(
-                SourceChainConfigSet { source_chain_selector, source_chain_config: *config }
+                SourceChainConfigSet { source_chain_selector, source_chain_config: config }
             );
             event::emit_event(
                 &mut state.source_chain_config_set_events,
-                SourceChainConfigSet { source_chain_selector, source_chain_config: *config }
+                SourceChainConfigSet { source_chain_selector, source_chain_config: config }
             );
         }
     }

--- a/contracts/ccip/ccip_onramp/sources/onramp.move
+++ b/contracts/ccip/ccip_onramp/sources/onramp.move
@@ -10,7 +10,7 @@ module ccip_onramp::onramp {
     use std::primary_fungible_store;
     use std::signer;
     use std::string::{Self, String};
-    use std::smart_table::{Self, SmartTable};
+    use std::big_ordered_map::{Self, BigOrderedMap};
 
     use ccip::address;
     use ccip::auth;
@@ -40,7 +40,7 @@ module ccip_onramp::onramp {
         allowlist_admin: address,
 
         // dest chain selector -> config
-        dest_chain_configs: SmartTable<u64, DestChainConfig>,
+        dest_chain_configs: BigOrderedMap<u64, DestChainConfig>,
         config_set_events: EventHandle<ConfigSet>,
         dest_chain_config_set_events: EventHandle<DestChainConfigSet>,
         ccip_message_sent_events: EventHandle<CCIPMessageSent>,
@@ -221,7 +221,7 @@ module ccip_onramp::onramp {
             chain_selector,
             fee_aggregator: @0x0,
             allowlist_admin: @0x0,
-            dest_chain_configs: smart_table::new(),
+            dest_chain_configs: big_ordered_map::new_with_config(0, 0, false),
             config_set_events: account::new_event_handle(state_signer),
             dest_chain_config_set_events: account::new_event_handle(state_signer),
             ccip_message_sent_events: account::new_event_handle(state_signer),
@@ -245,7 +245,7 @@ module ccip_onramp::onramp {
     #[view]
     public fun is_chain_supported(dest_chain_selector: u64): bool acquires OnRampState {
         let state = borrow_state();
-        state.dest_chain_configs.contains(dest_chain_selector)
+        state.dest_chain_configs.contains(&dest_chain_selector)
     }
 
     #[view]
@@ -254,10 +254,10 @@ module ccip_onramp::onramp {
     ): u64 acquires OnRampState {
         let state = borrow_state();
         assert!(
-            state.dest_chain_configs.contains(dest_chain_selector),
+            state.dest_chain_configs.contains(&dest_chain_selector),
             error::invalid_argument(E_UNKNOWN_DEST_CHAIN_SELECTOR)
         );
-        let dest_chain_config = state.dest_chain_configs.borrow(dest_chain_selector);
+        let dest_chain_config = state.dest_chain_configs.borrow(&dest_chain_selector);
         dest_chain_config.sequence_number + 1
     }
 
@@ -391,11 +391,13 @@ module ccip_onramp::onramp {
 
         let state = borrow_state_mut();
         assert!(
-            state.dest_chain_configs.contains(dest_chain_selector),
+            state.dest_chain_configs.contains(&dest_chain_selector),
             error::invalid_argument(E_UNKNOWN_DEST_CHAIN_SELECTOR)
         );
 
-        let dest_chain_config = state.dest_chain_configs.borrow_mut(dest_chain_selector);
+        // Use remove and add pattern due to variable size struct
+        // https://github.com/aptos-labs/aptos-core/blob/96fa267/aptos-move/framework/aptos-framework/sources/datastructures/big_ordered_map.move#L450
+        let dest_chain_config = state.dest_chain_configs.borrow(&dest_chain_selector);
 
         if (dest_chain_config.allowlist_enabled) {
             assert!(
@@ -481,9 +483,15 @@ module ccip_onramp::onramp {
             );
         };
 
-        dest_chain_config.sequence_number += 1;
+        let sequence_number = dest_chain_config.sequence_number + 1;
 
-        let sequence_number = dest_chain_config.sequence_number;
+        let updated_config = DestChainConfig {
+            sequence_number,
+            router: dest_chain_config.router,
+            allowlist_enabled: dest_chain_config.allowlist_enabled,
+            allowed_senders: dest_chain_config.allowed_senders
+        };
+        state.dest_chain_configs.upsert(dest_chain_selector, updated_config);
 
         let (
             fee_value_juels,
@@ -581,11 +589,11 @@ module ccip_onramp::onramp {
         let state = borrow_state();
 
         assert!(
-            state.dest_chain_configs.contains(dest_chain_selector),
+            state.dest_chain_configs.contains(&dest_chain_selector),
             error::invalid_argument(E_UNKNOWN_DEST_CHAIN_SELECTOR)
         );
 
-        let dest_chain_config = state.dest_chain_configs.borrow(dest_chain_selector);
+        let dest_chain_config = state.dest_chain_configs.borrow(&dest_chain_selector);
 
         (
             dest_chain_config.sequence_number,
@@ -601,11 +609,11 @@ module ccip_onramp::onramp {
         let state = borrow_state();
 
         assert!(
-            state.dest_chain_configs.contains(dest_chain_selector),
+            state.dest_chain_configs.contains(&dest_chain_selector),
             error::invalid_argument(E_UNKNOWN_DEST_CHAIN_SELECTOR)
         );
 
-        let dest_chain_config = state.dest_chain_configs.borrow(dest_chain_selector);
+        let dest_chain_config = state.dest_chain_configs.borrow(&dest_chain_selector);
 
         (dest_chain_config.allowlist_enabled, dest_chain_config.allowed_senders)
     }
@@ -641,7 +649,7 @@ module ccip_onramp::onramp {
         for (i in 0..dest_chains_len) {
             let dest_chain_selector = dest_chain_selectors[i];
             assert!(
-                state.dest_chain_configs.contains(dest_chain_selector),
+                state.dest_chain_configs.contains(&dest_chain_selector),
                 error::invalid_argument(E_UNKNOWN_DEST_CHAIN_SELECTOR)
             );
 
@@ -649,9 +657,10 @@ module ccip_onramp::onramp {
             let add_allowed_senders = dest_chain_add_allowed_senders[i];
             let remove_allowed_senders = dest_chain_remove_allowed_senders[i];
 
-            let dest_chain_config =
-                state.dest_chain_configs.borrow_mut(dest_chain_selector);
-            dest_chain_config.allowlist_enabled = allowlist_enabled;
+            // Use remove and add pattern due to variable size struct
+            // https://github.com/aptos-labs/aptos-core/blob/96fa267/aptos-move/framework/aptos-framework/sources/datastructures/big_ordered_map.move#L450
+            let dest_chain_config = state.dest_chain_configs.borrow(&dest_chain_selector);
+            let updated_allowed_senders = dest_chain_config.allowed_senders;
 
             if (add_allowed_senders.length() > 0) {
                 assert!(
@@ -665,10 +674,9 @@ module ccip_onramp::onramp {
                         error::invalid_argument(E_INVALID_ALLOWLIST_ADDRESS)
                     );
 
-                    let (found, _) =
-                        dest_chain_config.allowed_senders.index_of(&sender_address);
+                    let (found, _) = updated_allowed_senders.index_of(&sender_address);
                     if (!found) {
-                        dest_chain_config.allowed_senders.push_back(sender_address);
+                        updated_allowed_senders.push_back(sender_address);
                     };
                 });
 
@@ -689,10 +697,9 @@ module ccip_onramp::onramp {
 
             if (remove_allowed_senders.length() > 0) {
                 remove_allowed_senders.for_each_ref(|sender_address| {
-                    let (found, i) =
-                        dest_chain_config.allowed_senders.index_of(sender_address);
+                    let (found, i) = updated_allowed_senders.index_of(sender_address);
                     if (found) {
-                        dest_chain_config.allowed_senders.swap_remove(i);
+                        updated_allowed_senders.swap_remove(i);
                     }
                 });
 
@@ -710,6 +717,14 @@ module ccip_onramp::onramp {
                     }
                 );
             };
+
+            let updated_config = DestChainConfig {
+                sequence_number: dest_chain_config.sequence_number,
+                router: dest_chain_config.router,
+                allowlist_enabled,
+                allowed_senders: updated_allowed_senders
+            };
+            state.dest_chain_configs.upsert(dest_chain_selector, updated_config);
         };
     }
 
@@ -898,23 +913,27 @@ module ccip_onramp::onramp {
             let router = dest_chain_routers[i];
             let allowlist_enabled = dest_chain_allowlist_enabled[i];
 
-            if (!state.dest_chain_configs.contains(dest_chain_selector)) {
-                state.dest_chain_configs.add(
-                    dest_chain_selector,
+            let updated_config =
+                if (!state.dest_chain_configs.contains(&dest_chain_selector)) {
                     DestChainConfig {
                         sequence_number: 0,
-                        router: @0x0,
-                        allowlist_enabled: false,
+                        router,
+                        allowlist_enabled,
                         allowed_senders: vector[]
                     }
-                );
-            };
+                } else {
+                    let existing_config =
+                        state.dest_chain_configs.borrow(&dest_chain_selector);
+                    DestChainConfig {
+                        sequence_number: existing_config.sequence_number,
+                        router,
+                        allowlist_enabled,
+                        allowed_senders: existing_config.allowed_senders
+                    }
+                };
 
-            let dest_chain_config =
-                state.dest_chain_configs.borrow_mut(dest_chain_selector);
-
-            dest_chain_config.router = router;
-            dest_chain_config.allowlist_enabled = allowlist_enabled;
+            state.dest_chain_configs.upsert(dest_chain_selector, updated_config);
+            let dest_chain_config = state.dest_chain_configs.borrow(&dest_chain_selector);
 
             event::emit(
                 DestChainConfigSet {

--- a/contracts/ccip/ccip_router/sources/router.move
+++ b/contracts/ccip/ccip_router/sources/router.move
@@ -14,7 +14,7 @@ module ccip_router::router {
     use std::option::{Self, Option};
     use std::signer;
     use std::string::{Self, String};
-    use std::smart_table::{Self, SmartTable};
+    use std::big_ordered_map::{Self, BigOrderedMap};
     use std::event::EventHandle;
 
     use ccip::ownable;
@@ -28,7 +28,7 @@ module ccip_router::router {
     struct RouterState has key {
         state_signer_cap: SignerCapability,
         ownable_state: ownable::OwnableState,
-        on_ramp_versions: SmartTable<u64, vector<u8>>,
+        on_ramp_versions: BigOrderedMap<u64, vector<u8>>,
         on_ramp_set_events: EventHandle<OnRampSet>
     }
 
@@ -58,7 +58,7 @@ module ccip_router::router {
             RouterState {
                 state_signer_cap,
                 ownable_state: ownable::new(&state_signer, @ccip_router),
-                on_ramp_versions: smart_table::new(),
+                on_ramp_versions: big_ordered_map::new_with_config(0, 0, false),
                 on_ramp_set_events: account::new_event_handle(&state_signer)
             }
         );
@@ -82,7 +82,7 @@ module ccip_router::router {
     /// @return True if the chain is supported, false otherwise.
     public fun is_chain_supported(dest_chain_selector: u64): bool acquires RouterState {
         let state = borrow_state();
-        state.on_ramp_versions.contains(dest_chain_selector)
+        state.on_ramp_versions.contains(&dest_chain_selector)
     }
 
     #[view]
@@ -94,11 +94,11 @@ module ccip_router::router {
         let state = borrow_state();
 
         assert!(
-            state.on_ramp_versions.contains(dest_chain_selector),
+            state.on_ramp_versions.contains(&dest_chain_selector),
             error::invalid_argument(E_UNSUPPORTED_DESTINATION_CHAIN)
         );
 
-        let on_ramp_version = *state.on_ramp_versions.borrow(dest_chain_selector);
+        let on_ramp_version = *state.on_ramp_versions.borrow(&dest_chain_selector);
 
         if (on_ramp_version == vector[1, 6, 0]) {
             @ccip_onramp
@@ -124,11 +124,11 @@ module ccip_router::router {
         let state = borrow_state();
 
         assert!(
-            state.on_ramp_versions.contains(dest_chain_selector),
+            state.on_ramp_versions.contains(&dest_chain_selector),
             error::invalid_argument(E_UNSUPPORTED_DESTINATION_CHAIN)
         );
 
-        let on_ramp_version = *state.on_ramp_versions.borrow(dest_chain_selector);
+        let on_ramp_version = *state.on_ramp_versions.borrow(&dest_chain_selector);
 
         if (on_ramp_version == vector[1, 6, 0]) {
             onramp_1_6_0::get_fee(
@@ -193,11 +193,11 @@ module ccip_router::router {
         let state = borrow_state();
 
         assert!(
-            state.on_ramp_versions.contains(dest_chain_selector),
+            state.on_ramp_versions.contains(&dest_chain_selector),
             error::invalid_argument(E_UNSUPPORTED_DESTINATION_CHAIN)
         );
 
-        let on_ramp_version = *state.on_ramp_versions.borrow(dest_chain_selector);
+        let on_ramp_version = *state.on_ramp_versions.borrow(&dest_chain_selector);
 
         let state_signer =
             account::create_signer_with_capability(&state.state_signer_cap);
@@ -246,7 +246,11 @@ module ccip_router::router {
     ): vector<vector<u8>> acquires RouterState {
         let state = borrow_state();
         dest_chain_selectors.map((|dest_chain_selector| {
-            *state.on_ramp_versions.borrow_with_default(dest_chain_selector, &vector[])
+            if (state.on_ramp_versions.contains(&dest_chain_selector)) {
+                *state.on_ramp_versions.borrow(&dest_chain_selector)
+            } else {
+                vector[]
+            }
         }))
     }
 
@@ -291,8 +295,8 @@ module ccip_router::router {
             |dest_chain_selector, on_ramp_version| {
                 let version_len = on_ramp_version.length();
                 if (version_len == 0) {
-                    if (state.on_ramp_versions.contains(dest_chain_selector)) {
-                        state.on_ramp_versions.remove(dest_chain_selector);
+                    if (state.on_ramp_versions.contains(&dest_chain_selector)) {
+                        state.on_ramp_versions.remove(&dest_chain_selector);
                     };
                 } else {
                     assert!(

--- a/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool.move
+++ b/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool.move
@@ -4,7 +4,7 @@ module ccip_token_pool::token_pool {
     use std::event::{Self, EventHandle};
     use std::fungible_asset::{Self, FungibleAsset, Metadata};
     use std::object::{Self, Object};
-    use std::smart_table::{Self, SmartTable};
+    use std::big_ordered_map::{Self, BigOrderedMap};
 
     use ccip::address;
     use ccip::eth_abi;
@@ -23,7 +23,7 @@ module ccip_token_pool::token_pool {
     struct TokenPoolState has key, store {
         allowlist_state: allowlist::AllowlistState,
         fa_metadata: Object<Metadata>,
-        remote_chain_configs: SmartTable<u64, RemoteChainConfig>,
+        remote_chain_configs: BigOrderedMap<u64, RemoteChainConfig>,
         rate_limiter_config: token_pool_rate_limiter::RateLimitState,
         locked_events: EventHandle<LockedOrBurned>,
         released_events: EventHandle<ReleasedOrMinted>,
@@ -139,7 +139,7 @@ module ccip_token_pool::token_pool {
         TokenPoolState {
             allowlist_state: allowlist::new(event_account, allowlist),
             fa_metadata,
-            remote_chain_configs: smart_table::new(),
+            remote_chain_configs: big_ordered_map::new_with_config(0, 0, false),
             rate_limiter_config: token_pool_rate_limiter::new(event_account),
             locked_events: account::new_event_handle(event_account),
             released_events: account::new_event_handle(event_account),
@@ -189,7 +189,7 @@ module ccip_token_pool::token_pool {
     public fun is_supported_chain(
         state: &TokenPoolState, remote_chain_selector: u64
     ): bool {
-        state.remote_chain_configs.contains(remote_chain_selector)
+        state.remote_chain_configs.contains(&remote_chain_selector)
     }
 
     public fun apply_chain_updates(
@@ -202,10 +202,10 @@ module ccip_token_pool::token_pool {
         remote_chain_selectors_to_remove.for_each_ref(|remote_chain_selector| {
             let remote_chain_selector: u64 = *remote_chain_selector;
             assert!(
-                state.remote_chain_configs.contains(remote_chain_selector),
+                state.remote_chain_configs.contains(&remote_chain_selector),
                 error::invalid_argument(E_UNKNOWN_REMOTE_CHAIN_SELECTOR)
             );
-            state.remote_chain_configs.remove(remote_chain_selector);
+            state.remote_chain_configs.remove(&remote_chain_selector);
 
             event::emit(ChainRemoved { remote_chain_selector });
             event::emit_event(
@@ -226,7 +226,7 @@ module ccip_token_pool::token_pool {
         for (i in 0..add_len) {
             let remote_chain_selector = remote_chain_selectors_to_add[i];
             assert!(
-                !state.remote_chain_configs.contains(remote_chain_selector),
+                !state.remote_chain_configs.contains(&remote_chain_selector),
                 error::invalid_argument(E_REMOTE_CHAIN_ALREADY_EXISTS)
             );
             let remote_pool_addresses = remote_pool_addresses_to_add[i];
@@ -277,11 +277,11 @@ module ccip_token_pool::token_pool {
         state: &TokenPoolState, remote_chain_selector: u64
     ): vector<vector<u8>> {
         assert!(
-            state.remote_chain_configs.contains(remote_chain_selector),
+            state.remote_chain_configs.contains(&remote_chain_selector),
             error::invalid_argument(E_UNKNOWN_REMOTE_CHAIN_SELECTOR)
         );
         let remote_chain_config =
-            state.remote_chain_configs.borrow(remote_chain_selector);
+            state.remote_chain_configs.borrow(&remote_chain_selector);
         remote_chain_config.remote_pools
     }
 
@@ -297,11 +297,11 @@ module ccip_token_pool::token_pool {
         state: &TokenPoolState, remote_chain_selector: u64
     ): vector<u8> {
         assert!(
-            state.remote_chain_configs.contains(remote_chain_selector),
+            state.remote_chain_configs.contains(&remote_chain_selector),
             error::invalid_argument(E_UNKNOWN_REMOTE_CHAIN_SELECTOR)
         );
         let remote_chain_config =
-            state.remote_chain_configs.borrow(remote_chain_selector);
+            state.remote_chain_configs.borrow(&remote_chain_selector);
         remote_chain_config.remote_token_address
     }
 
@@ -313,16 +313,24 @@ module ccip_token_pool::token_pool {
         address::assert_non_zero_address_vector(&remote_pool_address);
 
         assert!(
-            state.remote_chain_configs.contains(remote_chain_selector),
+            state.remote_chain_configs.contains(&remote_chain_selector),
             error::invalid_argument(E_UNKNOWN_REMOTE_CHAIN_SELECTOR)
         );
+
+        // Use remove and add pattern due to variable size struct
+        // https://github.com/aptos-labs/aptos-core/blob/96fa267/aptos-move/framework/aptos-framework/sources/datastructures/big_ordered_map.move#L450
         let remote_chain_config =
-            state.remote_chain_configs.borrow_mut(remote_chain_selector);
+            state.remote_chain_configs.remove(&remote_chain_selector);
 
         let (found, _) = remote_chain_config.remote_pools.index_of(&remote_pool_address);
         assert!(!found, error::invalid_argument(E_REMOTE_POOL_ALREADY_ADDED));
 
         remote_chain_config.remote_pools.push_back(remote_pool_address);
+        let updated_config = RemoteChainConfig {
+            remote_token_address: remote_chain_config.remote_token_address,
+            remote_pools: remote_chain_config.remote_pools
+        };
+        state.remote_chain_configs.add(remote_chain_selector, updated_config);
 
         event::emit(RemotePoolAdded { remote_chain_selector, remote_pool_address });
         event::emit_event(
@@ -337,17 +345,25 @@ module ccip_token_pool::token_pool {
         remote_pool_address: vector<u8>
     ) {
         assert!(
-            state.remote_chain_configs.contains(remote_chain_selector),
+            state.remote_chain_configs.contains(&remote_chain_selector),
             error::invalid_argument(E_UNKNOWN_REMOTE_CHAIN_SELECTOR)
         );
+
+        // Use remove and add pattern due to variable size struct
         let remote_chain_config =
-            state.remote_chain_configs.borrow_mut(remote_chain_selector);
+            state.remote_chain_configs.remove(&remote_chain_selector);
 
         let (found, i) = remote_chain_config.remote_pools.index_of(&remote_pool_address);
         assert!(found, error::invalid_argument(E_UNKNOWN_REMOTE_POOL));
 
         // remove instead of swap_remove for readability, so the newest added pool is always at the end.
         remote_chain_config.remote_pools.remove(i);
+
+        let updated_config = RemoteChainConfig {
+            remote_token_address: remote_chain_config.remote_token_address,
+            remote_pools: remote_chain_config.remote_pools
+        };
+        state.remote_chain_configs.add(remote_chain_selector, updated_config);
 
         event::emit(RemotePoolRemoved { remote_chain_selector, remote_pool_address });
         event::emit_event(
@@ -691,7 +707,7 @@ module ccip_token_pool::token_pool {
         } = state;
 
         allowlist::destroy_allowlist(allowlist_state);
-        remote_chain_configs.destroy();
+        remote_chain_configs.destroy(|_dv| {});
         event::destroy_handle(locked_events);
         event::destroy_handle(released_events);
         event::destroy_handle(remote_pool_added_events);

--- a/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool_rate_limiter.move
+++ b/contracts/ccip/ccip_token_pools/token_pool/sources/token_pool_rate_limiter.move
@@ -1,6 +1,5 @@
 module ccip_token_pool::token_pool_rate_limiter {
-    use std::smart_table;
-    use std::smart_table::SmartTable;
+    use std::big_ordered_map::{Self, BigOrderedMap};
     use std::account;
     use std::error;
     use std::event;
@@ -9,8 +8,8 @@ module ccip_token_pool::token_pool_rate_limiter {
     use ccip_token_pool::rate_limiter;
 
     struct RateLimitState has store {
-        outbound_rate_limiter_config: SmartTable<u64, rate_limiter::TokenBucket>,
-        inbound_rate_limiter_config: SmartTable<u64, rate_limiter::TokenBucket>,
+        outbound_rate_limiter_config: BigOrderedMap<u64, rate_limiter::TokenBucket>,
+        inbound_rate_limiter_config: BigOrderedMap<u64, rate_limiter::TokenBucket>,
         tokens_consumed_events: EventHandle<TokensConsumed>,
         config_changed_events: EventHandle<ConfigChanged>
     }
@@ -36,8 +35,8 @@ module ccip_token_pool::token_pool_rate_limiter {
 
     public fun new(event_account: &signer): RateLimitState {
         RateLimitState {
-            outbound_rate_limiter_config: smart_table::new(),
-            inbound_rate_limiter_config: smart_table::new(),
+            outbound_rate_limiter_config: big_ordered_map::new_with_config(0, 0, false),
+            inbound_rate_limiter_config: big_ordered_map::new_with_config(0, 0, false),
             tokens_consumed_events: account::new_event_handle(event_account),
             config_changed_events: account::new_event_handle(event_account)
         }
@@ -67,16 +66,16 @@ module ccip_token_pool::token_pool_rate_limiter {
 
     inline fun consume_from_bucket(
         tokens_consumed_events: &mut EventHandle<TokensConsumed>,
-        rate_limiter: &mut SmartTable<u64, rate_limiter::TokenBucket>,
+        rate_limiter: &mut BigOrderedMap<u64, rate_limiter::TokenBucket>,
         dest_chain_selector: u64,
         requested_tokens: u64
     ) {
         assert!(
-            rate_limiter.contains(dest_chain_selector),
+            rate_limiter.contains(&dest_chain_selector),
             error::invalid_argument(E_BUCKET_NOT_FOUND)
         );
 
-        let bucket = rate_limiter.borrow_mut(dest_chain_selector);
+        let bucket = rate_limiter.borrow_mut(&dest_chain_selector);
         rate_limiter::consume(bucket, requested_tokens);
 
         event::emit(
@@ -104,10 +103,13 @@ module ccip_token_pool::token_pool_rate_limiter {
         inbound_capacity: u64,
         inbound_rate: u64
     ) {
-        let outbound_config =
-            state.outbound_rate_limiter_config.borrow_mut_with_default(
+        if (!state.outbound_rate_limiter_config.contains(&remote_chain_selector)) {
+            state.outbound_rate_limiter_config.add(
                 remote_chain_selector, rate_limiter::new(false, 0, 0)
             );
+        };
+        let outbound_config =
+            state.outbound_rate_limiter_config.borrow_mut(&remote_chain_selector);
         rate_limiter::set_token_bucket_config(
             outbound_config,
             outbound_is_enabled,
@@ -115,10 +117,13 @@ module ccip_token_pool::token_pool_rate_limiter {
             outbound_rate
         );
 
-        let inbound_config =
-            state.inbound_rate_limiter_config.borrow_mut_with_default(
+        if (!state.inbound_rate_limiter_config.contains(&remote_chain_selector)) {
+            state.inbound_rate_limiter_config.add(
                 remote_chain_selector, rate_limiter::new(false, 0, 0)
             );
+        };
+        let inbound_config =
+            state.inbound_rate_limiter_config.borrow_mut(&remote_chain_selector);
         rate_limiter::set_token_bucket_config(
             inbound_config,
             inbound_is_enabled,
@@ -155,7 +160,7 @@ module ccip_token_pool::token_pool_rate_limiter {
         state: &RateLimitState, remote_chain_selector: u64
     ): rate_limiter::TokenBucket {
         rate_limiter::get_current_token_bucket_state(
-            state.inbound_rate_limiter_config.borrow(remote_chain_selector)
+            state.inbound_rate_limiter_config.borrow(&remote_chain_selector)
         )
     }
 
@@ -163,7 +168,7 @@ module ccip_token_pool::token_pool_rate_limiter {
         state: &RateLimitState, remote_chain_selector: u64
     ): rate_limiter::TokenBucket {
         rate_limiter::get_current_token_bucket_state(
-            state.outbound_rate_limiter_config.borrow(remote_chain_selector)
+            state.outbound_rate_limiter_config.borrow(&remote_chain_selector)
         )
     }
 
@@ -175,8 +180,8 @@ module ccip_token_pool::token_pool_rate_limiter {
             config_changed_events
         } = state;
 
-        outbound_rate_limiter_config.destroy();
-        inbound_rate_limiter_config.destroy();
+        outbound_rate_limiter_config.destroy(|_dv| {});
+        inbound_rate_limiter_config.destroy(|_dv| {});
         event::destroy_handle(tokens_consumed_events);
         event::destroy_handle(config_changed_events);
     }

--- a/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/usdc_token_pool/sources/usdc_token_pool.move
@@ -8,7 +8,7 @@ module usdc_token_pool::usdc_token_pool {
     use std::object::{Self, Object, ObjectCore};
     use std::option;
     use std::signer;
-    use std::smart_table::{Self, SmartTable};
+    use std::big_ordered_map::{Self, BigOrderedMap};
     use std::string::{Self, String};
 
     use ccip::address;
@@ -41,7 +41,7 @@ module usdc_token_pool::usdc_token_pool {
         store_signer_cap: SignerCapability,
         ownable_state: ownable::OwnableState,
         token_pool_state: token_pool::TokenPoolState,
-        chain_to_domain: SmartTable<u64, Domain>,
+        chain_to_domain: BigOrderedMap<u64, Domain>,
         local_domain_identifier: u32,
         store_signer_address: address,
         domain_set_events: EventHandle<DomainsSet>
@@ -166,7 +166,7 @@ module usdc_token_pool::usdc_token_pool {
         let pool = USDCTokenPoolState {
             ownable_state,
             store_signer_address: signer::address_of(&store_signer),
-            chain_to_domain: smart_table::new(),
+            chain_to_domain: big_ordered_map::new_with_config(0, 0, false),
             local_domain_identifier: message_transmitter::local_domain(),
             store_signer_cap,
             token_pool_state,
@@ -329,11 +329,11 @@ module usdc_token_pool::usdc_token_pool {
         let remote_chain_selector =
             token_admin_registry::get_lock_or_burn_remote_chain_selector(&input);
         assert!(
-            smart_table::contains(&pool.chain_to_domain, remote_chain_selector),
+            pool.chain_to_domain.contains(&remote_chain_selector),
             error::invalid_argument(E_DOMAIN_NOT_FOUND)
         );
 
-        let remote_domain_info = pool.chain_to_domain.borrow(remote_chain_selector);
+        let remote_domain_info = pool.chain_to_domain.borrow(&remote_chain_selector);
 
         assert!(
             remote_domain_info.enabled,
@@ -503,7 +503,7 @@ module usdc_token_pool::usdc_token_pool {
     #[view]
     public fun get_domain(chain_selector: u64): Domain acquires USDCTokenPoolState {
         let pool = borrow_pool();
-        *pool.chain_to_domain.borrow(chain_selector)
+        *pool.chain_to_domain.borrow(&chain_selector)
     }
 
     public fun set_domains(

--- a/contracts/mcms/mcms/sources/mcms.move
+++ b/contracts/mcms/mcms/sources/mcms.move
@@ -6,12 +6,13 @@ module mcms::mcms {
     use std::signer;
     use std::simple_map::{Self, SimpleMap};
     use std::string::{String};
-    use aptos_std::smart_table::{Self, SmartTable};
-    use aptos_std::smart_vector::{Self, SmartVector};
-    use aptos_framework::chain_id;
-    use aptos_framework::object::{Self, ExtendRef, Object};
-    use aptos_framework::timestamp;
-    use aptos_std::secp256k1;
+    use std::big_ordered_map::{Self, BigOrderedMap};
+    use std::smart_vector::{Self, SmartVector};
+    use std::chain_id;
+    use std::object::{Self, ExtendRef, Object};
+    use std::timestamp;
+    use std::secp256k1;
+
     use mcms::bcs_stream::{Self, BCSStream};
     use mcms::mcms_account;
     use mcms::mcms_deployer;
@@ -220,7 +221,7 @@ module mcms::mcms {
             publisher,
             Timelock {
                 min_delay: 0,
-                timestamps: smart_table::new(),
+                timestamps: big_ordered_map::new_with_config(0, 0, false),
                 blocked_functions: smart_vector::new()
             }
         );
@@ -1048,7 +1049,7 @@ module mcms::mcms {
     struct Timelock has key {
         min_delay: u64,
         /// hashed batch of hashed calls -> timestamp
-        timestamps: SmartTable<vector<u8>, u64>,
+        timestamps: BigOrderedMap<vector<u8>, u64>,
         /// blocked functions
         blocked_functions: SmartVector<Function>
     }
@@ -1187,7 +1188,9 @@ module mcms::mcms {
 
     inline fun timelock_after_call(id: vector<u8>) {
         assert!(timelock_is_operation_ready(id), E_OPERATION_NOT_READY);
-        *borrow_mut_timelock().timestamps.borrow_mut(id) = DONE_TIMESTAMP;
+        let timelock = borrow_mut_timelock();
+        timelock.timestamps.remove(&id);
+        timelock.timestamps.add(id, DONE_TIMESTAMP);
     }
 
     /// Anyone can call this as it checks if the operation was scheduled by a bypasser or proposer.
@@ -1438,7 +1441,7 @@ module mcms::mcms {
     inline fun timelock_cancel(id: vector<u8>) {
         assert!(timelock_is_operation_pending(id), E_OPERATION_CANNOT_BE_CANCELLED);
 
-        borrow_mut_timelock().timestamps.remove(id);
+        borrow_mut_timelock().timestamps.remove(&id);
         event::emit(Cancelled { id });
     }
 
@@ -1513,39 +1516,39 @@ module mcms::mcms {
     inline fun timelock_is_operation_internal(
         timelock: &Timelock, id: vector<u8>
     ): bool {
-        timelock.timestamps.contains(id) && *timelock.timestamps.borrow(id) > 0
+        timelock.timestamps.contains(&id) && *timelock.timestamps.borrow(&id) > 0
     }
 
     #[view]
     public fun timelock_is_operation_pending(id: vector<u8>): bool acquires Timelock {
         let timelock = borrow_timelock();
-        timelock.timestamps.contains(id)
-            && *timelock.timestamps.borrow(id) > DONE_TIMESTAMP
+        timelock.timestamps.contains(&id)
+            && *timelock.timestamps.borrow(&id) > DONE_TIMESTAMP
     }
 
     #[view]
     public fun timelock_is_operation_ready(id: vector<u8>): bool acquires Timelock {
         let timelock = borrow_timelock();
-        if (!timelock.timestamps.contains(id)) {
+        if (!timelock.timestamps.contains(&id)) {
             return false
         };
 
-        let timestamp_value = *timelock.timestamps.borrow(id);
+        let timestamp_value = *timelock.timestamps.borrow(&id);
         timestamp_value > DONE_TIMESTAMP && timestamp_value <= timestamp::now_seconds()
     }
 
     #[view]
     public fun timelock_is_operation_done(id: vector<u8>): bool acquires Timelock {
         let timelock = borrow_timelock();
-        timelock.timestamps.contains(id)
-            && *timelock.timestamps.borrow(id) == DONE_TIMESTAMP
+        timelock.timestamps.contains(&id)
+            && *timelock.timestamps.borrow(&id) == DONE_TIMESTAMP
     }
 
     #[view]
     public fun timelock_get_timestamp(id: vector<u8>): u64 acquires Timelock {
         let timelock = borrow_timelock();
-        if (timelock.timestamps.contains(id)) {
-            *timelock.timestamps.borrow(id)
+        if (timelock.timestamps.contains(&id)) {
+            *timelock.timestamps.borrow(&id)
         } else { 0 }
     }
 

--- a/contracts/mcms/mcms/sources/mcms_deployer.move
+++ b/contracts/mcms/mcms/sources/mcms_deployer.move
@@ -3,7 +3,7 @@
 module mcms::mcms_deployer {
     use std::code::PackageRegistry;
     use std::error;
-    use std::smart_table::{Self, SmartTable};
+    use std::big_ordered_map::{Self, BigOrderedMap};
     use std::object;
     use std::object_code_deployment;
 
@@ -14,7 +14,7 @@ module mcms::mcms_deployer {
 
     struct StagingArea has key {
         metadata_serialized: vector<u8>,
-        code: SmartTable<u64, vector<u8>>,
+        code: BigOrderedMap<u64, vector<u8>>,
         last_module_idx: u64
     }
 
@@ -105,7 +105,7 @@ module mcms::mcms_deployer {
                 &mcms_account::get_signer(),
                 StagingArea {
                     metadata_serialized: vector[],
-                    code: smart_table::new(),
+                    code: big_ordered_map::new_with_config(0, 0, false),
                     last_module_idx: 0
                 }
             );
@@ -121,8 +121,11 @@ module mcms::mcms_deployer {
             let inner_code = code_chunks[i];
             let idx = (code_indices[i] as u64);
 
-            if (staging_area.code.contains(idx)) {
-                staging_area.code.borrow_mut(idx).append(inner_code);
+            if (staging_area.code.contains(&idx)) {
+                // Use remove-modify-add pattern instead of borrow_mut for variable-sized values
+                let existing_code = staging_area.code.remove(&idx);
+                existing_code.append(inner_code);
+                staging_area.code.add(idx, existing_code);
             } else {
                 staging_area.code.add(idx, inner_code);
                 if (idx > staging_area.last_module_idx) {
@@ -138,7 +141,7 @@ module mcms::mcms_deployer {
         let last_module_idx = staging_area.last_module_idx;
         let code = vector[];
         for (i in 0..(last_module_idx + 1)) {
-            code.push_back(*staging_area.code.borrow(i));
+            code.push_back(*staging_area.code.borrow(&i));
         };
         code
     }
@@ -146,6 +149,6 @@ module mcms::mcms_deployer {
     inline fun cleanup_staging_area_internal() {
         let StagingArea { metadata_serialized: _, code, last_module_idx: _ } =
             move_from<StagingArea>(@mcms);
-        code.destroy();
+        code.destroy(|_dv| {});
     }
 }


### PR DESCRIPTION
## Desc
Migrate SmartTable to BigOrderedMap

## Limitations
`BigOrderedMap`
- When using `borrow_mut`, is either key or value has a variable size, `borrow_mut` reverts.
- From docs: https://github.com/aptos-labs/aptos-core/blob/96fa267/aptos-move/framework/aptos-framework/sources/datastructures/big_ordered_map.move#L450

"In case of variable size, use either `borrow`, `copy` then `upsert`, or `remove` and `add` instead of mutable borrow."

