### PR TITLE
relayer: defer getClient calls

### DIFF
--- a/relayer/chain/chain.go
+++ b/relayer/chain/chain.go
@@ -119,16 +119,12 @@ func newChain(cfg *config.TOMLConfig, loopKs loop.Keystore, lggr logger.Logger, 
 		ds:   ds,
 	}
 
-	getClient := func() (aptos.AptosRpcClient, error) {
-		return ch.GetClient()
-	}
-
-	ch.txm, err = txm.New(lggr, loopKs, *cfg.TransactionManager, getClient)
+	ch.txm, err = txm.New(lggr, loopKs, *cfg.TransactionManager, ch.GetClient)
 	if err != nil {
 		return nil, err
 	}
 
-	ch.logPoller, err = logpoller.NewLogPoller(lggr, ch.chainInfo(), getClient, ds, cfg.LogPoller)
+	ch.logPoller, err = logpoller.NewLogPoller(lggr, ch.chainInfo(), ch.GetClient, ds, cfg.LogPoller)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create log poller: %w", err)
 	}
@@ -140,7 +136,7 @@ func newChain(cfg *config.TOMLConfig, loopKs loop.Keystore, lggr logger.Logger, 
 		Config:    *cfg.BalanceMonitor,
 		Logger:    lggr,
 		Keystore:  loopKs,
-		NewClient: getClient,
+		NewClient: ch.GetClient,
 	})
 	if err != nil {
 		return nil, err

--- a/relayer/logpoller/event_poller.go
+++ b/relayer/logpoller/event_poller.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	cache "github.com/patrickmn/go-cache"
+	"github.com/patrickmn/go-cache"
 
 	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/aptos-labs/aptos-go-sdk/api"
@@ -166,7 +166,12 @@ func (l *AptosLogPoller) syncEvent(ctx context.Context, boundAddress aptos.Accou
 	var resource map[string]any
 
 	if !found {
-		resource, err = l.client.AccountResource(eventAccountAddress, eventHandle)
+		var client aptos.AptosRpcClient
+		client, err = l.getClient()
+		if err != nil {
+			return fmt.Errorf("failed to get client: %w", err)
+		}
+		resource, err = client.AccountResource(eventAccountAddress, eventHandle)
 		if err != nil {
 			return fmt.Errorf("syncEvent: failed to fetch the resource: %w", err)
 		}
@@ -179,7 +184,12 @@ func (l *AptosLogPoller) syncEvent(ctx context.Context, boundAddress aptos.Accou
 		resource, ok = resourceAny.(map[string]any)
 		if !ok {
 			l.lggr.Errorw("Failed to cast cached resource to map[string]any", "key", cacheKey)
-			resource, err = l.client.AccountResource(eventAccountAddress, eventHandle)
+			var client aptos.AptosRpcClient
+			client, err = l.getClient()
+			if err != nil {
+				return fmt.Errorf("failed to get client: %w", err)
+			}
+			resource, err = client.AccountResource(eventAccountAddress, eventHandle)
 			if err != nil {
 				return fmt.Errorf("syncEvent: failed to fetch the resource after cache cast failure: %w", err)
 			}
@@ -195,13 +205,19 @@ func (l *AptosLogPoller) syncEvent(ctx context.Context, boundAddress aptos.Accou
 	batchSize := l.config.EventBatchSize
 	var totalProcessed int = 0
 
+	var client aptos.AptosRpcClient
+	client, err = l.getClient()
+	if err != nil {
+		return fmt.Errorf("failed to get client: %w", err)
+	}
+
 eventLoop:
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			events, err := l.client.EventsByCreationNumber(eventAccountAddress, creationNumber, &latestOffset, &batchSize)
+			events, err := client.EventsByCreationNumber(eventAccountAddress, creationNumber, &latestOffset, &batchSize)
 			if err != nil {
 				l.lggr.Errorw("syncEvent: failed to fetch new events", "error", err)
 				return fmt.Errorf("syncEvent: failed to fetch events: %w", err)
@@ -328,7 +344,11 @@ func (l *AptosLogPoller) computeEventAccountAddress(boundAddress aptos.AccountAd
 			Args:     [][]byte{},
 		}
 
-		data, err := l.client.View(viewPayload)
+		client, err := l.getClient()
+		if err != nil {
+			return eventAccountAddress, err
+		}
+		data, err := client.View(viewPayload)
 		if err != nil {
 			return eventAccountAddress, fmt.Errorf("failed to call view function: %+w", err)
 		}
@@ -354,7 +374,12 @@ func (l *AptosLogPoller) getBlockHead(version uint64) (types.Head, error) {
 		block, ok = cachedBlockAny.(*api.Block)
 		if !ok {
 			l.lggr.Errorw("Failed to cast cached block to *api.Block", "key", cacheKey)
-			block, err = l.client.BlockByVersion(version, false)
+			var client aptos.AptosRpcClient
+			client, err = l.getClient()
+			if err != nil {
+				return types.Head{}, fmt.Errorf("failed to get client: %w", err)
+			}
+			block, err = client.BlockByVersion(version, false)
 			if err != nil {
 				return types.Head{}, fmt.Errorf("failed to get block by version after cache cast failure: %w", err)
 			}
@@ -363,7 +388,12 @@ func (l *AptosLogPoller) getBlockHead(version uint64) (types.Head, error) {
 			l.lggr.Debugw("Using cached block", "version", version)
 		}
 	} else {
-		block, err = l.client.BlockByVersion(version, false)
+		var client aptos.AptosRpcClient
+		client, err = l.getClient()
+		if err != nil {
+			return types.Head{}, fmt.Errorf("failed to get client: %w", err)
+		}
+		block, err = client.BlockByVersion(version, false)
 		if err != nil {
 			return types.Head{}, fmt.Errorf("failed to get block by version: %w", err)
 		}

--- a/relayer/logpoller/logpoller.go
+++ b/relayer/logpoller/logpoller.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	cache "github.com/patrickmn/go-cache"
+	"github.com/patrickmn/go-cache"
 
 	"github.com/aptos-labs/aptos-go-sdk"
 
@@ -31,7 +31,7 @@ type AptosLogPoller struct {
 	lggr      logger.Logger
 	dbStore   *db.DBStore
 	config    *Config
-	client    aptos.AptosRpcClient
+	getClient func() (aptos.AptosRpcClient, error)
 	chainInfo types.ChainInfo
 
 	mu      sync.RWMutex
@@ -49,11 +49,6 @@ type AptosLogPoller struct {
 }
 
 func NewLogPoller(lggr logger.Logger, chainInfo types.ChainInfo, getClient func() (aptos.AptosRpcClient, error), ds sqlutil.DataSource, cfg *Config) (*AptosLogPoller, error) {
-	client, err := getClient()
-	if err != nil {
-		return nil, err
-	}
-
 	if cfg == nil {
 		cfg = &DefaultConfigSet
 	}
@@ -67,7 +62,7 @@ func NewLogPoller(lggr logger.Logger, chainInfo types.ChainInfo, getClient func(
 		lggr:      logger.Named(lggr, "AptosLogPoller"),
 		dbStore:   dbStore,
 		config:    cfg,
-		client:    client,
+		getClient: getClient,
 		chainInfo: chainInfo,
 
 		modules: make(map[string]*moduleInfo),

--- a/relayer/logpoller/tx_poller.go
+++ b/relayer/logpoller/tx_poller.go
@@ -188,7 +188,12 @@ func (l *AptosLogPoller) syncTransmitterTxs(ctx context.Context, transmitter apt
 	case <-ctx.Done():
 		return totalProcessed, ctx.Err()
 	default:
-		txns, err := l.client.AccountTransactions(transmitter, &sequenceNumber, &batchSize)
+		var client aptos.AptosRpcClient
+		client, err = l.getClient()
+		if err != nil {
+			return totalProcessed, fmt.Errorf("failed to get client: %w", err)
+		}
+		txns, err := client.AccountTransactions(transmitter, &sequenceNumber, &batchSize)
 		if err != nil {
 			return totalProcessed, fmt.Errorf("failed to fetch transactions: %w", err)
 		}

--- a/relayer/txm/txm.go
+++ b/relayer/txm/txm.go
@@ -42,21 +42,16 @@ type AptosTxm struct {
 	done          sync.WaitGroup
 	stop          chan struct{}
 
-	client aptos.AptosRpcClient
+	getClient func() (aptos.AptosRpcClient, error)
 }
 
 // TODO: Config input is not validated for sanity
 func New(lgr logger.Logger, keystore loop.Keystore, config Config, getClient func() (aptos.AptosRpcClient, error)) (*AptosTxm, error) {
-	client, err := getClient()
-	if err != nil {
-		return nil, err
-	}
-
 	return &AptosTxm{
 		baseLogger: logger.Named(lgr, "AptosTxm"),
 		keystore:   keystore,
 		config:     config,
-		client:     client,
+		getClient:  getClient,
 
 		transactions:              map[string]*AptosTx{},
 		transactionsLastPruneTime: getTimestampSecs(),
@@ -469,8 +464,12 @@ func (a *AptosTxm) getTransactionAttempt(tx *AptosTx) uint64 {
 }
 
 func (a *AptosTxm) signAndBroadcast(tx *AptosTx) {
-	client := a.client
 	ctxLogger := GetContexedTxLogger(a.baseLogger, tx.ID, tx.Metadata)
+	client, err := a.getClient()
+	if err != nil {
+		ctxLogger.Errorw("Unable to sign and broadcast: failed to get client", "error", err)
+		return
+	}
 
 	txStore := a.accountStore.GetTxStore(tx.FromAddress.String())
 	if txStore == nil {
@@ -598,7 +597,11 @@ func (a *AptosTxm) confirmLoop() {
 }
 
 func (a *AptosTxm) checkUnconfirmed() {
-	client := a.client
+	client, err := a.getClient()
+	if err != nil {
+		a.baseLogger.Errorw("Unable to check unconfirmed: failed to get client", "error", err)
+		return
+	}
 	allUnconfirmedTxs := a.accountStore.GetAllUnconfirmed()
 
 	for accountAddress, unconfirmedTxs := range allUnconfirmedTxs {


### PR DESCRIPTION
It is critical that construction does not depend on external resources being online. This PR defers some client fetches that were being done in constructors, because the implementations block on getting chain IDs from the RPCs.