### PR TITLE
Address/remove todos

### DIFF
--- a/contracts/ccip/ccip/sources/fee_quoter.move
+++ b/contracts/ccip/ccip/sources/fee_quoter.move
@@ -43,7 +43,7 @@ module ccip::fee_quoter {
     const MOVE_PRECOMPILE_SPACE: u256 = 0x0b;
 
     const GAS_PRICE_BITS: u8 = 112;
-    const GAS_PRICE_MASK_112_BITS: u256 = (MAX_U256 >> (255 - GAS_PRICE_BITS + 1)); // 2^112 - 1
+    const GAS_PRICE_MASK_112_BITS: u256 = 0xffffffffffffffffffffffffffff; // 28 f's
 
     const MESSAGE_FIXED_BYTES: u64 = 32 * 15;
     const MESSAGE_FIXED_BYTES_PER_TOKEN: u64 = 32 * (4 + (3 + 2));

--- a/contracts/ccip/ccip/sources/fee_quoter.move
+++ b/contracts/ccip/ccip/sources/fee_quoter.move
@@ -43,6 +43,7 @@ module ccip::fee_quoter {
     const MOVE_PRECOMPILE_SPACE: u256 = 0x0b;
 
     const GAS_PRICE_BITS: u8 = 112;
+    const GAS_PRICE_MASK_112_BITS: u256 = (MAX_U256 >> (255 - GAS_PRICE_BITS + 1)); // 2^112 - 1
 
     const MESSAGE_FIXED_BYTES: u64 = 32 * 15;
     const MESSAGE_FIXED_BYTES_PER_TOKEN: u64 = 32 * (4 + (3 + 2));
@@ -98,7 +99,6 @@ module ccip::fee_quoter {
         dest_chain_configs: SmartTable<u64, DestChainConfig>,
         // dest chain selector -> local token -> TokenTransferFeeConfig
         token_transfer_fee_configs: SmartTable<u64, SmartTable<address, TokenTransferFeeConfig>>,
-        // TODO: update calculations - should this be octa per apt?
         premium_multiplier_wei_per_eth: SmartTable<address, u64>,
         fee_token_added_events: EventHandle<FeeTokenAdded>,
         fee_token_removed_events: EventHandle<FeeTokenRemoved>,
@@ -674,7 +674,6 @@ module ccip::fee_quoter {
                 state, dest_chain_config, dest_chain_selector
             );
 
-        // TODO: this should probably be premium_fee_usd_octa for aptos?
         let (premium_fee_usd_wei, token_transfer_gas, token_transfer_bytes_overhead) =
             if (tokens_len > 0) {
                 get_token_transfer_cost(
@@ -695,10 +694,9 @@ module ccip::fee_quoter {
 
         let data_availability_cost_usd_36_decimals =
             if (dest_chain_config.dest_data_availability_multiplier_bps > 0) {
-                // TODO: on EVM, the gas price is uint224 and the top 112 bits are used. here we're using a u256
-                // and expecting that the extra top 22 bits are zeroes. update this and `gas_cost` below
-                // if needed.
-                let data_availability_gas_price = packed_gas_price >> GAS_PRICE_BITS;
+                // Extract data availability gas price (upper 112 bits) - matches EVM uint112 behavior
+                let data_availability_gas_price =
+                    (packed_gas_price >> GAS_PRICE_BITS) & GAS_PRICE_MASK_112_BITS;
                 get_data_availability_cost(
                     dest_chain_config,
                     data_availability_gas_price,
@@ -730,7 +728,7 @@ module ccip::fee_quoter {
             (dest_chain_config.dest_gas_overhead as u256) + (token_transfer_gas as u256)
                 + dest_call_data_cost + gas_limit;
 
-        let gas_cost = packed_gas_price & (MAX_U256 >> (255 - GAS_PRICE_BITS + 1));
+        let gas_cost = packed_gas_price & GAS_PRICE_MASK_112_BITS;
 
         let total_cost_usd =
             (

--- a/contracts/ccip/ccip/tests/client_test.move
+++ b/contracts/ccip/ccip/tests/client_test.move
@@ -78,7 +78,7 @@ module ccip::client_test {
     ]
     fun test_svm_token_shorter_receiver() {
         let short_receiver = vector[1, 2, 3];
-        let encoded =
+        let _encoded =
             client::encode_svm_extra_args_v1(
                 100u32, 0u64, false, short_receiver, vector[]
             );

--- a/contracts/ccip/ccip/tests/fee_quoter/fee_quoter_calculation.move
+++ b/contracts/ccip/ccip/tests/fee_quoter/fee_quoter_calculation.move
@@ -349,4 +349,17 @@ module ccip::fee_quoter_calculation {
             fee_quoter_setup::create_extra_args(500000, true) // extra args
         );
     }
+
+    #[test(aptos_framework = @aptos_framework, ccip = @ccip, owner = @mcms)]
+    fun test_gas_price_mask_112_bits(
+        aptos_framework: &signer, ccip: &signer, owner: &signer
+    ) {
+        let gas_price_bits = 112;
+        let twenty_eight_fs = 0xffffffffffffffffffffffffffff;
+        let max_u256 =
+            115792089237316195423570985008687907853269984665640564039457584007913129639935;
+        let gas_price_mask_112_bits = (max_u256 >> (255 - gas_price_bits + 1)); // 2^112 - 1
+
+        assert!(gas_price_mask_112_bits == twenty_eight_fs);
+    }
 }

--- a/contracts/ccip/ccip_offramp/sources/ocr3_base.move
+++ b/contracts/ccip/ccip_offramp/sources/ocr3_base.move
@@ -271,8 +271,6 @@ module ccip_offramp::ocr3_base {
             error::invalid_argument(E_INVALID_SEQUENCE_LENGTH)
         );
 
-        // TODO: EVM checks transaction data length here
-
         assert!(
             config_digest == config_info.config_digest,
             error::invalid_argument(E_CONFIG_DIGEST_MISMATCH)

--- a/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
@@ -409,7 +409,6 @@ module managed_token_pool::managed_token_pool {
     // |                      Storage helpers                         |
     // ================================================================
 
-    // TODO: separate functions due to deploy error, see ccip::state_object
     #[view]
     public fun get_store_address(): address {
         store_address()


### PR DESCRIPTION
# Description

### Addressing Todos
1. Data availability gas price extraction wasn't properly masked to 112 bits to match EVM behavior.

**fee_quoter:**
- Added `GAS_PRICE_MASK_112_BITS` constant: `(MAX_U256 >> (255 - GAS_PRICE_BITS + 1))`
- Amend data availability extraction: `(packed_gas_price >> GAS_PRICE_BITS) & GAS_PRICE_MASK_112_BITS`
- Updated execution gas extraction: `packed_gas_price & GAS_PRICE_MASK_112_BITS`
- Removed resolved TODO comments

Ensures gas prices are limited to 112 bits each (matching EVM's uint224 = 112+112 bits), maintaining cross-chain fee consistency.

2. Remove TODO

**ocr3_base** Removed `// TODO: EVM checks transaction data length here`
- EVM's `msg.data` length validation is for ABI format integrity. Move's type system provides equivalent protection automatically, making this check unneeded
