### PR TITLE
contracts: add keystone forwarder report unit tests

### DIFF
--- a/contracts/platform/sources/forwarder.move
+++ b/contracts/platform/sources/forwarder.move
@@ -427,17 +427,15 @@ module platform::forwarder {
     }
 
     #[test_only]
-    fun sign_report(
-        config: &OracleSet, report: vector<u8>, report_context: vector<u8>
+    fun sign_report_n(
+        config: &OracleSet, report: vector<u8>, report_context: vector<u8>, n: u8
     ): vector<Signature> {
-        // blake2b(report_context, report)
         let msg = report_context;
         vector::append(&mut msg, report);
         let msg = blake2b_256(msg);
 
         let signatures = vector[];
-        let required_signatures = config.f + 1;
-        for (i in 0..required_signatures) {
+        for (i in 0..n) {
             let config_signer = vector::borrow(&config.signers, (i as u64));
             let public_key =
                 ed25519::new_unvalidated_public_key_from_bytes(
@@ -449,13 +447,72 @@ module platform::forwarder {
         signatures
     }
 
+    #[test_only]
+    fun sign_report(
+        config: &OracleSet, report: vector<u8>, report_context: vector<u8>
+    ): vector<Signature> {
+        sign_report_n(config, report, report_context, config.f + 1)
+    }
+
+    #[test_only]
+    fun build_report_with_overrides(
+        version: u8, don_id: u32, config_version: u32, execution_id: vector<u8>
+    ): (vector<u8>, vector<u8>, vector<u8>) {
+        let timestamp: u32 = 1;
+        let workflow_id =
+            x"6d795f6964000000000000000000000000000000000000000000000000000000";
+        let workflow_name = x"000000000000DEADBEEF";
+        let workflow_owner = x"0000000000000000000000000000000000000051";
+        let report_id = x"0001";
+        let mercury_reports = vector[x"010203", x"aabbcc"];
+
+        let report = vector[];
+        vector::push_back(&mut report, version);
+        vector::append(&mut report, execution_id);
+
+        let bytes = bcs::to_bytes(&timestamp);
+        vector::reverse(&mut bytes);
+        vector::append(&mut report, bytes);
+
+        let bytes = bcs::to_bytes(&don_id);
+        vector::reverse(&mut bytes);
+        vector::append(&mut report, bytes);
+
+        let bytes = bcs::to_bytes(&config_version);
+        vector::reverse(&mut bytes);
+        vector::append(&mut report, bytes);
+
+        vector::append(&mut report, workflow_id);
+        vector::append(&mut report, workflow_name);
+        vector::append(&mut report, workflow_owner);
+        vector::append(&mut report, report_id);
+        vector::append(&mut report, bcs::to_bytes(&mercury_reports));
+
+        let report_context =
+            x"a0b000000000000000000000000000000000000000000000000000000000000a0b000000000000000000000000000000000000000000000000000000000000a0b000000000000000000000000000000000000000000000000000000000000000";
+
+        let raw_report = vector[];
+        vector::append(&mut raw_report, copy report_context);
+        vector::append(&mut raw_report, copy report);
+
+        (raw_report, report, report_context)
+    }
+
+    #[test_only]
+    fun build_report(config: &OracleSet): (vector<u8>, vector<u8>, vector<u8>) {
+        build_report_with_overrides(
+            1,
+            config.don_id,
+            config.config_version,
+            x"6d795f657865637574696f6e5f69640000000000000000000000000000000000"
+        )
+    }
+
     #[test(owner = @owner, publisher = @platform)]
     public entry fun test_happy_path(owner: &signer, publisher: &signer) acquires State {
         set_up_test(owner, publisher);
 
         let config = generate_oracle_set();
-
-        // configure DON
         set_config(
             owner,
             config.don_id,
@@ -464,63 +521,482 @@ module platform::forwarder {
             config.oracles
         );
 
-        // generate report
-        let version = 1;
-        let timestamp: u32 = 1;
-        let workflow_id =
-            x"6d795f6964000000000000000000000000000000000000000000000000000000";
-        let workflow_name = x"000000000000DEADBEEF";
-        let workflow_owner = x"0000000000000000000000000000000000000051";
-        let report_id = x"0001";
-        let execution_id =
-            x"6d795f657865637574696f6e5f69640000000000000000000000000000000000";
-        let mercury_reports = vector[x"010203", x"aabbcc"];
-
-        let report = vector[];
-        // header
-        vector::push_back(&mut report, version);
-        vector::append(&mut report, execution_id);
-
-        let bytes = bcs::to_bytes(&timestamp);
-        // convert little-endian to big-endian
-        vector::reverse(&mut bytes);
-        vector::append(&mut report, bytes);
-
-        let bytes = bcs::to_bytes(&config.don_id);
-        // convert little-endian to big-endian
-        vector::reverse(&mut bytes);
-        vector::append(&mut report, bytes);
-
-        let bytes = bcs::to_bytes(&config.config_version);
-        // convert little-endian to big-endian
-        vector::reverse(&mut bytes);
-        vector::append(&mut report, bytes);
-
-        // metadata
-        vector::append(&mut report, workflow_id);
-        vector::append(&mut report, workflow_name);
-        vector::append(&mut report, workflow_owner);
-        vector::append(&mut report, report_id);
-        // report
-        vector::append(&mut report, bcs::to_bytes(&mercury_reports));
-
-        let report_context =
-            x"a0b000000000000000000000000000000000000000000000000000000000000a0b000000000000000000000000000000000000000000000000000000000000a0b000000000000000000000000000000000000000000000000000000000000000";
-        assert!(vector::length(&report_context) == 96, 1);
-
-        let raw_report = vector[];
-        vector::append(&mut raw_report, report_context);
-        vector::append(&mut raw_report, report);
-
-        // sign report
+        let (raw_report, report, report_context) = build_report(&config);
         let signatures = sign_report(&config, report, report_context);
 
-        // call entrypoint
+        let receiver = signer::address_of(publisher);
+        let execution_id =
+            x"6d795f657865637574696f6e5f69640000000000000000000000000000000000";
+        let report_id: u16 = 1;
+
+        assert!(
+            !get_transmission_state(receiver, execution_id, report_id),
+            1
+        );
+
+        validate_and_process_report(owner, receiver, raw_report, signatures);
+
+        assert!(
+            get_transmission_state(receiver, execution_id, report_id),
+            2
+        );
+        let transmitter = get_transmitter(receiver, execution_id, report_id);
+        assert!(*option::borrow(&transmitter) == signer::address_of(owner), 3);
+    }
+
+    #[test(owner = @owner, publisher = @platform)]
+    #[expected_failure(abort_code = 15, location = platform::forwarder)]
+    fun test_report_incorrect_don(owner: &signer, publisher: &signer) acquires State {
+        set_up_test(owner, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let (raw_report, report, report_context) =
+            build_report_with_overrides(
+                1,
+                999,
+                config.config_version,
+                x"6d795f657865637574696f6e5f69640000000000000000000000000000000000"
+            );
+        let signatures = sign_report(&config, report, report_context);
+
         validate_and_process_report(
             owner,
             signer::address_of(publisher),
             raw_report,
             signatures
+        );
+    }
+
+    #[test(owner = @owner, publisher = @platform)]
+    #[expected_failure(abort_code = 15, location = platform::forwarder)]
+    fun test_report_inexistent_config_version(
+        owner: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let (raw_report, report, report_context) =
+            build_report_with_overrides(
+                1,
+                config.don_id,
+                config.config_version + 1,
+                x"6d795f657865637574696f6e5f69640000000000000000000000000000000000"
+            );
+        let signatures = sign_report(&config, report, report_context);
+
+        validate_and_process_report(
+            owner,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test(owner = @owner, publisher = @platform)]
+    #[expected_failure]
+    fun test_report_malformed(owner: &signer, publisher: &signer) acquires State {
+        set_up_test(owner, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let raw_report = x"deadbeef";
+        let signatures: vector<Signature> = vector[];
+
+        validate_and_process_report(
+            owner,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test(owner = @owner, publisher = @platform)]
+    #[expected_failure(abort_code = 65540, location = platform::forwarder)]
+    fun test_report_too_few_signatures(
+        owner: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let (raw_report, report, report_context) = build_report(&config);
+        let signatures = sign_report_n(&config, report, report_context, config.f);
+
+        validate_and_process_report(
+            owner,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test(owner = @owner, publisher = @platform)]
+    #[expected_failure(abort_code = 65540, location = platform::forwarder)]
+    fun test_report_too_many_signatures(
+        owner: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let (raw_report, report, report_context) = build_report(&config);
+        let signatures = sign_report_n(&config, report, report_context, config.f + 2);
+
+        validate_and_process_report(
+            owner,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test(owner = @owner, publisher = @platform)]
+    #[expected_failure(abort_code = 65541, location = platform::forwarder)]
+    fun test_report_invalid_signature(owner: &signer, publisher: &signer) acquires State {
+        set_up_test(owner, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let (raw_report, _report, _report_context) = build_report(&config);
+        let msg = blake2b_256(copy raw_report);
+
+        // Valid signature from signer 0
+        let pk0 =
+            ed25519::new_unvalidated_public_key_from_bytes(
+                *vector::borrow(&config.oracles, 0)
+            );
+        let sig0 = ed25519::sign_arbitrary_bytes(vector::borrow(&config.signers, 0), msg);
+
+        // Signer 1's public key paired with signer 0's signature
+        let pk1 =
+            ed25519::new_unvalidated_public_key_from_bytes(
+                *vector::borrow(&config.oracles, 1)
+            );
+        let bad_sig =
+            ed25519::sign_arbitrary_bytes(vector::borrow(&config.signers, 0), msg);
+
+        let signatures = vector[
+            Signature { sig: sig0, public_key: pk0 },
+            Signature { sig: bad_sig, public_key: pk1 }
+        ];
+
+        validate_and_process_report(
+            owner,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test(owner = @owner, publisher = @platform)]
+    #[expected_failure(abort_code = 65538, location = platform::forwarder)]
+    fun test_report_invalid_signer(owner: &signer, publisher: &signer) acquires State {
+        set_up_test(owner, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let (raw_report, _report, _report_context) = build_report(&config);
+        let msg = blake2b_256(copy raw_report);
+
+        // Valid signature from signer 0
+        let pk0 =
+            ed25519::new_unvalidated_public_key_from_bytes(
+                *vector::borrow(&config.oracles, 0)
+            );
+        let sig0 = ed25519::sign_arbitrary_bytes(vector::borrow(&config.signers, 0), msg);
+
+        // Unknown signer not in config
+        let (unknown_sk, unknown_pk) = ed25519::generate_keys();
+        let unknown_pk =
+            ed25519::new_unvalidated_public_key_from_bytes(
+                ed25519::validated_public_key_to_bytes(&unknown_pk)
+            );
+        let unknown_sig = ed25519::sign_arbitrary_bytes(&unknown_sk, msg);
+
+        let signatures = vector[
+            Signature { sig: sig0, public_key: pk0 },
+            Signature { sig: unknown_sig, public_key: unknown_pk }
+        ];
+
+        validate_and_process_report(
+            owner,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test(owner = @owner, publisher = @platform)]
+    #[expected_failure(abort_code = 65539, location = platform::forwarder)]
+    fun test_report_duplicate_signatures(
+        owner: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let (raw_report, _report, _report_context) = build_report(&config);
+        let msg = blake2b_256(copy raw_report);
+
+        // Same signer twice
+        let pk0a =
+            ed25519::new_unvalidated_public_key_from_bytes(
+                *vector::borrow(&config.oracles, 0)
+            );
+        let sig0a = ed25519::sign_arbitrary_bytes(
+            vector::borrow(&config.signers, 0), msg
+        );
+        let pk0b =
+            ed25519::new_unvalidated_public_key_from_bytes(
+                *vector::borrow(&config.oracles, 0)
+            );
+        let sig0b = ed25519::sign_arbitrary_bytes(
+            vector::borrow(&config.signers, 0), msg
+        );
+
+        let signatures = vector[
+            Signature { sig: sig0a, public_key: pk0a },
+            Signature { sig: sig0b, public_key: pk0b }
+        ];
+
+        validate_and_process_report(
+            owner,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test(owner = @owner, publisher = @platform)]
+    #[expected_failure(abort_code = 6, location = platform::forwarder)]
+    fun test_report_already_processed(owner: &signer, publisher: &signer) acquires State {
+        set_up_test(owner, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        // First submission succeeds
+        let (raw_report, report, report_context) = build_report(&config);
+        let signatures = sign_report(&config, report, report_context);
+        validate_and_process_report(
+            owner,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+
+        // Second submission with same report fails
+        let (raw_report2, report2, report_context2) = build_report(&config);
+        let signatures2 = sign_report(&config, report2, report_context2);
+        validate_and_process_report(
+            owner,
+            signer::address_of(publisher),
+            raw_report2,
+            signatures2
+        );
+    }
+
+    #[test(owner = @owner, publisher = @platform)]
+    #[expected_failure(abort_code = 16, location = platform::forwarder)]
+    fun test_report_invalid_version(owner: &signer, publisher: &signer) acquires State {
+        set_up_test(owner, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let (raw_report, report, report_context) =
+            build_report_with_overrides(
+                2,
+                config.don_id,
+                config.config_version,
+                x"6d795f657865637574696f6e5f69640000000000000000000000000000000000"
+            );
+        let signatures = sign_report(&config, report, report_context);
+
+        validate_and_process_report(
+            owner,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 65544, location = platform::forwarder)]
+    fun test_report_malformed_signature() {
+        signature_from_bytes(
+            x"0102030405060708091011121314151617181920212223242526272829303132"
+        );
+    }
+
+    #[test(owner = @owner, publisher = @platform)]
+    #[expected_failure(abort_code = 15, location = platform::forwarder)]
+    fun test_report_after_clear_config(
+        owner: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+        clear_config(owner, config.don_id, config.config_version);
+
+        let (raw_report, report, report_context) = build_report(&config);
+        let signatures = sign_report(&config, report, report_context);
+
+        validate_and_process_report(
+            owner,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test(owner = @owner, publisher = @platform)]
+    fun test_report_config_version_lifecycle(
+        owner: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner, publisher);
+
+        let config_v1 = generate_oracle_set();
+        let config_v2 = generate_oracle_set();
+        config_v2.config_version = 2;
+
+        set_config(
+            owner,
+            config_v1.don_id,
+            config_v1.config_version,
+            config_v1.f,
+            config_v1.oracles
+        );
+        set_config(
+            owner,
+            config_v2.don_id,
+            config_v2.config_version,
+            config_v2.f,
+            config_v2.oracles
+        );
+
+        // Report on v1 succeeds
+        let (raw_report_v1, report_v1, report_context_v1) = build_report(&config_v1);
+        let signatures_v1 = sign_report(&config_v1, report_v1, report_context_v1);
+        let receiver = signer::address_of(publisher);
+        validate_and_process_report(owner, receiver, raw_report_v1, signatures_v1);
+
+        // Verify transmitter recorded for v1
+        let execution_id =
+            x"6d795f657865637574696f6e5f69640000000000000000000000000000000000";
+        let report_id: u16 = 1;
+        assert!(
+            get_transmission_state(receiver, execution_id, report_id),
+            1
+        );
+        assert!(
+            *option::borrow(&get_transmitter(receiver, execution_id, report_id))
+                == signer::address_of(owner),
+            2
+        );
+
+        // Clear config v1
+        clear_config(owner, config_v1.don_id, config_v1.config_version);
+
+        // Report on v2 succeeds (v2 unaffected by v1 clear)
+        let new_execution_id =
+            x"6d795f657865637574696f6e5f69640000000000000000000000000000000001";
+        let (raw_report_v2, report_v2, report_context_v2) =
+            build_report_with_overrides(
+                1,
+                config_v2.don_id,
+                config_v2.config_version,
+                new_execution_id
+            );
+        let signatures_v2 = sign_report(&config_v2, report_v2, report_context_v2);
+        validate_and_process_report(owner, receiver, raw_report_v2, signatures_v2);
+
+        // Verify transmitter recorded for v2
+        assert!(
+            get_transmission_state(receiver, new_execution_id, report_id),
+            3
+        );
+        assert!(
+            *option::borrow(&get_transmitter(receiver, new_execution_id, report_id))
+                == signer::address_of(owner),
+            4
         );
     }
 

--- a/contracts/platform_secondary/sources/forwarder.move
+++ b/contracts/platform_secondary/sources/forwarder.move
@@ -429,17 +429,15 @@ module platform_secondary::forwarder {
     }
 
     #[test_only]
-    fun sign_report(
-        config: &OracleSet, report: vector<u8>, report_context: vector<u8>
+    fun sign_report_n(
+        config: &OracleSet, report: vector<u8>, report_context: vector<u8>, n: u8
     ): vector<Signature> {
-        // blake2b(report_context, report)
         let msg = report_context;
         vector::append(&mut msg, report);
         let msg = blake2b_256(msg);
 
         let signatures = vector[];
-        let required_signatures = config.f + 1;
-        for (i in 0..required_signatures) {
+        for (i in 0..n) {
             let config_signer = vector::borrow(&config.signers, (i as u64));
             let public_key =
                 ed25519::new_unvalidated_public_key_from_bytes(
@@ -451,6 +449,67 @@ module platform_secondary::forwarder {
         signatures
     }
 
+    #[test_only]
+    fun sign_report(
+        config: &OracleSet, report: vector<u8>, report_context: vector<u8>
+    ): vector<Signature> {
+        sign_report_n(config, report, report_context, config.f + 1)
+    }
+
+    #[test_only]
+    fun build_report_with_overrides(
+        version: u8, don_id: u32, config_version: u32, execution_id: vector<u8>
+    ): (vector<u8>, vector<u8>, vector<u8>) {
+        let timestamp: u32 = 1;
+        let workflow_id =
+            x"6d795f6964000000000000000000000000000000000000000000000000000000";
+        let workflow_name = x"000000000000DEADBEEF";
+        let workflow_owner = x"0000000000000000000000000000000000000051";
+        let report_id = x"0001";
+        let mercury_reports = vector[x"010203", x"aabbcc"];
+
+        let report = vector[];
+        vector::push_back(&mut report, version);
+        vector::append(&mut report, execution_id);
+
+        let bytes = bcs::to_bytes(&timestamp);
+        vector::reverse(&mut bytes);
+        vector::append(&mut report, bytes);
+
+        let bytes = bcs::to_bytes(&don_id);
+        vector::reverse(&mut bytes);
+        vector::append(&mut report, bytes);
+
+        let bytes = bcs::to_bytes(&config_version);
+        vector::reverse(&mut bytes);
+        vector::append(&mut report, bytes);
+
+        vector::append(&mut report, workflow_id);
+        vector::append(&mut report, workflow_name);
+        vector::append(&mut report, workflow_owner);
+        vector::append(&mut report, report_id);
+        vector::append(&mut report, bcs::to_bytes(&mercury_reports));
+
+        let report_context =
+            x"a0b000000000000000000000000000000000000000000000000000000000000a0b000000000000000000000000000000000000000000000000000000000000a0b000000000000000000000000000000000000000000000000000000000000000";
+
+        let raw_report = vector[];
+        vector::append(&mut raw_report, copy report_context);
+        vector::append(&mut raw_report, copy report);
+
+        (raw_report, report, report_context)
+    }
+
+    #[test_only]
+    fun build_report(config: &OracleSet): (vector<u8>, vector<u8>, vector<u8>) {
+        build_report_with_overrides(
+            1,
+            config.don_id,
+            config.config_version,
+            x"6d795f657865637574696f6e5f69640000000000000000000000000000000000"
+        )
+    }
+
     #[test(owner_secondary = @owner_secondary, publisher = @platform_secondary)]
     public entry fun test_happy_path(
         owner_secondary: &signer, publisher: &signer
@@ -458,8 +517,6 @@ module platform_secondary::forwarder {
         set_up_test(owner_secondary, publisher);
 
         let config = generate_oracle_set();
-
-        // configure DON
         set_config(
             owner_secondary,
             config.don_id,
@@ -468,63 +525,509 @@ module platform_secondary::forwarder {
             config.oracles
         );
 
-        // generate report
-        let version = 1;
-        let timestamp: u32 = 1;
-        let workflow_id =
-            x"6d795f6964000000000000000000000000000000000000000000000000000000";
-        let workflow_name = x"000000000000DEADBEEF";
-        let workflow_owner = x"0000000000000000000000000000000000000051";
-        let report_id = x"0001";
-        let execution_id =
-            x"6d795f657865637574696f6e5f69640000000000000000000000000000000000";
-        let mercury_reports = vector[x"010203", x"aabbcc"];
-
-        let report = vector[];
-        // header
-        vector::push_back(&mut report, version);
-        vector::append(&mut report, execution_id);
-
-        let bytes = bcs::to_bytes(&timestamp);
-        // convert little-endian to big-endian
-        vector::reverse(&mut bytes);
-        vector::append(&mut report, bytes);
-
-        let bytes = bcs::to_bytes(&config.don_id);
-        // convert little-endian to big-endian
-        vector::reverse(&mut bytes);
-        vector::append(&mut report, bytes);
-
-        let bytes = bcs::to_bytes(&config.config_version);
-        // convert little-endian to big-endian
-        vector::reverse(&mut bytes);
-        vector::append(&mut report, bytes);
-
-        // metadata
-        vector::append(&mut report, workflow_id);
-        vector::append(&mut report, workflow_name);
-        vector::append(&mut report, workflow_owner);
-        vector::append(&mut report, report_id);
-        // report
-        vector::append(&mut report, bcs::to_bytes(&mercury_reports));
-
-        let report_context =
-            x"a0b000000000000000000000000000000000000000000000000000000000000a0b000000000000000000000000000000000000000000000000000000000000a0b000000000000000000000000000000000000000000000000000000000000000";
-        assert!(vector::length(&report_context) == 96, 1);
-
-        let raw_report = vector[];
-        vector::append(&mut raw_report, report_context);
-        vector::append(&mut raw_report, report);
-
-        // sign report
+        let (raw_report, report, report_context) = build_report(&config);
         let signatures = sign_report(&config, report, report_context);
 
-        // call entrypoint
+        let receiver = signer::address_of(publisher);
+        let execution_id =
+            x"6d795f657865637574696f6e5f69640000000000000000000000000000000000";
+        let report_id: u16 = 1;
+
+        assert!(
+            !get_transmission_state(receiver, execution_id, report_id),
+            1
+        );
+
+        validate_and_process_report(
+            owner_secondary,
+            receiver,
+            raw_report,
+            signatures
+        );
+
+        assert!(
+            get_transmission_state(receiver, execution_id, report_id),
+            2
+        );
+        let transmitter = get_transmitter(receiver, execution_id, report_id);
+        assert!(*option::borrow(&transmitter) == signer::address_of(owner_secondary), 3);
+    }
+
+    #[test(owner_secondary = @owner_secondary, publisher = @platform_secondary)]
+    #[expected_failure(abort_code = 15, location = platform_secondary::forwarder)]
+    fun test_report_incorrect_don(
+        owner_secondary: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner_secondary,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let (raw_report, report, report_context) =
+            build_report_with_overrides(
+                1,
+                999,
+                config.config_version,
+                x"6d795f657865637574696f6e5f69640000000000000000000000000000000000"
+            );
+        let signatures = sign_report(&config, report, report_context);
+
         validate_and_process_report(
             owner_secondary,
             signer::address_of(publisher),
             raw_report,
             signatures
+        );
+    }
+
+    #[test(owner_secondary = @owner_secondary, publisher = @platform_secondary)]
+    #[expected_failure(abort_code = 15, location = platform_secondary::forwarder)]
+    fun test_report_inexistent_config_version(
+        owner_secondary: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner_secondary,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let (raw_report, report, report_context) =
+            build_report_with_overrides(
+                1,
+                config.don_id,
+                config.config_version + 1,
+                x"6d795f657865637574696f6e5f69640000000000000000000000000000000000"
+            );
+        let signatures = sign_report(&config, report, report_context);
+
+        validate_and_process_report(
+            owner_secondary,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test(owner_secondary = @owner_secondary, publisher = @platform_secondary)]
+    #[expected_failure]
+    fun test_report_malformed(
+        owner_secondary: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner_secondary,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let raw_report = x"deadbeef";
+        let signatures: vector<Signature> = vector[];
+
+        validate_and_process_report(
+            owner_secondary,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test(owner_secondary = @owner_secondary, publisher = @platform_secondary)]
+    #[expected_failure(abort_code = 65540, location = platform_secondary::forwarder)]
+    fun test_report_too_few_signatures(
+        owner_secondary: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner_secondary,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let (raw_report, report, report_context) = build_report(&config);
+        let signatures = sign_report_n(&config, report, report_context, config.f);
+
+        validate_and_process_report(
+            owner_secondary,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test(owner_secondary = @owner_secondary, publisher = @platform_secondary)]
+    #[expected_failure(abort_code = 65540, location = platform_secondary::forwarder)]
+    fun test_report_too_many_signatures(
+        owner_secondary: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner_secondary,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let (raw_report, report, report_context) = build_report(&config);
+        let signatures = sign_report_n(&config, report, report_context, config.f + 2);
+
+        validate_and_process_report(
+            owner_secondary,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test(owner_secondary = @owner_secondary, publisher = @platform_secondary)]
+    #[expected_failure(abort_code = 65541, location = platform_secondary::forwarder)]
+    fun test_report_invalid_signature(
+        owner_secondary: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner_secondary,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let (raw_report, _report, _report_context) = build_report(&config);
+        let msg = blake2b_256(copy raw_report);
+
+        // Valid signature from signer 0
+        let pk0 =
+            ed25519::new_unvalidated_public_key_from_bytes(
+                *vector::borrow(&config.oracles, 0)
+            );
+        let sig0 = ed25519::sign_arbitrary_bytes(vector::borrow(&config.signers, 0), msg);
+
+        // Signer 1's public key paired with signer 0's signature
+        let pk1 =
+            ed25519::new_unvalidated_public_key_from_bytes(
+                *vector::borrow(&config.oracles, 1)
+            );
+        let bad_sig =
+            ed25519::sign_arbitrary_bytes(vector::borrow(&config.signers, 0), msg);
+
+        let signatures = vector[
+            Signature { sig: sig0, public_key: pk0 },
+            Signature { sig: bad_sig, public_key: pk1 }
+        ];
+
+        validate_and_process_report(
+            owner_secondary,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test(owner_secondary = @owner_secondary, publisher = @platform_secondary)]
+    #[expected_failure(abort_code = 65538, location = platform_secondary::forwarder)]
+    fun test_report_invalid_signer(
+        owner_secondary: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner_secondary,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let (raw_report, _report, _report_context) = build_report(&config);
+        let msg = blake2b_256(copy raw_report);
+
+        // Valid signature from signer 0
+        let pk0 =
+            ed25519::new_unvalidated_public_key_from_bytes(
+                *vector::borrow(&config.oracles, 0)
+            );
+        let sig0 = ed25519::sign_arbitrary_bytes(vector::borrow(&config.signers, 0), msg);
+
+        // Unknown signer not in config
+        let (unknown_sk, unknown_pk) = ed25519::generate_keys();
+        let unknown_pk =
+            ed25519::new_unvalidated_public_key_from_bytes(
+                ed25519::validated_public_key_to_bytes(&unknown_pk)
+            );
+        let unknown_sig = ed25519::sign_arbitrary_bytes(&unknown_sk, msg);
+
+        let signatures = vector[
+            Signature { sig: sig0, public_key: pk0 },
+            Signature { sig: unknown_sig, public_key: unknown_pk }
+        ];
+
+        validate_and_process_report(
+            owner_secondary,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test(owner_secondary = @owner_secondary, publisher = @platform_secondary)]
+    #[expected_failure(abort_code = 65539, location = platform_secondary::forwarder)]
+    fun test_report_duplicate_signatures(
+        owner_secondary: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner_secondary,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let (raw_report, _report, _report_context) = build_report(&config);
+        let msg = blake2b_256(copy raw_report);
+
+        // Same signer twice
+        let pk0a =
+            ed25519::new_unvalidated_public_key_from_bytes(
+                *vector::borrow(&config.oracles, 0)
+            );
+        let sig0a = ed25519::sign_arbitrary_bytes(
+            vector::borrow(&config.signers, 0), msg
+        );
+        let pk0b =
+            ed25519::new_unvalidated_public_key_from_bytes(
+                *vector::borrow(&config.oracles, 0)
+            );
+        let sig0b = ed25519::sign_arbitrary_bytes(
+            vector::borrow(&config.signers, 0), msg
+        );
+
+        let signatures = vector[
+            Signature { sig: sig0a, public_key: pk0a },
+            Signature { sig: sig0b, public_key: pk0b }
+        ];
+
+        validate_and_process_report(
+            owner_secondary,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test(owner_secondary = @owner_secondary, publisher = @platform_secondary)]
+    #[expected_failure(abort_code = 6, location = platform_secondary::forwarder)]
+    fun test_report_already_processed(
+        owner_secondary: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner_secondary,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        // First submission succeeds
+        let (raw_report, report, report_context) = build_report(&config);
+        let signatures = sign_report(&config, report, report_context);
+        validate_and_process_report(
+            owner_secondary,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+
+        // Second submission with same report fails
+        let (raw_report2, report2, report_context2) = build_report(&config);
+        let signatures2 = sign_report(&config, report2, report_context2);
+        validate_and_process_report(
+            owner_secondary,
+            signer::address_of(publisher),
+            raw_report2,
+            signatures2
+        );
+    }
+
+    #[test(owner_secondary = @owner_secondary, publisher = @platform_secondary)]
+    #[expected_failure(abort_code = 16, location = platform_secondary::forwarder)]
+    fun test_report_invalid_version(
+        owner_secondary: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner_secondary,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+
+        let (raw_report, report, report_context) =
+            build_report_with_overrides(
+                2,
+                config.don_id,
+                config.config_version,
+                x"6d795f657865637574696f6e5f69640000000000000000000000000000000000"
+            );
+        let signatures = sign_report(&config, report, report_context);
+
+        validate_and_process_report(
+            owner_secondary,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 65544, location = platform_secondary::forwarder)]
+    fun test_report_malformed_signature() {
+        signature_from_bytes(
+            x"0102030405060708091011121314151617181920212223242526272829303132"
+        );
+    }
+
+    #[test(owner_secondary = @owner_secondary, publisher = @platform_secondary)]
+    #[expected_failure(abort_code = 15, location = platform_secondary::forwarder)]
+    fun test_report_after_clear_config(
+        owner_secondary: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        let config = generate_oracle_set();
+        set_config(
+            owner_secondary,
+            config.don_id,
+            config.config_version,
+            config.f,
+            config.oracles
+        );
+        clear_config(owner_secondary, config.don_id, config.config_version);
+
+        let (raw_report, report, report_context) = build_report(&config);
+        let signatures = sign_report(&config, report, report_context);
+
+        validate_and_process_report(
+            owner_secondary,
+            signer::address_of(publisher),
+            raw_report,
+            signatures
+        );
+    }
+
+    #[test(owner_secondary = @owner_secondary, publisher = @platform_secondary)]
+    fun test_report_config_version_lifecycle(
+        owner_secondary: &signer, publisher: &signer
+    ) acquires State {
+        set_up_test(owner_secondary, publisher);
+
+        let config_v1 = generate_oracle_set();
+        let config_v2 = generate_oracle_set();
+        config_v2.config_version = 2;
+
+        set_config(
+            owner_secondary,
+            config_v1.don_id,
+            config_v1.config_version,
+            config_v1.f,
+            config_v1.oracles
+        );
+        set_config(
+            owner_secondary,
+            config_v2.don_id,
+            config_v2.config_version,
+            config_v2.f,
+            config_v2.oracles
+        );
+
+        // Report on v1 succeeds
+        let (raw_report_v1, report_v1, report_context_v1) = build_report(&config_v1);
+        let signatures_v1 = sign_report(&config_v1, report_v1, report_context_v1);
+        let receiver = signer::address_of(publisher);
+        validate_and_process_report(
+            owner_secondary,
+            receiver,
+            raw_report_v1,
+            signatures_v1
+        );
+
+        // Verify transmitter recorded for v1
+        let execution_id =
+            x"6d795f657865637574696f6e5f69640000000000000000000000000000000000";
+        let report_id: u16 = 1;
+        assert!(
+            get_transmission_state(receiver, execution_id, report_id),
+            1
+        );
+        assert!(
+            *option::borrow(&get_transmitter(receiver, execution_id, report_id))
+                == signer::address_of(owner_secondary),
+            2
+        );
+
+        // Clear config v1
+        clear_config(owner_secondary, config_v1.don_id, config_v1.config_version);
+
+        // Report on v2 succeeds (v2 unaffected by v1 clear)
+        let new_execution_id =
+            x"6d795f657865637574696f6e5f69640000000000000000000000000000000001";
+        let (raw_report_v2, report_v2, report_context_v2) =
+            build_report_with_overrides(
+                1,
+                config_v2.don_id,
+                config_v2.config_version,
+                new_execution_id
+            );
+        let signatures_v2 = sign_report(&config_v2, report_v2, report_context_v2);
+        validate_and_process_report(
+            owner_secondary,
+            receiver,
+            raw_report_v2,
+            signatures_v2
+        );
+
+        // Verify transmitter recorded for v2
+        assert!(
+            get_transmission_state(receiver, new_execution_id, report_id),
+            3
+        );
+        assert!(
+            *option::borrow(&get_transmitter(receiver, new_execution_id, report_id))
+                == signer::address_of(owner_secondary),
+            4
         );
     }
 


### PR DESCRIPTION
## Summary

Port EVM `KeystoneForwarder_ReportTest.t.sol` to Move unit tests for both `platform` and `platform_secondary` forwarder contracts (NONEVM-98).

- Add 14 report validation tests per module (28 total) covering: incorrect DON, inexistent config version, malformed reports/signatures, signature count bounds, invalid/duplicate signers, replay detection, invalid report version, config clear, and multi-version lifecycle
- Extract `build_report`/`sign_report_n` test helpers to eliminate duplication
- Enhance `test_happy_path` with pre/post-condition assertions for transmission state and transmitter verification

### EVM Tests Ported (9)
| EVM Test | Move Test | Abort Code |
|---|---|---|
| `test_RevertWhen_ReportHasIncorrectDON` | `test_report_incorrect_don` | 15 |
| `test_RevertWhen_ReportHasInexistentConfigVersion` | `test_report_inexistent_config_version` | 15 |
| `test_RevertWhen_ReportIsMalformed` | `test_report_malformed` | vector OOB |
| `test_RevertWhen_TooFewSignatures` | `test_report_too_few_signatures` | 65540 |
| `test_RevertWhen_TooManySignatures` | `test_report_too_many_signatures` | 65540 |
| `test_RevertWhen_AnySignatureIsInvalid` | `test_report_invalid_signature` | 65541 |
| `test_RevertWhen_AnySignerIsInvalid` | `test_report_invalid_signer` | 65538 |
| `test_RevertWhen_ReportHasDuplicateSignatures` | `test_report_duplicate_signatures` | 65539 |
| `test_RevertWhen_RetryingSuccessfulTransmission` | `test_report_already_processed` | 6 |

### Move-Specific Tests (5)
| Move Test | Description |
|---|---|
| `test_report_invalid_version` | Report version != 1 |
| `test_report_malformed_signature` | Signature bytes != 96 |
| `test_report_after_clear_config` | Report after config cleared |
| `test_report_config_version_lifecycle` | Multi-config v1+v2 lifecycle with clear |
| `test_happy_path` (enhanced) | Added transmission state + transmitter assertions |

### Skipped EVM Tests (7 — not applicable to Move)
Gas limit, receiver contract model, and retry-with-more-gas tests have no Move equivalent.

## Test plan
- [x] `aptos move test --skip-fetch-latest-git-deps --package-dir contracts/platform` — 20 tests pass
- [x] `aptos move test --skip-fetch-latest-git-deps --package-dir contracts/platform_secondary` — 20 tests pass
- [x] `make move-test` — full CI-equivalent check passes