### PR TITLE
fix(bindings): remove unused tokenPoolAdministrator argument

### DIFF
--- a/bindings/ccip_token_pools/managed_token_pool/managed_token_pool.go
+++ b/bindings/ccip_token_pools/managed_token_pool/managed_token_pool.go
@@ -36,7 +36,7 @@ var FunctionInfo = bind.MustParseFunctionInfo(
 	module_managed_token_pool.FunctionInfo,
 )
 
-func Compile(address, ccipAddress, mcmsAddress, ccipTokenPoolAddress, managedTokenAddress, tokenPoolAdministrator aptos.AccountAddress, registerMCMSEntrypoints bool) (compile.CompiledPackage, error) {
+func Compile(address, ccipAddress, mcmsAddress, ccipTokenPoolAddress, managedTokenAddress aptos.AccountAddress, registerMCMSEntrypoints bool) (compile.CompiledPackage, error) {
 	namedAddresses := map[string]aptos.AccountAddress{
 		"managed_token_pool":        address,
 		"ccip":                      ccipAddress,


### PR DESCRIPTION
Removing `tokenPoolAdministrator` from the arguments since it's not beeign used. 