### PR TITLE
feat: pointer-based TOML config with proper default merging

### DIFF
--- a/relayer/aptos_service.go
+++ b/relayer/aptos_service.go
@@ -219,7 +219,7 @@ func (s *aptosService) SubmitTransaction(ctx context.Context, req commonaptos.Su
 	s.logger.Infow("SubmitTransaction: enqueued successfully", "txID", txID)
 
 	// TODO: dont use txmgr config, create and use workflow/cre config PLEX-2598
-	maximumWaitTime := time.Duration(s.chain.Config().TransactionManager.TxExpirationSecs) * time.Second
+	maximumWaitTime := time.Duration(*s.chain.Config().TransactionManager.TxExpirationSecs) * time.Second
 	s.logger.Infow("SubmitTransaction: polling for status", "txID", txID, "maximumWaitTime", maximumWaitTime)
 
 	retryCtx, cancel := context.WithTimeout(ctx, maximumWaitTime)

--- a/relayer/config/config.go
+++ b/relayer/config/config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/pelletier/go-toml/v2"
@@ -23,10 +22,8 @@ const ChainFamilyName = "aptos"
 var DefaultConfigSet = ConfigSet{
 	TransactionManager: txm.DefaultConfigSet,
 	LogPoller:          logpoller.DefaultConfigSet,
-	BalanceMonitor: monitor.GenericBalanceConfig{
-		BalancePollPeriod: *config.MustNewDuration(10 * time.Second),
-	},
-	WriteTargetCap: write_target.DefaultConfigSet,
+	BalanceMonitor:     monitor.DefaultBalanceConfig,
+	WriteTargetCap:     write_target.DefaultConfigSet,
 }
 
 type ConfigSet struct { //nolint:revive
@@ -43,11 +40,11 @@ type WorkflowConfig struct {
 }
 
 type Chain struct {
-	TransactionManager *txm.Config
-	LogPoller          *logpoller.Config
-	BalanceMonitor     *monitor.GenericBalanceConfig
-	WriteTargetCap     *write_target.Config
-	Workflow           *WorkflowConfig
+	TransactionManager *txm.Config                  `toml:"TransactionManager"`
+	LogPoller          *logpoller.Config             `toml:"LogPoller"`
+	BalanceMonitor     *monitor.GenericBalanceConfig `toml:"BalanceMonitor"`
+	WriteTargetCap     *write_target.Config          `toml:"WriteTargetCap"`
+	Workflow           *WorkflowConfig               `toml:"Workflow"`
 }
 
 type Node struct {
@@ -84,7 +81,48 @@ type TOMLConfig struct {
 	Nodes Nodes
 }
 
-// decodeConfig decodes the rawConfig as (Aptos) TOML and sets default values
+// applyDefaults ensures all component configs are non-nil and fully populated.
+// For absent TOML sections (nil pointers), creates empty configs.
+// Calls Resolve() on each to fill nil fields from per-package defaults.
+func (cfg *TOMLConfig) applyDefaults() {
+	if cfg.TransactionManager == nil {
+		cfg.TransactionManager = &txm.Config{}
+	}
+	cfg.TransactionManager.Resolve()
+
+	if cfg.LogPoller == nil {
+		cfg.LogPoller = &logpoller.Config{}
+	}
+	cfg.LogPoller.Resolve()
+
+	if cfg.BalanceMonitor == nil {
+		cfg.BalanceMonitor = &monitor.GenericBalanceConfig{}
+	}
+	cfg.BalanceMonitor.Resolve()
+
+	if cfg.WriteTargetCap == nil {
+		cfg.WriteTargetCap = &write_target.Config{}
+	}
+	cfg.WriteTargetCap.Resolve()
+
+	// Set network name defaults
+	if cfg.NetworkName == "" {
+		network, err := GetNetworkConfig(cfg.ChainID)
+		if err == nil {
+			cfg.NetworkName = network.Name
+		} else {
+			cfg.NetworkName = "unknown"
+		}
+	}
+
+	if cfg.NetworkNameFull == "" {
+		cfg.NetworkNameFull = fmt.Sprintf("%s-%s", ChainFamilyName, cfg.NetworkName)
+	}
+}
+
+// NewDecodedTOMLConfig decodes the rawConfig as (Aptos) TOML, merges with
+// defaults, and validates. Fields absent from the TOML get default values;
+// fields explicitly set (including to zero) are preserved as-is.
 func NewDecodedTOMLConfig(rawConfig string) (*TOMLConfig, error) {
 	d := toml.NewDecoder(strings.NewReader(rawConfig))
 	d.DisallowUnknownFields()
@@ -94,6 +132,8 @@ func NewDecodedTOMLConfig(rawConfig string) (*TOMLConfig, error) {
 		return &TOMLConfig{}, fmt.Errorf("failed to decode config toml: %w:\n\t%s", err, rawConfig)
 	}
 
+	cfg.applyDefaults()
+
 	if err := cfg.ValidateConfig(); err != nil {
 		return &TOMLConfig{}, fmt.Errorf("invalid aptos config: %w", err)
 	}
@@ -102,43 +142,11 @@ func NewDecodedTOMLConfig(rawConfig string) (*TOMLConfig, error) {
 		return &TOMLConfig{}, fmt.Errorf("cannot create new chain with ID %s: config is disabled", cfg.ChainID)
 	}
 
-	cfg.SetDefaults()
 	return &cfg, nil
 }
 
 func (c *TOMLConfig) IsEnabled() bool {
 	return c.Enabled == nil || *c.Enabled
-}
-
-func (c *TOMLConfig) SetDefaults() {
-	if c.TransactionManager == nil {
-		c.TransactionManager = &DefaultConfigSet.TransactionManager
-	}
-	if c.LogPoller == nil {
-		c.LogPoller = &DefaultConfigSet.LogPoller
-	}
-	if c.BalanceMonitor == nil {
-		c.BalanceMonitor = &DefaultConfigSet.BalanceMonitor
-	}
-	if c.WriteTargetCap == nil {
-		c.WriteTargetCap = &DefaultConfigSet.WriteTargetCap
-	}
-
-	// Set network name defaults
-	if c.NetworkName == "" {
-		// Check if known network by chain ID
-		network, err := GetNetworkConfig(c.ChainID)
-		if err == nil {
-			c.NetworkName = network.Name
-		} else {
-			c.NetworkName = "unknown"
-		}
-	}
-
-	// Set network name full defaults
-	if c.NetworkNameFull == "" {
-		c.NetworkNameFull = fmt.Sprintf("%s-%s", ChainFamilyName, c.NetworkName)
-	}
 }
 
 func (c *TOMLConfig) ValidateConfig() (err error) {

--- a/relayer/config/config_test.go
+++ b/relayer/config/config_test.go
@@ -32,7 +32,6 @@ URL = "http://node-1"
 	require.NoError(t, err)
 
 	// Enabled by default
-	// This is a core expectation of the API contract.
 	assert.True(t, cfg.IsEnabled())
 
 	raw = `
@@ -62,76 +61,34 @@ URL = "http://node-1"
 	require.ErrorContains(t, err, "config is disabled")
 }
 
-func TestTOMLConfig_LogPoller(t *testing.T) {
+// TestTOMLConfig_CustomValues verifies that fully-specified custom TOML values
+// survive the decode → applyDefaults → validate pipeline.
+func TestTOMLConfig_CustomValues(t *testing.T) {
 	t.Parallel()
 
-	// Test with default config
-	raw := `
-ChainID = "2"
-[[Nodes]]
-Name = "node-1"
-URL = "http://node-1"
-    `
+	t.Run("LogPoller", func(t *testing.T) {
+		t.Parallel()
 
-	cfg, err := NewDecodedTOMLConfig(raw)
-	require.NoError(t, err)
-
-	// Check that LogPoller config has defaults
-	assert.NotNil(t, cfg.LogPoller)
-	assert.Equal(t, 12*time.Second, cfg.LogPoller.EventPollingInterval.Duration())
-	assert.Equal(t, uint64(100), *cfg.LogPoller.EventBatchSize)
-
-	// Test with custom config
-	raw = `
-ChainID = "2"
-[[Nodes]]
-Name = "node-1"
-URL = "http://node-1"
-
+		raw := baseTOML + `
 [LogPoller]
 EventPollingInterval = "15s"
 TxPollingInterval = "20s"
 EventBatchSize = 50
 TxBatchSize = 75
-    `
+`
+		cfg, err := NewDecodedTOMLConfig(raw)
+		require.NoError(t, err)
 
-	cfg, err = NewDecodedTOMLConfig(raw)
-	require.NoError(t, err)
+		assert.Equal(t, 15*time.Second, cfg.LogPoller.EventPollingInterval.Duration())
+		assert.Equal(t, 20*time.Second, cfg.LogPoller.TxPollingInterval.Duration())
+		assert.Equal(t, uint64(50), *cfg.LogPoller.EventBatchSize)
+		assert.Equal(t, uint64(75), *cfg.LogPoller.TxBatchSize)
+	})
 
-	assert.Equal(t, 15*time.Second, cfg.LogPoller.EventPollingInterval.Duration())
-	assert.Equal(t, 20*time.Second, cfg.LogPoller.TxPollingInterval.Duration())
-	assert.Equal(t, uint64(50), *cfg.LogPoller.EventBatchSize)
-	assert.Equal(t, uint64(75), *cfg.LogPoller.TxBatchSize)
-}
+	t.Run("TransactionManager", func(t *testing.T) {
+		t.Parallel()
 
-func TestTOMLConfig_TxManager(t *testing.T) {
-	t.Parallel()
-
-	// Test with default config
-	raw := `
-ChainID = "2"
-[[Nodes]]
-Name = "node-1"
-URL = "http://node-1"
-    `
-
-	cfg, err := NewDecodedTOMLConfig(raw)
-	require.NoError(t, err)
-
-	// Check that TxManager config has defaults
-	assert.NotNil(t, cfg.TransactionManager)
-	assert.Equal(t, uint64(0), *cfg.TransactionManager.GasLimitOverhead)
-	assert.Equal(t, uint64(200000), *cfg.TransactionManager.DefaultMaxGasAmount)
-	assert.Equal(t, uint(100), *cfg.TransactionManager.BroadcastChanSize)
-	assert.Equal(t, uint(2), *cfg.TransactionManager.ConfirmPollSecs)
-
-	// Test with custom config
-	raw = `
-ChainID = "2"
-[[Nodes]]
-Name = "node-1"
-URL = "http://node-1"
-
+		raw := baseTOML + `
 [TransactionManager]
 GasLimitOverhead = 34
 DefaultMaxGasAmount = 300000
@@ -142,216 +99,22 @@ MaxSubmitRetryAttempts = 15
 SubmitDelayDuration = 5
 TxExpirationSecs = 20
 MaxTxRetryAttempts = 8
-    `
-
-	cfg, err = NewDecodedTOMLConfig(raw)
-	require.NoError(t, err)
-
-	assert.Equal(t, uint64(34), *cfg.TransactionManager.GasLimitOverhead)
-	assert.Equal(t, uint64(300000), *cfg.TransactionManager.DefaultMaxGasAmount)
-	assert.Equal(t, uint(200), *cfg.TransactionManager.BroadcastChanSize)
-	assert.Equal(t, uint(3), *cfg.TransactionManager.ConfirmPollSecs)
-	assert.Equal(t, uint(10), *cfg.TransactionManager.MaxSimulateAttempts)
-	assert.Equal(t, uint(15), *cfg.TransactionManager.MaxSubmitRetryAttempts)
-	assert.Equal(t, uint(5), *cfg.TransactionManager.SubmitDelayDuration)
-	assert.Equal(t, uint64(20), *cfg.TransactionManager.TxExpirationSecs)
-	assert.Equal(t, uint64(8), *cfg.TransactionManager.MaxTxRetryAttempts)
-}
-
-// TEST-02: Partial TransactionManager -- user field preserved, remaining 10 fields merged from defaults
-func TestSetDefaults_PartialTransactionManager(t *testing.T) {
-	t.Parallel()
-
-	raw := baseTOML + `
-[TransactionManager]
-BroadcastChanSize = 50
-`
-	cfg, err := NewDecodedTOMLConfig(raw)
-	require.NoError(t, err)
-	require.NotNil(t, cfg.TransactionManager)
-
-	// User-specified field preserved
-	assert.Equal(t, uint(50), *cfg.TransactionManager.BroadcastChanSize)
-
-	// All 10 remaining fields merged from txm.DefaultConfigSet
-	assert.Equal(t, txm.DefaultConfigSet.ConfirmPollSecs, cfg.TransactionManager.ConfirmPollSecs)
-	assert.Equal(t, txm.DefaultConfigSet.DefaultMaxGasAmount, cfg.TransactionManager.DefaultMaxGasAmount)
-	assert.Equal(t, txm.DefaultConfigSet.GasLimitOverhead, cfg.TransactionManager.GasLimitOverhead)
-	assert.Equal(t, txm.DefaultConfigSet.MaxSimulateAttempts, cfg.TransactionManager.MaxSimulateAttempts)
-	assert.Equal(t, txm.DefaultConfigSet.MaxSubmitRetryAttempts, cfg.TransactionManager.MaxSubmitRetryAttempts)
-	assert.Equal(t, txm.DefaultConfigSet.SubmitDelayDuration, cfg.TransactionManager.SubmitDelayDuration)
-	assert.Equal(t, txm.DefaultConfigSet.TxExpirationSecs, cfg.TransactionManager.TxExpirationSecs)
-	assert.Equal(t, txm.DefaultConfigSet.MaxTxRetryAttempts, cfg.TransactionManager.MaxTxRetryAttempts)
-	assert.Equal(t, txm.DefaultConfigSet.PruneIntervalSecs, cfg.TransactionManager.PruneIntervalSecs)
-	assert.Equal(t, txm.DefaultConfigSet.PruneTxExpirationSecs, cfg.TransactionManager.PruneTxExpirationSecs)
-}
-
-// TEST-03: Partial LogPoller -- user field preserved, remaining 5 fields merged from defaults
-func TestSetDefaults_PartialLogPoller(t *testing.T) {
-	t.Parallel()
-
-	raw := baseTOML + `
-[LogPoller]
-EventBatchSize = 50
-`
-	cfg, err := NewDecodedTOMLConfig(raw)
-	require.NoError(t, err)
-	require.NotNil(t, cfg.LogPoller)
-
-	// User-specified field preserved
-	assert.Equal(t, uint64(50), *cfg.LogPoller.EventBatchSize)
-
-	// All 5 remaining fields merged from logpoller.DefaultConfigSet
-	assert.Equal(t, logpoller.DefaultConfigSet.EventPollingInterval.Duration(), cfg.LogPoller.EventPollingInterval.Duration())
-	assert.Equal(t, logpoller.DefaultConfigSet.TxPollingInterval.Duration(), cfg.LogPoller.TxPollingInterval.Duration())
-	assert.Equal(t, logpoller.DefaultConfigSet.PollTimeout.Duration(), cfg.LogPoller.PollTimeout.Duration())
-	assert.Equal(t, logpoller.DefaultConfigSet.TxBatchSize, cfg.LogPoller.TxBatchSize)
-	assert.Equal(t, logpoller.DefaultConfigSet.TXPollerDisabled, cfg.LogPoller.TXPollerDisabled)
-}
-
-// TEST-04: Partial BalanceMonitor -- custom value preserved; empty section gets defaults
-func TestSetDefaults_PartialBalanceMonitor(t *testing.T) {
-	t.Parallel()
-
-	t.Run("custom value preserved", func(t *testing.T) {
-		t.Parallel()
-
-		raw := baseTOML + `
-[BalanceMonitor]
-BalancePollPeriod = "30s"
 `
 		cfg, err := NewDecodedTOMLConfig(raw)
 		require.NoError(t, err)
-		require.NotNil(t, cfg.BalanceMonitor)
-		assert.Equal(t, 30*time.Second, cfg.BalanceMonitor.BalancePollPeriod.Duration())
+
+		assert.Equal(t, uint64(34), *cfg.TransactionManager.GasLimitOverhead)
+		assert.Equal(t, uint64(300000), *cfg.TransactionManager.DefaultMaxGasAmount)
+		assert.Equal(t, uint(200), *cfg.TransactionManager.BroadcastChanSize)
+		assert.Equal(t, uint(3), *cfg.TransactionManager.ConfirmPollSecs)
+		assert.Equal(t, uint(10), *cfg.TransactionManager.MaxSimulateAttempts)
+		assert.Equal(t, uint(15), *cfg.TransactionManager.MaxSubmitRetryAttempts)
+		assert.Equal(t, uint(5), *cfg.TransactionManager.SubmitDelayDuration)
+		assert.Equal(t, uint64(20), *cfg.TransactionManager.TxExpirationSecs)
+		assert.Equal(t, uint64(8), *cfg.TransactionManager.MaxTxRetryAttempts)
 	})
 
-	t.Run("empty section gets defaults", func(t *testing.T) {
-		t.Parallel()
-
-		raw := baseTOML + `
-[BalanceMonitor]
-`
-		cfg, err := NewDecodedTOMLConfig(raw)
-		require.NoError(t, err)
-		require.NotNil(t, cfg.BalanceMonitor)
-		assert.Equal(t, DefaultConfigSet.BalanceMonitor.BalancePollPeriod.Duration(), cfg.BalanceMonitor.BalancePollPeriod.Duration())
-	})
-}
-
-// TEST-05: Partial WriteTargetCap -- user field preserved, remaining 2 fields merged from defaults
-func TestSetDefaults_PartialWriteTargetCap(t *testing.T) {
-	t.Parallel()
-
-	raw := baseTOML + `
-[WriteTargetCap]
-Tag = "custom"
-`
-	cfg, err := NewDecodedTOMLConfig(raw)
-	require.NoError(t, err)
-	require.NotNil(t, cfg.WriteTargetCap)
-
-	// User-specified field preserved
-	assert.Equal(t, "custom", *cfg.WriteTargetCap.Tag)
-
-	// Remaining 2 fields merged from write_target.DefaultConfigSet
-	assert.Equal(t, write_target.DefaultConfigSet.ConfirmerPollPeriod.Duration(), cfg.WriteTargetCap.ConfirmerPollPeriod.Duration())
-	assert.Equal(t, write_target.DefaultConfigSet.ConfirmerTimeout.Duration(), cfg.WriteTargetCap.ConfirmerTimeout.Duration())
-}
-
-// TEST-06: Edge cases -- zero-valued defaults are correctly applied (not treated as "unset")
-func TestSetDefaults_EdgeCases_ZeroDefaults(t *testing.T) {
-	t.Parallel()
-
-	t.Run("GasLimitOverhead remains 0 with partial TXM config", func(t *testing.T) {
-		t.Parallel()
-
-		raw := baseTOML + `
-[TransactionManager]
-BroadcastChanSize = 50
-`
-		cfg, err := NewDecodedTOMLConfig(raw)
-		require.NoError(t, err)
-		assert.Equal(t, uint64(0), *cfg.TransactionManager.GasLimitOverhead,
-			"GasLimitOverhead should be 0 -- the default IS zero")
-	})
-
-	t.Run("TXPollerDisabled remains false with partial LogPoller config", func(t *testing.T) {
-		t.Parallel()
-
-		raw := baseTOML + `
-[LogPoller]
-EventBatchSize = 50
-`
-		cfg, err := NewDecodedTOMLConfig(raw)
-		require.NoError(t, err)
-		assert.Equal(t, false, *cfg.LogPoller.TXPollerDisabled,
-			"TXPollerDisabled should be false -- the default IS false")
-	})
-}
-
-// TEST-07: Absent sections -- nil pointers produce complete defaults for all 4 sections
-func TestSetDefaults_AbsentSections(t *testing.T) {
-	t.Parallel()
-
-	// No config section headers at all -- just base TOML
-	cfg, err := NewDecodedTOMLConfig(baseTOML)
-	require.NoError(t, err)
-
-	// All 4 section pointers must be non-nil after applyDefaults
-	require.NotNil(t, cfg.TransactionManager)
-	require.NotNil(t, cfg.LogPoller)
-	require.NotNil(t, cfg.BalanceMonitor)
-	require.NotNil(t, cfg.WriteTargetCap)
-
-	// TransactionManager: all 11 fields match txm.DefaultConfigSet
-	assert.Equal(t, txm.DefaultConfigSet.BroadcastChanSize, cfg.TransactionManager.BroadcastChanSize)
-	assert.Equal(t, txm.DefaultConfigSet.ConfirmPollSecs, cfg.TransactionManager.ConfirmPollSecs)
-	assert.Equal(t, txm.DefaultConfigSet.DefaultMaxGasAmount, cfg.TransactionManager.DefaultMaxGasAmount)
-	assert.Equal(t, txm.DefaultConfigSet.GasLimitOverhead, cfg.TransactionManager.GasLimitOverhead)
-	assert.Equal(t, txm.DefaultConfigSet.MaxSimulateAttempts, cfg.TransactionManager.MaxSimulateAttempts)
-	assert.Equal(t, txm.DefaultConfigSet.MaxSubmitRetryAttempts, cfg.TransactionManager.MaxSubmitRetryAttempts)
-	assert.Equal(t, txm.DefaultConfigSet.SubmitDelayDuration, cfg.TransactionManager.SubmitDelayDuration)
-	assert.Equal(t, txm.DefaultConfigSet.TxExpirationSecs, cfg.TransactionManager.TxExpirationSecs)
-	assert.Equal(t, txm.DefaultConfigSet.MaxTxRetryAttempts, cfg.TransactionManager.MaxTxRetryAttempts)
-	assert.Equal(t, txm.DefaultConfigSet.PruneIntervalSecs, cfg.TransactionManager.PruneIntervalSecs)
-	assert.Equal(t, txm.DefaultConfigSet.PruneTxExpirationSecs, cfg.TransactionManager.PruneTxExpirationSecs)
-
-	// LogPoller: all 6 fields match logpoller.DefaultConfigSet
-	assert.Equal(t, logpoller.DefaultConfigSet.EventPollingInterval.Duration(), cfg.LogPoller.EventPollingInterval.Duration())
-	assert.Equal(t, logpoller.DefaultConfigSet.TxPollingInterval.Duration(), cfg.LogPoller.TxPollingInterval.Duration())
-	assert.Equal(t, logpoller.DefaultConfigSet.PollTimeout.Duration(), cfg.LogPoller.PollTimeout.Duration())
-	assert.Equal(t, logpoller.DefaultConfigSet.EventBatchSize, cfg.LogPoller.EventBatchSize)
-	assert.Equal(t, logpoller.DefaultConfigSet.TxBatchSize, cfg.LogPoller.TxBatchSize)
-	assert.Equal(t, logpoller.DefaultConfigSet.TXPollerDisabled, cfg.LogPoller.TXPollerDisabled)
-
-	// BalanceMonitor: 1 field matches DefaultConfigSet.BalanceMonitor
-	assert.Equal(t, DefaultConfigSet.BalanceMonitor.BalancePollPeriod.Duration(), cfg.BalanceMonitor.BalancePollPeriod.Duration())
-
-	// WriteTargetCap: all 3 fields match write_target.DefaultConfigSet
-	assert.Equal(t, write_target.DefaultConfigSet.Tag, cfg.WriteTargetCap.Tag)
-	assert.Equal(t, write_target.DefaultConfigSet.ConfirmerPollPeriod.Duration(), cfg.WriteTargetCap.ConfirmerPollPeriod.Duration())
-	assert.Equal(t, write_target.DefaultConfigSet.ConfirmerTimeout.Duration(), cfg.WriteTargetCap.ConfirmerTimeout.Duration())
-}
-
-// TEST-08: Fully specified sections retain all user-provided values
-func TestSetDefaults_FullySpecified(t *testing.T) {
-	t.Parallel()
-
-	t.Run("BalanceMonitor retains all values", func(t *testing.T) {
-		t.Parallel()
-
-		raw := baseTOML + `
-[BalanceMonitor]
-BalancePollPeriod = "30s"
-`
-		cfg, err := NewDecodedTOMLConfig(raw)
-		require.NoError(t, err)
-		require.NotNil(t, cfg.BalanceMonitor)
-		assert.Equal(t, 30*time.Second, cfg.BalanceMonitor.BalancePollPeriod.Duration())
-	})
-
-	t.Run("WriteTargetCap retains all values", func(t *testing.T) {
+	t.Run("WriteTargetCap", func(t *testing.T) {
 		t.Parallel()
 
 		raw := baseTOML + `
@@ -367,19 +130,49 @@ ConfirmerTimeout = "30s"
 		assert.Equal(t, 5*time.Second, cfg.WriteTargetCap.ConfirmerPollPeriod.Duration())
 		assert.Equal(t, 30*time.Second, cfg.WriteTargetCap.ConfirmerTimeout.Duration())
 	})
+
+	t.Run("BalanceMonitor", func(t *testing.T) {
+		t.Parallel()
+
+		raw := baseTOML + `
+[BalanceMonitor]
+BalancePollPeriod = "30s"
+`
+		cfg, err := NewDecodedTOMLConfig(raw)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.BalanceMonitor)
+		assert.Equal(t, 30*time.Second, cfg.BalanceMonitor.BalancePollPeriod.Duration())
+	})
+}
+
+// Absent sections -- nil pointers produce complete defaults
+func TestSetDefaults_AbsentSections(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := NewDecodedTOMLConfig(baseTOML)
+	require.NoError(t, err)
+
+	require.NotNil(t, cfg.TransactionManager)
+	require.NotNil(t, cfg.LogPoller)
+	require.NotNil(t, cfg.BalanceMonitor)
+	require.NotNil(t, cfg.WriteTargetCap)
+
+	// Spot-check one field per section (exhaustive Resolve tests live in sub-packages)
+	assert.Equal(t, txm.DefaultConfigSet.BroadcastChanSize, cfg.TransactionManager.BroadcastChanSize)
+	assert.Equal(t, logpoller.DefaultConfigSet.EventPollingInterval.Duration(), cfg.LogPoller.EventPollingInterval.Duration())
+	assert.Equal(t, DefaultConfigSet.BalanceMonitor.BalancePollPeriod.Duration(), cfg.BalanceMonitor.BalancePollPeriod.Duration())
+	assert.Equal(t, write_target.DefaultConfigSet.Tag, cfg.WriteTargetCap.Tag)
 }
 
 // Regression guard: global DefaultConfigSet must never be mutated by config resolution
 func TestNoGlobalMutation(t *testing.T) {
 	t.Parallel()
 
-	// Snapshot all 4 DefaultConfigSet sub-structs before test
 	originalTM := DefaultConfigSet.TransactionManager
 	originalLP := DefaultConfigSet.LogPoller
 	originalBM := DefaultConfigSet.BalanceMonitor
 	originalWT := DefaultConfigSet.WriteTargetCap
 
-	// Create config with a partial section
 	cfg, err := NewDecodedTOMLConfig(baseTOML + `
 [TransactionManager]
 BroadcastChanSize = 999
@@ -389,16 +182,13 @@ BroadcastChanSize = 999
 	// Mutate through the returned pointer
 	*cfg.TransactionManager.BroadcastChanSize = 12345
 
-	// Assert all 4 DefaultConfigSet sub-structs are unchanged
 	assert.Equal(t, originalTM, DefaultConfigSet.TransactionManager, "TransactionManager defaults must not be mutated")
 	assert.Equal(t, originalLP, DefaultConfigSet.LogPoller, "LogPoller defaults must not be mutated")
 	assert.Equal(t, originalBM, DefaultConfigSet.BalanceMonitor, "BalanceMonitor defaults must not be mutated")
 	assert.Equal(t, originalWT, DefaultConfigSet.WriteTargetCap, "WriteTargetCap defaults must not be mutated")
 }
 
-// Explicit zero overrides: user can set a field to 0/false and it is NOT
-// replaced by the default. This is the key improvement of the pointer-based
-// TOML deserialization approach.
+// Explicit zero overrides are preserved (not replaced by defaults).
 func TestExplicitZeroOverride(t *testing.T) {
 	t.Parallel()
 

--- a/relayer/config/config_test.go
+++ b/relayer/config/config_test.go
@@ -6,7 +6,18 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-aptos/relayer/logpoller"
+	"github.com/smartcontractkit/chainlink-aptos/relayer/txm"
+	"github.com/smartcontractkit/chainlink-aptos/relayer/write_target"
 )
+
+const baseTOML = `
+ChainID = "2"
+[[Nodes]]
+Name = "node-1"
+URL = "http://node-1"
+`
 
 func TestTOMLConfig(t *testing.T) {
 	t.Parallel()
@@ -68,7 +79,7 @@ URL = "http://node-1"
 	// Check that LogPoller config has defaults
 	assert.NotNil(t, cfg.LogPoller)
 	assert.Equal(t, 12*time.Second, cfg.LogPoller.EventPollingInterval.Duration())
-	assert.Equal(t, uint64(100), cfg.LogPoller.EventBatchSize)
+	assert.Equal(t, uint64(100), *cfg.LogPoller.EventBatchSize)
 
 	// Test with custom config
 	raw = `
@@ -89,8 +100,8 @@ TxBatchSize = 75
 
 	assert.Equal(t, 15*time.Second, cfg.LogPoller.EventPollingInterval.Duration())
 	assert.Equal(t, 20*time.Second, cfg.LogPoller.TxPollingInterval.Duration())
-	assert.Equal(t, uint64(50), cfg.LogPoller.EventBatchSize)
-	assert.Equal(t, uint64(75), cfg.LogPoller.TxBatchSize)
+	assert.Equal(t, uint64(50), *cfg.LogPoller.EventBatchSize)
+	assert.Equal(t, uint64(75), *cfg.LogPoller.TxBatchSize)
 }
 
 func TestTOMLConfig_TxManager(t *testing.T) {
@@ -109,10 +120,10 @@ URL = "http://node-1"
 
 	// Check that TxManager config has defaults
 	assert.NotNil(t, cfg.TransactionManager)
-	assert.Equal(t, uint64(0), cfg.TransactionManager.GasLimitOverhead)
-	assert.Equal(t, uint64(200000), cfg.TransactionManager.DefaultMaxGasAmount)
-	assert.Equal(t, uint(100), cfg.TransactionManager.BroadcastChanSize)
-	assert.Equal(t, uint(2), cfg.TransactionManager.ConfirmPollSecs)
+	assert.Equal(t, uint64(0), *cfg.TransactionManager.GasLimitOverhead)
+	assert.Equal(t, uint64(200000), *cfg.TransactionManager.DefaultMaxGasAmount)
+	assert.Equal(t, uint(100), *cfg.TransactionManager.BroadcastChanSize)
+	assert.Equal(t, uint(2), *cfg.TransactionManager.ConfirmPollSecs)
 
 	// Test with custom config
 	raw = `
@@ -136,13 +147,311 @@ MaxTxRetryAttempts = 8
 	cfg, err = NewDecodedTOMLConfig(raw)
 	require.NoError(t, err)
 
-	assert.Equal(t, uint64(34), cfg.TransactionManager.GasLimitOverhead)
-	assert.Equal(t, uint64(300000), cfg.TransactionManager.DefaultMaxGasAmount)
-	assert.Equal(t, uint(200), cfg.TransactionManager.BroadcastChanSize)
-	assert.Equal(t, uint(3), cfg.TransactionManager.ConfirmPollSecs)
-	assert.Equal(t, uint(10), cfg.TransactionManager.MaxSimulateAttempts)
-	assert.Equal(t, uint(15), cfg.TransactionManager.MaxSubmitRetryAttempts)
-	assert.Equal(t, uint(5), cfg.TransactionManager.SubmitDelayDuration)
-	assert.Equal(t, uint64(20), cfg.TransactionManager.TxExpirationSecs)
-	assert.Equal(t, uint64(8), cfg.TransactionManager.MaxTxRetryAttempts)
+	assert.Equal(t, uint64(34), *cfg.TransactionManager.GasLimitOverhead)
+	assert.Equal(t, uint64(300000), *cfg.TransactionManager.DefaultMaxGasAmount)
+	assert.Equal(t, uint(200), *cfg.TransactionManager.BroadcastChanSize)
+	assert.Equal(t, uint(3), *cfg.TransactionManager.ConfirmPollSecs)
+	assert.Equal(t, uint(10), *cfg.TransactionManager.MaxSimulateAttempts)
+	assert.Equal(t, uint(15), *cfg.TransactionManager.MaxSubmitRetryAttempts)
+	assert.Equal(t, uint(5), *cfg.TransactionManager.SubmitDelayDuration)
+	assert.Equal(t, uint64(20), *cfg.TransactionManager.TxExpirationSecs)
+	assert.Equal(t, uint64(8), *cfg.TransactionManager.MaxTxRetryAttempts)
+}
+
+// TEST-02: Partial TransactionManager -- user field preserved, remaining 10 fields merged from defaults
+func TestSetDefaults_PartialTransactionManager(t *testing.T) {
+	t.Parallel()
+
+	raw := baseTOML + `
+[TransactionManager]
+BroadcastChanSize = 50
+`
+	cfg, err := NewDecodedTOMLConfig(raw)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.TransactionManager)
+
+	// User-specified field preserved
+	assert.Equal(t, uint(50), *cfg.TransactionManager.BroadcastChanSize)
+
+	// All 10 remaining fields merged from txm.DefaultConfigSet
+	assert.Equal(t, txm.DefaultConfigSet.ConfirmPollSecs, cfg.TransactionManager.ConfirmPollSecs)
+	assert.Equal(t, txm.DefaultConfigSet.DefaultMaxGasAmount, cfg.TransactionManager.DefaultMaxGasAmount)
+	assert.Equal(t, txm.DefaultConfigSet.GasLimitOverhead, cfg.TransactionManager.GasLimitOverhead)
+	assert.Equal(t, txm.DefaultConfigSet.MaxSimulateAttempts, cfg.TransactionManager.MaxSimulateAttempts)
+	assert.Equal(t, txm.DefaultConfigSet.MaxSubmitRetryAttempts, cfg.TransactionManager.MaxSubmitRetryAttempts)
+	assert.Equal(t, txm.DefaultConfigSet.SubmitDelayDuration, cfg.TransactionManager.SubmitDelayDuration)
+	assert.Equal(t, txm.DefaultConfigSet.TxExpirationSecs, cfg.TransactionManager.TxExpirationSecs)
+	assert.Equal(t, txm.DefaultConfigSet.MaxTxRetryAttempts, cfg.TransactionManager.MaxTxRetryAttempts)
+	assert.Equal(t, txm.DefaultConfigSet.PruneIntervalSecs, cfg.TransactionManager.PruneIntervalSecs)
+	assert.Equal(t, txm.DefaultConfigSet.PruneTxExpirationSecs, cfg.TransactionManager.PruneTxExpirationSecs)
+}
+
+// TEST-03: Partial LogPoller -- user field preserved, remaining 5 fields merged from defaults
+func TestSetDefaults_PartialLogPoller(t *testing.T) {
+	t.Parallel()
+
+	raw := baseTOML + `
+[LogPoller]
+EventBatchSize = 50
+`
+	cfg, err := NewDecodedTOMLConfig(raw)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.LogPoller)
+
+	// User-specified field preserved
+	assert.Equal(t, uint64(50), *cfg.LogPoller.EventBatchSize)
+
+	// All 5 remaining fields merged from logpoller.DefaultConfigSet
+	assert.Equal(t, logpoller.DefaultConfigSet.EventPollingInterval.Duration(), cfg.LogPoller.EventPollingInterval.Duration())
+	assert.Equal(t, logpoller.DefaultConfigSet.TxPollingInterval.Duration(), cfg.LogPoller.TxPollingInterval.Duration())
+	assert.Equal(t, logpoller.DefaultConfigSet.PollTimeout.Duration(), cfg.LogPoller.PollTimeout.Duration())
+	assert.Equal(t, logpoller.DefaultConfigSet.TxBatchSize, cfg.LogPoller.TxBatchSize)
+	assert.Equal(t, logpoller.DefaultConfigSet.TXPollerDisabled, cfg.LogPoller.TXPollerDisabled)
+}
+
+// TEST-04: Partial BalanceMonitor -- custom value preserved; empty section gets defaults
+func TestSetDefaults_PartialBalanceMonitor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("custom value preserved", func(t *testing.T) {
+		t.Parallel()
+
+		raw := baseTOML + `
+[BalanceMonitor]
+BalancePollPeriod = "30s"
+`
+		cfg, err := NewDecodedTOMLConfig(raw)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.BalanceMonitor)
+		assert.Equal(t, 30*time.Second, cfg.BalanceMonitor.BalancePollPeriod.Duration())
+	})
+
+	t.Run("empty section gets defaults", func(t *testing.T) {
+		t.Parallel()
+
+		raw := baseTOML + `
+[BalanceMonitor]
+`
+		cfg, err := NewDecodedTOMLConfig(raw)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.BalanceMonitor)
+		assert.Equal(t, DefaultConfigSet.BalanceMonitor.BalancePollPeriod.Duration(), cfg.BalanceMonitor.BalancePollPeriod.Duration())
+	})
+}
+
+// TEST-05: Partial WriteTargetCap -- user field preserved, remaining 2 fields merged from defaults
+func TestSetDefaults_PartialWriteTargetCap(t *testing.T) {
+	t.Parallel()
+
+	raw := baseTOML + `
+[WriteTargetCap]
+Tag = "custom"
+`
+	cfg, err := NewDecodedTOMLConfig(raw)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.WriteTargetCap)
+
+	// User-specified field preserved
+	assert.Equal(t, "custom", *cfg.WriteTargetCap.Tag)
+
+	// Remaining 2 fields merged from write_target.DefaultConfigSet
+	assert.Equal(t, write_target.DefaultConfigSet.ConfirmerPollPeriod.Duration(), cfg.WriteTargetCap.ConfirmerPollPeriod.Duration())
+	assert.Equal(t, write_target.DefaultConfigSet.ConfirmerTimeout.Duration(), cfg.WriteTargetCap.ConfirmerTimeout.Duration())
+}
+
+// TEST-06: Edge cases -- zero-valued defaults are correctly applied (not treated as "unset")
+func TestSetDefaults_EdgeCases_ZeroDefaults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GasLimitOverhead remains 0 with partial TXM config", func(t *testing.T) {
+		t.Parallel()
+
+		raw := baseTOML + `
+[TransactionManager]
+BroadcastChanSize = 50
+`
+		cfg, err := NewDecodedTOMLConfig(raw)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0), *cfg.TransactionManager.GasLimitOverhead,
+			"GasLimitOverhead should be 0 -- the default IS zero")
+	})
+
+	t.Run("TXPollerDisabled remains false with partial LogPoller config", func(t *testing.T) {
+		t.Parallel()
+
+		raw := baseTOML + `
+[LogPoller]
+EventBatchSize = 50
+`
+		cfg, err := NewDecodedTOMLConfig(raw)
+		require.NoError(t, err)
+		assert.Equal(t, false, *cfg.LogPoller.TXPollerDisabled,
+			"TXPollerDisabled should be false -- the default IS false")
+	})
+}
+
+// TEST-07: Absent sections -- nil pointers produce complete defaults for all 4 sections
+func TestSetDefaults_AbsentSections(t *testing.T) {
+	t.Parallel()
+
+	// No config section headers at all -- just base TOML
+	cfg, err := NewDecodedTOMLConfig(baseTOML)
+	require.NoError(t, err)
+
+	// All 4 section pointers must be non-nil after applyDefaults
+	require.NotNil(t, cfg.TransactionManager)
+	require.NotNil(t, cfg.LogPoller)
+	require.NotNil(t, cfg.BalanceMonitor)
+	require.NotNil(t, cfg.WriteTargetCap)
+
+	// TransactionManager: all 11 fields match txm.DefaultConfigSet
+	assert.Equal(t, txm.DefaultConfigSet.BroadcastChanSize, cfg.TransactionManager.BroadcastChanSize)
+	assert.Equal(t, txm.DefaultConfigSet.ConfirmPollSecs, cfg.TransactionManager.ConfirmPollSecs)
+	assert.Equal(t, txm.DefaultConfigSet.DefaultMaxGasAmount, cfg.TransactionManager.DefaultMaxGasAmount)
+	assert.Equal(t, txm.DefaultConfigSet.GasLimitOverhead, cfg.TransactionManager.GasLimitOverhead)
+	assert.Equal(t, txm.DefaultConfigSet.MaxSimulateAttempts, cfg.TransactionManager.MaxSimulateAttempts)
+	assert.Equal(t, txm.DefaultConfigSet.MaxSubmitRetryAttempts, cfg.TransactionManager.MaxSubmitRetryAttempts)
+	assert.Equal(t, txm.DefaultConfigSet.SubmitDelayDuration, cfg.TransactionManager.SubmitDelayDuration)
+	assert.Equal(t, txm.DefaultConfigSet.TxExpirationSecs, cfg.TransactionManager.TxExpirationSecs)
+	assert.Equal(t, txm.DefaultConfigSet.MaxTxRetryAttempts, cfg.TransactionManager.MaxTxRetryAttempts)
+	assert.Equal(t, txm.DefaultConfigSet.PruneIntervalSecs, cfg.TransactionManager.PruneIntervalSecs)
+	assert.Equal(t, txm.DefaultConfigSet.PruneTxExpirationSecs, cfg.TransactionManager.PruneTxExpirationSecs)
+
+	// LogPoller: all 6 fields match logpoller.DefaultConfigSet
+	assert.Equal(t, logpoller.DefaultConfigSet.EventPollingInterval.Duration(), cfg.LogPoller.EventPollingInterval.Duration())
+	assert.Equal(t, logpoller.DefaultConfigSet.TxPollingInterval.Duration(), cfg.LogPoller.TxPollingInterval.Duration())
+	assert.Equal(t, logpoller.DefaultConfigSet.PollTimeout.Duration(), cfg.LogPoller.PollTimeout.Duration())
+	assert.Equal(t, logpoller.DefaultConfigSet.EventBatchSize, cfg.LogPoller.EventBatchSize)
+	assert.Equal(t, logpoller.DefaultConfigSet.TxBatchSize, cfg.LogPoller.TxBatchSize)
+	assert.Equal(t, logpoller.DefaultConfigSet.TXPollerDisabled, cfg.LogPoller.TXPollerDisabled)
+
+	// BalanceMonitor: 1 field matches DefaultConfigSet.BalanceMonitor
+	assert.Equal(t, DefaultConfigSet.BalanceMonitor.BalancePollPeriod.Duration(), cfg.BalanceMonitor.BalancePollPeriod.Duration())
+
+	// WriteTargetCap: all 3 fields match write_target.DefaultConfigSet
+	assert.Equal(t, write_target.DefaultConfigSet.Tag, cfg.WriteTargetCap.Tag)
+	assert.Equal(t, write_target.DefaultConfigSet.ConfirmerPollPeriod.Duration(), cfg.WriteTargetCap.ConfirmerPollPeriod.Duration())
+	assert.Equal(t, write_target.DefaultConfigSet.ConfirmerTimeout.Duration(), cfg.WriteTargetCap.ConfirmerTimeout.Duration())
+}
+
+// TEST-08: Fully specified sections retain all user-provided values
+func TestSetDefaults_FullySpecified(t *testing.T) {
+	t.Parallel()
+
+	t.Run("BalanceMonitor retains all values", func(t *testing.T) {
+		t.Parallel()
+
+		raw := baseTOML + `
+[BalanceMonitor]
+BalancePollPeriod = "30s"
+`
+		cfg, err := NewDecodedTOMLConfig(raw)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.BalanceMonitor)
+		assert.Equal(t, 30*time.Second, cfg.BalanceMonitor.BalancePollPeriod.Duration())
+	})
+
+	t.Run("WriteTargetCap retains all values", func(t *testing.T) {
+		t.Parallel()
+
+		raw := baseTOML + `
+[WriteTargetCap]
+Tag = "custom-tag"
+ConfirmerPollPeriod = "5s"
+ConfirmerTimeout = "30s"
+`
+		cfg, err := NewDecodedTOMLConfig(raw)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.WriteTargetCap)
+		assert.Equal(t, "custom-tag", *cfg.WriteTargetCap.Tag)
+		assert.Equal(t, 5*time.Second, cfg.WriteTargetCap.ConfirmerPollPeriod.Duration())
+		assert.Equal(t, 30*time.Second, cfg.WriteTargetCap.ConfirmerTimeout.Duration())
+	})
+}
+
+// Regression guard: global DefaultConfigSet must never be mutated by config resolution
+func TestNoGlobalMutation(t *testing.T) {
+	t.Parallel()
+
+	// Snapshot all 4 DefaultConfigSet sub-structs before test
+	originalTM := DefaultConfigSet.TransactionManager
+	originalLP := DefaultConfigSet.LogPoller
+	originalBM := DefaultConfigSet.BalanceMonitor
+	originalWT := DefaultConfigSet.WriteTargetCap
+
+	// Create config with a partial section
+	cfg, err := NewDecodedTOMLConfig(baseTOML + `
+[TransactionManager]
+BroadcastChanSize = 999
+`)
+	require.NoError(t, err)
+
+	// Mutate through the returned pointer
+	*cfg.TransactionManager.BroadcastChanSize = 12345
+
+	// Assert all 4 DefaultConfigSet sub-structs are unchanged
+	assert.Equal(t, originalTM, DefaultConfigSet.TransactionManager, "TransactionManager defaults must not be mutated")
+	assert.Equal(t, originalLP, DefaultConfigSet.LogPoller, "LogPoller defaults must not be mutated")
+	assert.Equal(t, originalBM, DefaultConfigSet.BalanceMonitor, "BalanceMonitor defaults must not be mutated")
+	assert.Equal(t, originalWT, DefaultConfigSet.WriteTargetCap, "WriteTargetCap defaults must not be mutated")
+}
+
+// Explicit zero overrides: user can set a field to 0/false and it is NOT
+// replaced by the default. This is the key improvement of the pointer-based
+// TOML deserialization approach.
+func TestExplicitZeroOverride(t *testing.T) {
+	t.Parallel()
+
+	t.Run("TransactionManager explicit zero overrides default", func(t *testing.T) {
+		t.Parallel()
+
+		raw := baseTOML + `
+[TransactionManager]
+DefaultMaxGasAmount = 0
+MaxSimulateAttempts = 0
+`
+		cfg, err := NewDecodedTOMLConfig(raw)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0), *cfg.TransactionManager.DefaultMaxGasAmount,
+			"explicit 0 must override default of 200000")
+		assert.Equal(t, uint(0), *cfg.TransactionManager.MaxSimulateAttempts,
+			"explicit 0 must override default of 5")
+		// Non-specified fields still get defaults
+		assert.Equal(t, txm.DefaultConfigSet.BroadcastChanSize, cfg.TransactionManager.BroadcastChanSize)
+	})
+
+	t.Run("LogPoller explicit false overrides default", func(t *testing.T) {
+		t.Parallel()
+
+		raw := baseTOML + `
+[LogPoller]
+EventBatchSize = 0
+TXPollerDisabled = false
+`
+		cfg, err := NewDecodedTOMLConfig(raw)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0), *cfg.LogPoller.EventBatchSize,
+			"explicit 0 must override default of 100")
+		assert.Equal(t, false, *cfg.LogPoller.TXPollerDisabled,
+			"explicit false must be preserved")
+		// Non-specified fields still get defaults
+		assert.Equal(t, logpoller.DefaultConfigSet.EventPollingInterval.Duration(),
+			cfg.LogPoller.EventPollingInterval.Duration())
+	})
+
+	t.Run("WriteTargetCap explicit empty string", func(t *testing.T) {
+		t.Parallel()
+
+		raw := baseTOML + `
+[WriteTargetCap]
+Tag = ""
+`
+		cfg, err := NewDecodedTOMLConfig(raw)
+		require.NoError(t, err)
+		assert.Equal(t, "", *cfg.WriteTargetCap.Tag,
+			"explicit empty string must be preserved")
+		// Non-specified fields still get defaults
+		assert.Equal(t, write_target.DefaultConfigSet.ConfirmerPollPeriod.Duration(),
+			cfg.WriteTargetCap.ConfirmerPollPeriod.Duration())
+	})
 }

--- a/relayer/config/config_test.go
+++ b/relayer/config/config_test.go
@@ -6,10 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/smartcontractkit/chainlink-aptos/relayer/logpoller"
-	"github.com/smartcontractkit/chainlink-aptos/relayer/txm"
-	"github.com/smartcontractkit/chainlink-aptos/relayer/write_target"
 )
 
 const baseTOML = `
@@ -145,25 +141,6 @@ BalancePollPeriod = "30s"
 	})
 }
 
-// Absent sections -- nil pointers produce complete defaults
-func TestSetDefaults_AbsentSections(t *testing.T) {
-	t.Parallel()
-
-	cfg, err := NewDecodedTOMLConfig(baseTOML)
-	require.NoError(t, err)
-
-	require.NotNil(t, cfg.TransactionManager)
-	require.NotNil(t, cfg.LogPoller)
-	require.NotNil(t, cfg.BalanceMonitor)
-	require.NotNil(t, cfg.WriteTargetCap)
-
-	// Spot-check one field per section (exhaustive Resolve tests live in sub-packages)
-	assert.Equal(t, txm.DefaultConfigSet.BroadcastChanSize, cfg.TransactionManager.BroadcastChanSize)
-	assert.Equal(t, logpoller.DefaultConfigSet.EventPollingInterval.Duration(), cfg.LogPoller.EventPollingInterval.Duration())
-	assert.Equal(t, DefaultConfigSet.BalanceMonitor.BalancePollPeriod.Duration(), cfg.BalanceMonitor.BalancePollPeriod.Duration())
-	assert.Equal(t, write_target.DefaultConfigSet.Tag, cfg.WriteTargetCap.Tag)
-}
-
 // Regression guard: global DefaultConfigSet must never be mutated by config resolution
 func TestNoGlobalMutation(t *testing.T) {
 	t.Parallel()
@@ -188,60 +165,3 @@ BroadcastChanSize = 999
 	assert.Equal(t, originalWT, DefaultConfigSet.WriteTargetCap, "WriteTargetCap defaults must not be mutated")
 }
 
-// Explicit zero overrides are preserved (not replaced by defaults).
-func TestExplicitZeroOverride(t *testing.T) {
-	t.Parallel()
-
-	t.Run("TransactionManager explicit zero overrides default", func(t *testing.T) {
-		t.Parallel()
-
-		raw := baseTOML + `
-[TransactionManager]
-DefaultMaxGasAmount = 0
-MaxSimulateAttempts = 0
-`
-		cfg, err := NewDecodedTOMLConfig(raw)
-		require.NoError(t, err)
-		assert.Equal(t, uint64(0), *cfg.TransactionManager.DefaultMaxGasAmount,
-			"explicit 0 must override default of 200000")
-		assert.Equal(t, uint(0), *cfg.TransactionManager.MaxSimulateAttempts,
-			"explicit 0 must override default of 5")
-		// Non-specified fields still get defaults
-		assert.Equal(t, txm.DefaultConfigSet.BroadcastChanSize, cfg.TransactionManager.BroadcastChanSize)
-	})
-
-	t.Run("LogPoller explicit false overrides default", func(t *testing.T) {
-		t.Parallel()
-
-		raw := baseTOML + `
-[LogPoller]
-EventBatchSize = 0
-TXPollerDisabled = false
-`
-		cfg, err := NewDecodedTOMLConfig(raw)
-		require.NoError(t, err)
-		assert.Equal(t, uint64(0), *cfg.LogPoller.EventBatchSize,
-			"explicit 0 must override default of 100")
-		assert.Equal(t, false, *cfg.LogPoller.TXPollerDisabled,
-			"explicit false must be preserved")
-		// Non-specified fields still get defaults
-		assert.Equal(t, logpoller.DefaultConfigSet.EventPollingInterval.Duration(),
-			cfg.LogPoller.EventPollingInterval.Duration())
-	})
-
-	t.Run("WriteTargetCap explicit empty string", func(t *testing.T) {
-		t.Parallel()
-
-		raw := baseTOML + `
-[WriteTargetCap]
-Tag = ""
-`
-		cfg, err := NewDecodedTOMLConfig(raw)
-		require.NoError(t, err)
-		assert.Equal(t, "", *cfg.WriteTargetCap.Tag,
-			"explicit empty string must be preserved")
-		// Non-specified fields still get defaults
-		assert.Equal(t, write_target.DefaultConfigSet.ConfirmerPollPeriod.Duration(),
-			cfg.WriteTargetCap.ConfirmerPollPeriod.Duration())
-	})
-}

--- a/relayer/logpoller/config.go
+++ b/relayer/logpoller/config.go
@@ -6,33 +6,62 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
 )
 
-// Config holds configuration for the LogPoller
+func ptr[T any](v T) *T { return &v }
+
+// Config holds configuration for the LogPoller.
+// Pointer fields are used for TOML deserialization — nil means "not set by user".
+// After calling Resolve(), all fields are guaranteed non-nil.
 type Config struct {
 	// EventPollingInterval is the interval at which events are polled
-	EventPollingInterval config.Duration
+	EventPollingInterval *config.Duration `toml:"EventPollingInterval"`
 
 	// TxPollingInterval is the interval at which transactions are polled
-	TxPollingInterval config.Duration
+	TxPollingInterval *config.Duration `toml:"TxPollingInterval"`
 
 	// PollTimeout is the maximum time a single polling operation can take
-	PollTimeout config.Duration
+	PollTimeout *config.Duration `toml:"PollTimeout"`
 
 	// EventBatchSize is the maximum number of events to fetch in a single request
-	EventBatchSize uint64
+	EventBatchSize *uint64 `toml:"EventBatchSize"`
 
 	// TxBatchSize is the maximum number of transactions to fetch in a single request
-	TxBatchSize uint64
+	TxBatchSize *uint64 `toml:"TxBatchSize"`
 
 	// TXPollerDisabled if this is true, the TX poller will not run on log poller start
-	TXPollerDisabled bool
+	TXPollerDisabled *bool `toml:"TXPollerDisabled"`
 }
 
 // DefaultConfigSet is the default configuration for LogPoller
 var DefaultConfigSet = Config{
-	EventPollingInterval: *config.MustNewDuration(12 * time.Second),
-	TxPollingInterval:    *config.MustNewDuration(12 * time.Second),
-	PollTimeout:          *config.MustNewDuration(10 * time.Second),
-	EventBatchSize:       100,
-	TxBatchSize:          100,
-	TXPollerDisabled:     false,
+	EventPollingInterval: config.MustNewDuration(12 * time.Second),
+	TxPollingInterval:    config.MustNewDuration(12 * time.Second),
+	PollTimeout:          config.MustNewDuration(10 * time.Second),
+	EventBatchSize:       ptr(uint64(100)),
+	TxBatchSize:          ptr(uint64(100)),
+	TXPollerDisabled:     ptr(false),
+}
+
+// Resolve fills nil fields with defaults. After calling Resolve, all fields are guaranteed non-nil.
+func (c *Config) Resolve() {
+	if c.EventPollingInterval == nil {
+		v := *DefaultConfigSet.EventPollingInterval
+		c.EventPollingInterval = &v
+	}
+	if c.TxPollingInterval == nil {
+		v := *DefaultConfigSet.TxPollingInterval
+		c.TxPollingInterval = &v
+	}
+	if c.PollTimeout == nil {
+		v := *DefaultConfigSet.PollTimeout
+		c.PollTimeout = &v
+	}
+	if c.EventBatchSize == nil {
+		c.EventBatchSize = ptr(*DefaultConfigSet.EventBatchSize)
+	}
+	if c.TxBatchSize == nil {
+		c.TxBatchSize = ptr(*DefaultConfigSet.TxBatchSize)
+	}
+	if c.TXPollerDisabled == nil {
+		c.TXPollerDisabled = ptr(*DefaultConfigSet.TXPollerDisabled)
+	}
 }

--- a/relayer/logpoller/config_test.go
+++ b/relayer/logpoller/config_test.go
@@ -1,0 +1,23 @@
+package logpoller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolve_AllDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{}
+	cfg.Resolve()
+
+	assert.Equal(t, DefaultConfigSet.EventPollingInterval.Duration(), cfg.EventPollingInterval.Duration())
+	assert.Equal(t, DefaultConfigSet.TxPollingInterval.Duration(), cfg.TxPollingInterval.Duration())
+	assert.Equal(t, DefaultConfigSet.PollTimeout.Duration(), cfg.PollTimeout.Duration())
+	assert.Equal(t, DefaultConfigSet.EventBatchSize, cfg.EventBatchSize)
+	assert.Equal(t, DefaultConfigSet.TxBatchSize, cfg.TxBatchSize)
+	assert.Equal(t, DefaultConfigSet.TXPollerDisabled, cfg.TXPollerDisabled)
+}
+
+

--- a/relayer/logpoller/config_test.go
+++ b/relayer/logpoller/config_test.go
@@ -20,4 +20,31 @@ func TestResolve_AllDefaults(t *testing.T) {
 	assert.Equal(t, DefaultConfigSet.TXPollerDisabled, cfg.TXPollerDisabled)
 }
 
+func TestResolve_PartialOverride(t *testing.T) {
+	t.Parallel()
 
+	cfg := Config{
+		EventBatchSize: ptr(uint64(50)),
+	}
+	cfg.Resolve()
+
+	assert.Equal(t, uint64(50), *cfg.EventBatchSize)
+	assert.Equal(t, DefaultConfigSet.EventPollingInterval.Duration(), cfg.EventPollingInterval.Duration())
+	assert.Equal(t, DefaultConfigSet.TXPollerDisabled, cfg.TXPollerDisabled)
+}
+
+func TestResolve_ExplicitZero(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		EventBatchSize:   ptr(uint64(0)),
+		TXPollerDisabled: ptr(false),
+	}
+	cfg.Resolve()
+
+	assert.Equal(t, uint64(0), *cfg.EventBatchSize,
+		"explicit 0 must not be overwritten by default of 100")
+	assert.Equal(t, false, *cfg.TXPollerDisabled,
+		"explicit false must be preserved")
+	assert.Equal(t, DefaultConfigSet.EventPollingInterval.Duration(), cfg.EventPollingInterval.Duration())
+}

--- a/relayer/logpoller/event_poller.go
+++ b/relayer/logpoller/event_poller.go
@@ -202,7 +202,7 @@ func (l *AptosLogPoller) syncEvent(ctx context.Context, boundAddress aptos.Accou
 		return fmt.Errorf("syncEvent: failed to extract creation_num for %s: %w", eventFieldName, err)
 	}
 
-	batchSize := l.config.EventBatchSize
+	batchSize := *l.config.EventBatchSize
 	var totalProcessed int = 0
 
 	var client aptos.AptosRpcClient

--- a/relayer/logpoller/logpoller.go
+++ b/relayer/logpoller/logpoller.go
@@ -50,7 +50,8 @@ type AptosLogPoller struct {
 
 func NewLogPoller(lggr logger.Logger, chainInfo types.ChainInfo, getClient func() (aptos.AptosRpcClient, error), ds sqlutil.DataSource, cfg *Config) (*AptosLogPoller, error) {
 	if cfg == nil {
-		cfg = &DefaultConfigSet
+		tmp := DefaultConfigSet
+		cfg = &tmp
 	}
 
 	dbStore := db.NewDBStore(ds, lggr)
@@ -81,7 +82,7 @@ func (l *AptosLogPoller) Start(ctx context.Context) error {
 			syncEventCtx, l.eventCtxCancel = context.WithCancel(context.Background())
 			go l.startEventPolling(syncEventCtx)
 
-			if l.config.TXPollerDisabled == true {
+			if *l.config.TXPollerDisabled {
 				l.lggr.Info("Skipping transaction polling as TXPollerDisabled is set to true")
 				return nil
 			}

--- a/relayer/logpoller/tx_poller.go
+++ b/relayer/logpoller/tx_poller.go
@@ -115,7 +115,7 @@ func (l *AptosLogPoller) SyncAllTransmitterTxs(ctx context.Context) error {
 		return nil
 	}
 
-	batchSize := l.config.TxBatchSize
+	batchSize := *l.config.TxBatchSize
 	var totalProcessed int
 
 	for _, transmitter := range transmitters {

--- a/relayer/monitor/balance_config_test.go
+++ b/relayer/monitor/balance_config_test.go
@@ -1,0 +1,16 @@
+package monitor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolve_AllDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenericBalanceConfig{}
+	cfg.Resolve()
+
+	assert.Equal(t, DefaultBalanceConfig.BalancePollPeriod.Duration(), cfg.BalancePollPeriod.Duration())
+}

--- a/relayer/monitor/generic_balance.go
+++ b/relayer/monitor/generic_balance.go
@@ -14,9 +14,24 @@ import (
 	"github.com/smartcontractkit/chainlink-aptos/relayer/types"
 )
 
-// Config defines the balance monitor configuration.
+// GenericBalanceConfig defines the balance monitor configuration.
+// Pointer fields are used for TOML deserialization — nil means "not set by user".
+// After calling Resolve(), all fields are guaranteed non-nil.
 type GenericBalanceConfig struct {
-	BalancePollPeriod config.Duration
+	BalancePollPeriod *config.Duration `toml:"BalancePollPeriod"`
+}
+
+// DefaultBalanceConfig is the default configuration for the balance monitor.
+var DefaultBalanceConfig = GenericBalanceConfig{
+	BalancePollPeriod: config.MustNewDuration(10 * time.Second),
+}
+
+// Resolve fills nil fields with defaults. After calling Resolve, all fields are guaranteed non-nil.
+func (c *GenericBalanceConfig) Resolve() {
+	if c.BalancePollPeriod == nil {
+		v := *DefaultBalanceConfig.BalancePollPeriod
+		c.BalancePollPeriod = &v
+	}
 }
 
 // GenericBalanceClient defines the interface for getting account balances.

--- a/relayer/monitor/generic_balance_test.go
+++ b/relayer/monitor/generic_balance_test.go
@@ -37,7 +37,7 @@ func testOpts(t *testing.T) GenericBalanceMonitorOpts {
 	return GenericBalanceMonitorOpts{
 		ChainInfo:           types.ChainInfo{ChainFamilyName: "aptos", ChainID: "testnet", NetworkName: "testnet", NetworkNameFull: "aptos-testnet"},
 		ChainNativeCurrency: "APT",
-		Config:              GenericBalanceConfig{BalancePollPeriod: *config.MustNewDuration(100 * time.Millisecond)},
+		Config:              GenericBalanceConfig{BalancePollPeriod: config.MustNewDuration(100 * time.Millisecond)},
 		Logger:              logger.Test(t),
 		Keystore:            ks,
 		NewGenericBalanceClient: func() (GenericBalanceClient, error) {

--- a/relayer/txm/config.go
+++ b/relayer/txm/config.go
@@ -1,36 +1,78 @@
 package txm
 
+func ptr[T any](v T) *T { return &v }
+
 // TODO: these should be duration, not numbers
+// Config defines the transaction manager configuration.
+// Pointer fields are used for TOML deserialization — nil means "not set by user".
+// After calling Resolve(), all fields are guaranteed non-nil.
 type Config struct {
-	BroadcastChanSize uint
-	ConfirmPollSecs   uint
+	BroadcastChanSize *uint `toml:"BroadcastChanSize"`
+	ConfirmPollSecs   *uint `toml:"ConfirmPollSecs"`
 
-	DefaultMaxGasAmount uint64
-	GasLimitOverhead    uint64
+	DefaultMaxGasAmount *uint64 `toml:"DefaultMaxGasAmount"`
+	GasLimitOverhead    *uint64 `toml:"GasLimitOverhead"`
 
-	MaxSimulateAttempts    uint
-	MaxSubmitRetryAttempts uint
-	SubmitDelayDuration    uint
-	TxExpirationSecs       uint64
-	MaxTxRetryAttempts     uint64
-	PruneIntervalSecs      uint64
-	PruneTxExpirationSecs  uint64
+	MaxSimulateAttempts    *uint   `toml:"MaxSimulateAttempts"`
+	MaxSubmitRetryAttempts *uint   `toml:"MaxSubmitRetryAttempts"`
+	SubmitDelayDuration    *uint   `toml:"SubmitDelayDuration"`
+	TxExpirationSecs       *uint64 `toml:"TxExpirationSecs"`
+	MaxTxRetryAttempts     *uint64 `toml:"MaxTxRetryAttempts"`
+	PruneIntervalSecs      *uint64 `toml:"PruneIntervalSecs"`
+	PruneTxExpirationSecs  *uint64 `toml:"PruneTxExpirationSecs"`
 }
 
 // DefaultConfigSet is the default configuration for the TransactionManager
 var DefaultConfigSet = Config{
-	BroadcastChanSize: 100,
-	ConfirmPollSecs:   2,
+	BroadcastChanSize: ptr(uint(100)),
+	ConfirmPollSecs:   ptr(uint(2)),
 
 	// https://github.com/aptos-labs/aptos-ts-sdk/blob/32d4360740392782c1368647f89ba62e1b6a2cb3/src/utils/const.ts#L21
-	DefaultMaxGasAmount: 200000,
-	GasLimitOverhead:    0,
+	DefaultMaxGasAmount: ptr(uint64(200000)),
+	GasLimitOverhead:    ptr(uint64(0)),
 
-	MaxSimulateAttempts:    5,
-	MaxSubmitRetryAttempts: 10,
-	SubmitDelayDuration:    3,  // seconds
-	TxExpirationSecs:       10, // seconds
-	MaxTxRetryAttempts:     5,
-	PruneIntervalSecs:      uint64(60 * 60 * 4), // 4 hours
-	PruneTxExpirationSecs:  uint64(60 * 60 * 2), // 2 hours
+	MaxSimulateAttempts:    ptr(uint(5)),
+	MaxSubmitRetryAttempts: ptr(uint(10)),
+	SubmitDelayDuration:    ptr(uint(3)),            // seconds
+	TxExpirationSecs:       ptr(uint64(10)),         // seconds
+	MaxTxRetryAttempts:     ptr(uint64(5)),
+	PruneIntervalSecs:      ptr(uint64(60 * 60 * 4)), // 4 hours
+	PruneTxExpirationSecs:  ptr(uint64(60 * 60 * 2)), // 2 hours
+}
+
+// Resolve fills nil fields with defaults. After calling Resolve, all fields are guaranteed non-nil.
+func (c *Config) Resolve() {
+	if c.BroadcastChanSize == nil {
+		c.BroadcastChanSize = ptr(*DefaultConfigSet.BroadcastChanSize)
+	}
+	if c.ConfirmPollSecs == nil {
+		c.ConfirmPollSecs = ptr(*DefaultConfigSet.ConfirmPollSecs)
+	}
+	if c.DefaultMaxGasAmount == nil {
+		c.DefaultMaxGasAmount = ptr(*DefaultConfigSet.DefaultMaxGasAmount)
+	}
+	if c.GasLimitOverhead == nil {
+		c.GasLimitOverhead = ptr(*DefaultConfigSet.GasLimitOverhead)
+	}
+	if c.MaxSimulateAttempts == nil {
+		c.MaxSimulateAttempts = ptr(*DefaultConfigSet.MaxSimulateAttempts)
+	}
+	if c.MaxSubmitRetryAttempts == nil {
+		c.MaxSubmitRetryAttempts = ptr(*DefaultConfigSet.MaxSubmitRetryAttempts)
+	}
+	if c.SubmitDelayDuration == nil {
+		c.SubmitDelayDuration = ptr(*DefaultConfigSet.SubmitDelayDuration)
+	}
+	if c.TxExpirationSecs == nil {
+		c.TxExpirationSecs = ptr(*DefaultConfigSet.TxExpirationSecs)
+	}
+	if c.MaxTxRetryAttempts == nil {
+		c.MaxTxRetryAttempts = ptr(*DefaultConfigSet.MaxTxRetryAttempts)
+	}
+	if c.PruneIntervalSecs == nil {
+		c.PruneIntervalSecs = ptr(*DefaultConfigSet.PruneIntervalSecs)
+	}
+	if c.PruneTxExpirationSecs == nil {
+		c.PruneTxExpirationSecs = ptr(*DefaultConfigSet.PruneTxExpirationSecs)
+	}
 }

--- a/relayer/txm/config_test.go
+++ b/relayer/txm/config_test.go
@@ -1,0 +1,28 @@
+package txm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolve_AllDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{}
+	cfg.Resolve()
+
+	assert.Equal(t, DefaultConfigSet.BroadcastChanSize, cfg.BroadcastChanSize)
+	assert.Equal(t, DefaultConfigSet.ConfirmPollSecs, cfg.ConfirmPollSecs)
+	assert.Equal(t, DefaultConfigSet.DefaultMaxGasAmount, cfg.DefaultMaxGasAmount)
+	assert.Equal(t, DefaultConfigSet.GasLimitOverhead, cfg.GasLimitOverhead)
+	assert.Equal(t, DefaultConfigSet.MaxSimulateAttempts, cfg.MaxSimulateAttempts)
+	assert.Equal(t, DefaultConfigSet.MaxSubmitRetryAttempts, cfg.MaxSubmitRetryAttempts)
+	assert.Equal(t, DefaultConfigSet.SubmitDelayDuration, cfg.SubmitDelayDuration)
+	assert.Equal(t, DefaultConfigSet.TxExpirationSecs, cfg.TxExpirationSecs)
+	assert.Equal(t, DefaultConfigSet.MaxTxRetryAttempts, cfg.MaxTxRetryAttempts)
+	assert.Equal(t, DefaultConfigSet.PruneIntervalSecs, cfg.PruneIntervalSecs)
+	assert.Equal(t, DefaultConfigSet.PruneTxExpirationSecs, cfg.PruneTxExpirationSecs)
+}
+
+

--- a/relayer/txm/config_test.go
+++ b/relayer/txm/config_test.go
@@ -25,4 +25,31 @@ func TestResolve_AllDefaults(t *testing.T) {
 	assert.Equal(t, DefaultConfigSet.PruneTxExpirationSecs, cfg.PruneTxExpirationSecs)
 }
 
+func TestResolve_PartialOverride(t *testing.T) {
+	t.Parallel()
 
+	cfg := Config{
+		BroadcastChanSize: ptr(uint(50)),
+	}
+	cfg.Resolve()
+
+	assert.Equal(t, uint(50), *cfg.BroadcastChanSize)
+	assert.Equal(t, DefaultConfigSet.ConfirmPollSecs, cfg.ConfirmPollSecs)
+	assert.Equal(t, DefaultConfigSet.DefaultMaxGasAmount, cfg.DefaultMaxGasAmount)
+}
+
+func TestResolve_ExplicitZero(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		DefaultMaxGasAmount: ptr(uint64(0)),
+		MaxSimulateAttempts: ptr(uint(0)),
+	}
+	cfg.Resolve()
+
+	assert.Equal(t, uint64(0), *cfg.DefaultMaxGasAmount,
+		"explicit 0 must not be overwritten by default of 200000")
+	assert.Equal(t, uint(0), *cfg.MaxSimulateAttempts,
+		"explicit 0 must not be overwritten by default of 5")
+	assert.Equal(t, DefaultConfigSet.BroadcastChanSize, cfg.BroadcastChanSize)
+}

--- a/relayer/txm/txm.go
+++ b/relayer/txm/txm.go
@@ -66,7 +66,7 @@ func New(lgr logger.Logger, keystore loop.Keystore, config Config, getClient fun
 		transactions:              map[string]*AptosTx{},
 		transactionsLastPruneTime: getTimestampSecs(),
 
-		broadcastChan: make(chan string, config.BroadcastChanSize),
+		broadcastChan: make(chan string, *config.BroadcastChanSize),
 		accountStore:  NewAccountStore(),
 		stop:          make(chan struct{}),
 	}, nil
@@ -255,12 +255,12 @@ func (a *AptosTxm) enqueueTransaction(tx *AptosTx) error {
 
 	a.transactionsLock.Lock()
 	currentTimestamp := tx.Timestamp
-	if (currentTimestamp - a.transactionsLastPruneTime) > a.config.PruneIntervalSecs {
+	if (currentTimestamp - a.transactionsLastPruneTime) > *a.config.PruneIntervalSecs {
 		for txID, existingTx := range a.transactions {
 			if existingTx.Status != commontypes.Finalized && existingTx.Status != commontypes.Failed && existingTx.Status != commontypes.Fatal {
 				continue
 			}
-			if (currentTimestamp - existingTx.Timestamp) < a.config.PruneTxExpirationSecs {
+			if (currentTimestamp - existingTx.Timestamp) < *a.config.PruneTxExpirationSecs {
 				continue
 			}
 			ctxLogger.Debugw("Pruning transaction", "status", existingTx.Status)
@@ -414,7 +414,7 @@ func (a *AptosTxm) createRawTx(client aptos.AptosRpcClient, tx *AptosTx, nonce u
 		return nil, fmt.Errorf("failed to fetch ledger timestamp: %w", err)
 	}
 
-	expirationTimestampSecs := ledgerTimestampSecs + a.config.TxExpirationSecs
+	expirationTimestampSecs := ledgerTimestampSecs + *a.config.TxExpirationSecs
 
 	payload := aptos.TransactionPayload{
 		Payload: &aptos.EntryFunction{
@@ -487,16 +487,16 @@ func (a *AptosTxm) createRawTx(client aptos.AptosRpcClient, tx *AptosTx, nonce u
 	}
 
 	if rawTx.MaxGasAmount == 0 {
-		rawTx.MaxGasAmount = a.config.DefaultMaxGasAmount
-		ctxLogger.Debugw("using default max gas amount", "maxGasAmount", a.config.DefaultMaxGasAmount)
+		rawTx.MaxGasAmount = *a.config.DefaultMaxGasAmount
+		ctxLogger.Debugw("using default max gas amount", "maxGasAmount", *a.config.DefaultMaxGasAmount)
 	}
 
-	if a.config.GasLimitOverhead > 0 {
+	if *a.config.GasLimitOverhead > 0 {
 		originalGasLimit := rawTx.MaxGasAmount
-		rawTx.MaxGasAmount += a.config.GasLimitOverhead
+		rawTx.MaxGasAmount += *a.config.GasLimitOverhead
 		ctxLogger.Debugw("added gas limit overhead",
 			"original", originalGasLimit,
-			"overhead", a.config.GasLimitOverhead,
+			"overhead", *a.config.GasLimitOverhead,
 			"final", rawTx.MaxGasAmount)
 	}
 
@@ -608,7 +608,7 @@ func (a *AptosTxm) signAndBroadcast(ctx context.Context, tx *AptosTx) {
 	}
 
 	// broadcast with basic retry to try get the tx included in the mempool
-	for attempt := 1; attempt <= int(a.config.MaxSubmitRetryAttempts); attempt++ {
+	for attempt := 1; attempt <= int(*a.config.MaxSubmitRetryAttempts); attempt++ {
 		// build the tx with the nonce and expiration timestamp
 		nonce := txStore.GetNextNonce()
 
@@ -671,7 +671,7 @@ func (a *AptosTxm) signAndBroadcast(ctx context.Context, tx *AptosTx) {
 			}
 
 			ctxLogger.Errorw("failed to submit signed tx, retrying..", "error", httpError)
-			time.Sleep(time.Duration(a.config.SubmitDelayDuration) * time.Second)
+			time.Sleep(time.Duration(*a.config.SubmitDelayDuration) * time.Second)
 
 			httpErrorBody := string(httpError.Body)
 			if strings.Contains(httpErrorBody, "SEQUENCE_NUMBER_TOO_OLD") || strings.Contains(httpErrorBody, "SEQUENCE_NUMBER_TOO_NEW") {
@@ -708,7 +708,7 @@ func (a *AptosTxm) confirmLoop() {
 	ctx, cancel := commonutils.ContextFromChan(a.stop)
 	defer cancel()
 
-	pollDuration := time.Duration(a.config.ConfirmPollSecs) * time.Second
+	pollDuration := time.Duration(*a.config.ConfirmPollSecs) * time.Second
 	tick := time.After(pollDuration)
 
 	a.baseLogger.Debugw("confirmLoop: started")
@@ -869,7 +869,7 @@ func (r RetryReason) String() string {
 func (a *AptosTxm) maybeRetry(ctx context.Context, unconfirmedTx *UnconfirmedTx, retryReason RetryReason) bool {
 	ctxLogger := GetContexedTxLogger(a.baseLogger, unconfirmedTx.Tx.ID, unconfirmedTx.Tx.Metadata)
 	currentAttempt := a.getTransactionAttempt(unconfirmedTx.Tx)
-	if currentAttempt >= a.config.MaxTxRetryAttempts {
+	if currentAttempt >= *a.config.MaxTxRetryAttempts {
 		ctxLogger.Errorw("tx reached max num of retries and will be discarded", "hash", unconfirmedTx.Hash, "retryReason", retryReason)
 		return false
 	}
@@ -968,7 +968,7 @@ func (a *AptosTxm) simulateTransaction(client aptos.AptosRpcClient, rawTx aptos.
 
 	attempt := 1
 	var lastError error
-	for attempt <= int(a.config.MaxSimulateAttempts) {
+	for attempt <= int(*a.config.MaxSimulateAttempts) {
 		// need to fetch latest sequence number on-chain since we could have other in-flight txs which results in an error SEQUENCE_NUMBER_TOO_NEW
 		sequenceNumber, err := a.getSequenceNumber(client, fromAddress)
 		if err != nil {

--- a/relayer/txm/txm_error_test.go
+++ b/relayer/txm/txm_error_test.go
@@ -146,7 +146,7 @@ func runErrorsTest(t *testing.T, logger logger.Logger, config Config, rpcURL str
 
 	// Test with expired transaction
 	rawTx.SequenceNumber = sequenceNumber
-	rawTx.ExpirationTimestampSeconds = rawTx.ExpirationTimestampSeconds - txm.config.TxExpirationSecs - 3600 // 1 hour ago
+	rawTx.ExpirationTimestampSeconds = rawTx.ExpirationTimestampSeconds - *txm.config.TxExpirationSecs - 3600 // 1 hour ago
 	signedTx, err = txm.createSignedTx(rlClient, rawTx, selectedTx.PublicKey, selectedTx.FromAddress)
 	require.NoError(t, err)
 

--- a/relayer/txm/txm_test.go
+++ b/relayer/txm/txm_test.go
@@ -9,9 +9,12 @@ import (
 )
 
 func TestTxmMaybeRetryReturnsFalseWhenBroadcastChannelIsFull(t *testing.T) {
+	cfg := DefaultConfigSet
+	cfg.Resolve()
 	txm := &AptosTxm{
 		baseLogger:    logger.Test(t),
 		broadcastChan: make(chan string, 1),
+		config:        cfg,
 	}
 	txm.broadcastChan <- "existing"
 

--- a/relayer/txm/txm_test.go
+++ b/relayer/txm/txm_test.go
@@ -9,12 +9,10 @@ import (
 )
 
 func TestTxmMaybeRetryReturnsFalseWhenBroadcastChannelIsFull(t *testing.T) {
-	cfg := DefaultConfigSet
-	cfg.Resolve()
 	txm := &AptosTxm{
 		baseLogger:    logger.Test(t),
 		broadcastChan: make(chan string, 1),
-		config:        cfg,
+		config:        DefaultConfigSet,
 	}
 	txm.broadcastChan <- "existing"
 

--- a/relayer/write_target/aptos/write_target.go
+++ b/relayer/write_target/aptos/write_target.go
@@ -46,7 +46,7 @@ func NewAptosWriteTarget(ctx context.Context, chain chain.Chain, lggr logger.Log
 	// chainName, err := chainselectors.NameFromChainId(chain.ID().Uint64())
 
 	// Construct the ID for the WT (e.g., "write_aptos-localnet@1.0.0")
-	id, err := write_target.NewWriteTargetID(aptosconfig.ChainFamilyName, config.NetworkName, config.ChainID, config.WriteTargetCap.Tag, version)
+	id, err := write_target.NewWriteTargetID(aptosconfig.ChainFamilyName, config.NetworkName, config.ChainID, *config.WriteTargetCap.Tag, version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create write target ID: %+w", err)
 	}

--- a/relayer/write_target/config.go
+++ b/relayer/write_target/config.go
@@ -6,15 +6,35 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
 )
 
+func ptr[T any](v T) *T { return &v }
+
 // Config defines the write target component configuration.
+// Pointer fields are used for TOML deserialization — nil means "not set by user".
+// After calling Resolve(), all fields are guaranteed non-nil.
 type Config struct {
-	Tag                 string // allows modifying WT ID e.g. write_aptos-testnet:{{.Tag}}@1.0.3
-	ConfirmerPollPeriod config.Duration
-	ConfirmerTimeout    config.Duration
+	Tag                 *string          `toml:"Tag"` // allows modifying WT ID e.g. write_aptos-testnet:{{.Tag}}@1.0.3
+	ConfirmerPollPeriod *config.Duration `toml:"ConfirmerPollPeriod"`
+	ConfirmerTimeout    *config.Duration `toml:"ConfirmerTimeout"`
 }
 
 // DefaultConfigSet is the default configuration for the write target component.
 var DefaultConfigSet = Config{
-	ConfirmerPollPeriod: *config.MustNewDuration(1 * time.Second),
-	ConfirmerTimeout:    *config.MustNewDuration(10 * time.Second),
+	Tag:                 ptr(""),
+	ConfirmerPollPeriod: config.MustNewDuration(1 * time.Second),
+	ConfirmerTimeout:    config.MustNewDuration(10 * time.Second),
+}
+
+// Resolve fills nil fields with defaults. After calling Resolve, all fields are guaranteed non-nil.
+func (c *Config) Resolve() {
+	if c.Tag == nil {
+		c.Tag = ptr(*DefaultConfigSet.Tag)
+	}
+	if c.ConfirmerPollPeriod == nil {
+		v := *DefaultConfigSet.ConfirmerPollPeriod
+		c.ConfirmerPollPeriod = &v
+	}
+	if c.ConfirmerTimeout == nil {
+		v := *DefaultConfigSet.ConfirmerTimeout
+		c.ConfirmerTimeout = &v
+	}
 }

--- a/relayer/write_target/config_test.go
+++ b/relayer/write_target/config_test.go
@@ -1,0 +1,19 @@
+package write_target
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolve_AllDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{}
+	cfg.Resolve()
+
+	assert.Equal(t, DefaultConfigSet.Tag, cfg.Tag)
+	assert.Equal(t, DefaultConfigSet.ConfirmerPollPeriod.Duration(), cfg.ConfirmerPollPeriod.Duration())
+	assert.Equal(t, DefaultConfigSet.ConfirmerTimeout.Duration(), cfg.ConfirmerTimeout.Duration())
+}
+

--- a/relayer/write_target/config_test.go
+++ b/relayer/write_target/config_test.go
@@ -17,3 +17,29 @@ func TestResolve_AllDefaults(t *testing.T) {
 	assert.Equal(t, DefaultConfigSet.ConfirmerTimeout.Duration(), cfg.ConfirmerTimeout.Duration())
 }
 
+func TestResolve_PartialOverride(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Tag: ptr("custom"),
+	}
+	cfg.Resolve()
+
+	assert.Equal(t, "custom", *cfg.Tag)
+	assert.Equal(t, DefaultConfigSet.ConfirmerPollPeriod.Duration(), cfg.ConfirmerPollPeriod.Duration())
+	assert.Equal(t, DefaultConfigSet.ConfirmerTimeout.Duration(), cfg.ConfirmerTimeout.Duration())
+}
+
+func TestResolve_ExplicitZero(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Tag: ptr(""),
+	}
+	cfg.Resolve()
+
+	assert.Equal(t, "", *cfg.Tag,
+		"explicit empty string must be preserved")
+	assert.Equal(t, DefaultConfigSet.ConfirmerPollPeriod.Duration(), cfg.ConfirmerPollPeriod.Duration())
+	assert.Equal(t, DefaultConfigSet.ConfirmerTimeout.Duration(), cfg.ConfirmerTimeout.Duration())
+}

--- a/relayer/write_target/write_target_test.go
+++ b/relayer/write_target/write_target_test.go
@@ -160,8 +160,8 @@ func newMockedWriteTarget(t *testing.T, lggr logger.Logger) mockedWriteTarget {
 	wt := newWriteTarget(WriteTargetOpts{
 		ID: "write_aptos-1@1.0.0",
 		Config: Config{
-			ConfirmerPollPeriod: *config.MustNewDuration(100 * time.Millisecond),
-			ConfirmerTimeout:    *config.MustNewDuration(300 * time.Millisecond),
+			ConfirmerPollPeriod: config.MustNewDuration(100 * time.Millisecond),
+			ConfirmerTimeout:    config.MustNewDuration(300 * time.Millisecond),
 		},
 		ChainInfo:        rtypes.ChainInfo{},
 		Logger:           lggr,


### PR DESCRIPTION
## Summary

- Migrate sub-package Config struct fields from value types to pointer types for nil-vs-zero TOML deserialization semantics
- Add Resolve method to each Config struct that fills nil fields from DefaultConfigSet using defensive copies
- Replace the old SetDefaults with applyDefaults that creates empty configs for absent sections then calls Resolve on all sections
- Add TOML struct tags and DefaultBalanceConfig to balance monitor

## Problem

When a user specifies an Aptos.TransactionManager section with only BroadcastChanSize = 50, the TOML decoder creates a non-nil config. The old SetDefaults only checked for nil section pointers, so it skipped the section entirely -- leaving all other fields at Go zero values. With value-typed fields, there was no way to distinguish a field the user did not set from one the user explicitly set to zero.

## Solution

Pointer-based fields are nil when absent from TOML, and non-nil when explicitly set to zero. Each packages Resolve checks if a field is nil -- correctly distinguishing absent fields from explicit zero values. This aligns with Chainlink cores config pattern.

## Test plan

config/config_test.go -- TOML pipeline integration:
- TestTOMLConfig -- enabled/disabled behavior
- TestTOMLConfig_CustomValues -- fully-specified TOML values survive decode, applyDefaults, validate across 4 sections
- TestNoGlobalMutation -- DefaultConfigSet not mutated by config resolution

Sub-package Resolve unit tests for txm, logpoller, write_target, monitor:
- TestResolve_AllDefaults -- empty config gets all defaults
- TestResolve_PartialOverride -- user value preserved, rest filled from defaults
- TestResolve_ExplicitZero -- explicit zero/false/empty not overwritten by defaults