### PR TITLE
relayer: use loop.Relayer instead of deprecated types.Relayer

### DIFF
--- a/relayer/relay.go
+++ b/relayer/relay.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
@@ -20,7 +21,7 @@ import (
 	write_target "github.com/smartcontractkit/chainlink-aptos/relayer/write_target/aptos"
 )
 
-var _ types.Relayer = (*relayer)(nil) //nolint:staticcheck
+var _ loop.Relayer = (*relayer)(nil)
 
 type relayer struct {
 	chain chain.Chain
@@ -132,34 +133,6 @@ func (r *relayer) NewPluginProvider(ctx context.Context, rargs types.RelayArgs, 
 
 func (r *relayer) NewLLOProvider(ctx context.Context, rargs types.RelayArgs, pargs types.PluginArgs) (types.LLOProvider, error) {
 	return nil, errors.New("data streams is not supported for aptos")
-}
-
-func (r *relayer) NewMedianProvider(ctx context.Context, rargs types.RelayArgs, pargs types.PluginArgs) (types.MedianProvider, error) {
-	return nil, errors.New("ocr2 is not supported for aptos")
-}
-
-func (r *relayer) NewMercuryProvider(ctx context.Context, rargs types.RelayArgs, pargs types.PluginArgs) (types.MercuryProvider, error) {
-	return nil, errors.New("mercury is not supported for aptos")
-}
-
-func (r *relayer) NewFunctionsProvider(ctx context.Context, rargs types.RelayArgs, pargs types.PluginArgs) (types.FunctionsProvider, error) {
-	return nil, errors.New("functions are not supported for aptos")
-}
-
-func (r *relayer) NewAutomationProvider(ctx context.Context, rargs types.RelayArgs, pargs types.PluginArgs) (types.AutomationProvider, error) {
-	return nil, errors.New("automation is not supported for aptos")
-}
-
-func (r *relayer) NewOCR3CapabilityProvider(ctx context.Context, rargs types.RelayArgs, pargs types.PluginArgs) (types.OCR3CapabilityProvider, error) {
-	return nil, errors.New("ocr3 capability provider is not supported for aptos")
-}
-
-func (r *relayer) NewCCIPCommitProvider(ctx context.Context, rargs types.RelayArgs, pargs types.PluginArgs) (types.CCIPCommitProvider, error) {
-	return nil, errors.New("ccip.commit is not supported for aptos")
-}
-
-func (r *relayer) NewCCIPExecProvider(ctx context.Context, rargs types.RelayArgs, pargs types.PluginArgs) (types.CCIPExecProvider, error) {
-	return nil, errors.New("ccip.exec is not supported for aptos")
 }
 
 func (r *relayer) NewCCIPProvider(ctx context.Context, cargs types.CCIPProviderArgs) (types.CCIPProvider, error) {


### PR DESCRIPTION
## Summary
- Switch compile-time interface assertion from `types.Relayer` to `loop.Relayer`
- Remove 7 stub provider methods (`NewMedianProvider`, `NewMercuryProvider`, `NewFunctionsProvider`, `NewAutomationProvider`, `NewOCR3CapabilityProvider`, `NewCCIPCommitProvider`, `NewCCIPExecProvider`) that only existed to satisfy the larger deprecated interface
- The GRPC server handles their absence via comma-ok type assertions, producing the same `codes.Unimplemented` response

Resolves [NONEVM-100](https://smartcontract-it.atlassian.net/browse/NONEVM-100)

## Test plan
- [x] `go vet ./relayer/...` passes
- [x] `go vet ./cmd/chainlink-aptos/` passes
- [x] CI build and tests pass

[NONEVM-100]: https://smartcontract-it.atlassian.net/browse/NONEVM-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ