### PR TITLE
Passing source chain selector as string in getSourceChainConfig comparator

### DIFF
--- a/relayer/chainreader/tx_poller.go
+++ b/relayer/chainreader/tx_poller.go
@@ -397,7 +397,7 @@ func (a *aptosChainReader) getSourceChainConfig(ctx context.Context, sourceChain
 
 	filter := []query.Expression{
 		query.Comparator(selector,
-			primitives.ValueComparator{Value: sourceChainSelector, Operator: primitives.Eq},
+			primitives.ValueComparator{Value: fmt.Sprintf("%d", sourceChainSelector), Operator: primitives.Eq},
 		),
 	}
 

--- a/relayer/txm/txstore.go
+++ b/relayer/txm/txstore.go
@@ -147,7 +147,7 @@ func (s *TxStore) GetUnconfirmed() []*UnconfirmedTx {
 
 	for i, tx := range unconfirmed {
 		// create a shallow copy with the same fields
-		// note: still sharing the same tx pointer, 
+		// note: still sharing the same tx pointer,
 		// accessing underlying AptosTx must be synchronized
 		result[i] = &UnconfirmedTx{
 			Nonce:                   tx.Nonce,


### PR DESCRIPTION
…rator to bypass int64 conversion