### PR TITLE
Bump Aptos CLI to 7.14.0

### DIFF
--- a/.github/workflows/aptos-bindings.yml
+++ b/.github/workflows/aptos-bindings.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install Aptos CLI
         uses: aptos-labs/actions/install-aptos-cli@ce57287eb852b9819c1d74fecc3be187677559fd # v0.1
         with:
-          CLI_VERSION: 7.13.0
+          CLI_VERSION: 7.14.0
       - name: Run make wrappers
         run: make wrappers
       - name: Check if any files have been changed

--- a/.github/workflows/aptos-ccip-integration-tests.yml
+++ b/.github/workflows/aptos-ccip-integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Aptos CLI
       uses: aptos-labs/actions/install-aptos-cli@ce57287eb852b9819c1d74fecc3be187677559fd # v0.1
       with:
-        CLI_VERSION: 7.13.0
+        CLI_VERSION: 7.14.0
 
     - name: Run tests
       run: |

--- a/.github/workflows/aptos-ccip-tests.yml
+++ b/.github/workflows/aptos-ccip-tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Aptos CLI
         uses: aptos-labs/actions/install-aptos-cli@ce57287eb852b9819c1d74fecc3be187677559fd # v0.1
         with:
-          CLI_VERSION: 7.13.0
+          CLI_VERSION: 7.14.0
 
       - name: Checkout chainlink-aptos
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5

--- a/.github/workflows/aptos-contracts.yml
+++ b/.github/workflows/aptos-contracts.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Aptos CLI
       uses: aptos-labs/actions/install-aptos-cli@ce57287eb852b9819c1d74fecc3be187677559fd # v0.1
       with:
-        CLI_VERSION: 7.13.0
+        CLI_VERSION: 7.14.0
 
     - name: Run tests
       run: make move-test

--- a/.github/workflows/aptos-movefmt.yml
+++ b/.github/workflows/aptos-movefmt.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install Aptos CLI
         uses: aptos-labs/actions/install-aptos-cli@ce57287eb852b9819c1d74fecc3be187677559fd # v0.1
         with:
-          CLI_VERSION: 7.13.0
+          CLI_VERSION: 7.14.0
       - name: Update movefmt
         run: aptos update movefmt --target-version 1.4.5 # Fix version to prevent accidentally breaking the CI
       - name: Run movefmt

--- a/.github/workflows/aptos-relayer.yml
+++ b/.github/workflows/aptos-relayer.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install Aptos CLI
       uses: aptos-labs/actions/install-aptos-cli@ce57287eb852b9819c1d74fecc3be187677559fd # v0.1
       with:
-        CLI_VERSION: 7.13.0
+        CLI_VERSION: 7.14.0
 
     - name: Wait for PostgreSQL
       run: |

--- a/.github/workflows/go-all.yml
+++ b/.github/workflows/go-all.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Aptos CLI
         uses: aptos-labs/actions/install-aptos-cli@ce57287eb852b9819c1d74fecc3be187677559fd # v0.1
         with:
-          CLI_VERSION: 7.13.0
+          CLI_VERSION: 7.14.0
       - name: Build and test
         uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/1.0.0
         with:

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -3,7 +3,7 @@
 dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 container_name="chainlink-aptos.devnet"
-container_image="aptoslabs/tools:aptos-node-v1.38.7"
+container_image="aptoslabs/tools:aptos-node-v1.39.2"
 
 if [ -n "${CUSTOM_IMAGE:-}" ]; then
   container_image="${CUSTOM_IMAGE}"


### PR DESCRIPTION
- Bump Aptos CLI to https://github.com/aptos-labs/aptos-core/releases/tag/aptos-cli-v7.14.0
- Bump Aptos node to https://github.com/aptos-labs/aptos-core/releases/tag/aptos-node-v1.39.2