### PR TITLE
Bump Aptos CLI to 7.8.1 (CME-1724)

### DIFF
--- a/.github/workflows/aptos-bindings.yml
+++ b/.github/workflows/aptos-bindings.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install Aptos CLI
         uses: aptos-labs/actions/install-aptos-cli@ce57287eb852b9819c1d74fecc3be187677559fd # v0.1
         with:
-          CLI_VERSION: 7.7.0
+          CLI_VERSION: 7.8.1
       - name: Run make wrappers
         run: make wrappers
       - name: Check if any files have been changed

--- a/.github/workflows/aptos-contracts.yml
+++ b/.github/workflows/aptos-contracts.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Aptos CLI
       uses: aptos-labs/actions/install-aptos-cli@ce57287eb852b9819c1d74fecc3be187677559fd # v0.1
       with:
-        CLI_VERSION: 7.7.0
+        CLI_VERSION: 7.8.1
 
     - name: Run tests
       run: make move-test

--- a/.github/workflows/aptos-movefmt.yml
+++ b/.github/workflows/aptos-movefmt.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install Aptos CLI
         uses: aptos-labs/actions/install-aptos-cli@ce57287eb852b9819c1d74fecc3be187677559fd # v0.1
         with:
-          CLI_VERSION: 7.7.0
+          CLI_VERSION: 7.8.1
       - name: Update movefmt
         run: aptos update movefmt --target-version 1.0.8 # Fix version to prevent accidentally breaking the CI
       - name: Run movefmt

--- a/.github/workflows/aptos-relayer.yml
+++ b/.github/workflows/aptos-relayer.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install Aptos CLI
       uses: aptos-labs/actions/install-aptos-cli@ce57287eb852b9819c1d74fecc3be187677559fd # v0.1
       with:
-        CLI_VERSION: 7.7.0
+        CLI_VERSION: 7.8.1
 
     - name: Run tests
       run: cd relayer && go test -count=1 -p=1 -tags=integration ./...

--- a/.github/workflows/go-all.yml
+++ b/.github/workflows/go-all.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Aptos CLI
         uses: aptos-labs/actions/install-aptos-cli@ce57287eb852b9819c1d74fecc3be187677559fd # v0.1
         with:
-          CLI_VERSION: 7.7.0
+          CLI_VERSION: 7.8.1
       - name: Build and test
         uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/1.0.0
         with:


### PR DESCRIPTION
Bump CLI version to: https://github.com/aptos-labs/aptos-core/releases/tag/aptos-cli-v7.8.1