### PR TITLE
Add Object resource group identifier

### DIFF
--- a/contracts/ccip/ccip/sources/auth.move
+++ b/contracts/ccip/ccip/sources/auth.move
@@ -12,6 +12,7 @@ module ccip::auth {
     use mcms::bcs_stream;
     use mcms::mcms_registry;
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct AuthState has key {
         ownable_state: ownable::OwnableState,
         allowed_onramps: allowlist::AllowlistState,

--- a/contracts/ccip/ccip/sources/fee_quoter.move
+++ b/contracts/ccip/ccip/sources/fee_quoter.move
@@ -87,6 +87,7 @@ module ccip::fee_quoter {
     // the fee by 1e10 on Aptos before we emit it in the event.
     const LOCAL_8_TO_18_DECIMALS_LINK_MULTIPLIER: u256 = 10_000_000_000;
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct FeeQuoterState has key, store {
         // max_fee_juels_per_msg is in juels (1e18) denomination for consistency across chains.
         max_fee_juels_per_msg: u256,

--- a/contracts/ccip/ccip/sources/nonce_manager.move
+++ b/contracts/ccip/ccip/sources/nonce_manager.move
@@ -6,6 +6,7 @@ module ccip::nonce_manager {
     use ccip::auth;
     use ccip::state_object;
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct NonceManagerState has key, store {
         // dest chain selector -> sender -> nonce
         outbound_nonces: SmartTable<u64, SmartTable<address, u64>>

--- a/contracts/ccip/ccip/sources/receiver_registry.move
+++ b/contracts/ccip/ccip/sources/receiver_registry.move
@@ -17,6 +17,7 @@ module ccip::receiver_registry {
 
     friend ccip::receiver_dispatcher;
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct ReceiverRegistryState has key, store {
         extend_ref: ExtendRef,
         transfer_ref: TransferRef,

--- a/contracts/ccip/ccip/sources/rmn_remote.move
+++ b/contracts/ccip/ccip/sources/rmn_remote.move
@@ -22,6 +22,7 @@ module ccip::rmn_remote {
 
     const GLOBAL_CURSE_SUBJECT: vector<u8> = x"01000000000000000000000000000001";
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct RMNRemoteState has key {
         local_chain_selector: u64,
         config: Config,

--- a/contracts/ccip/ccip/sources/state_object.move
+++ b/contracts/ccip/ccip/sources/state_object.move
@@ -21,6 +21,7 @@ module ccip::state_object {
     friend ccip::rmn_remote;
     friend ccip::token_admin_registry;
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct StateObjectRefs has key {
         extend_ref: ExtendRef,
         transfer_ref: TransferRef

--- a/contracts/ccip/ccip/sources/token_admin_registry.move
+++ b/contracts/ccip/ccip/sources/token_admin_registry.move
@@ -26,6 +26,7 @@ module ccip::token_admin_registry {
         RELEASE_OR_MINT
     }
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct TokenAdminRegistryState has key, store {
         extend_ref: ExtendRef,
         transfer_ref: TransferRef,

--- a/contracts/managed_token_faucet/sources/faucet.move
+++ b/contracts/managed_token_faucet/sources/faucet.move
@@ -10,6 +10,7 @@ module managed_token::faucet {
 
     const E_NOT_PUBLISHER: u64 = 1;
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct FaucetState has key, store {
         extend_ref: ExtendRef
     }


### PR DESCRIPTION
## Desc
Add Object resource group identifier to CCIP resources. 

Provides better gas optimizations, as resources are accessed more efficiently.

These resources are stored within objects, hence the change. Provides ability to upgrade the same object. 
