### PR TITLE
feat: require explicit FromAddress in Workflow config (NONEVM-926)

### DIFF
--- a/relayer/config/config.go
+++ b/relayer/config/config.go
@@ -38,8 +38,8 @@ type ConfigSet struct { //nolint:revive
 
 type WorkflowConfig struct {
 	ForwarderAddress string
-	// FromAddress      string
-	PublicKey string
+	FromAddress      string
+	PublicKey        string
 }
 
 type Chain struct {
@@ -153,6 +153,13 @@ func (c *TOMLConfig) ValidateConfig() (err error) {
 		if err == nil && c.NetworkName != network.Name {
 			err = errors.Join(err, config.ErrInvalid{Name: "NetworkName", Value: c.NetworkName, Msg: fmt.Sprintf("does not match known network (%s) for chain ID", network.Name)})
 		}
+	}
+
+	if c.Workflow != nil && c.Workflow.FromAddress == "" {
+		err = errors.Join(err, config.ErrEmpty{
+			Name: "Workflow.FromAddress",
+			Msg:  "required - set it to your Aptos on-chain account address",
+		})
 	}
 
 	if len(c.Nodes) == 0 {

--- a/relayer/config/config_test.go
+++ b/relayer/config/config_test.go
@@ -146,3 +146,47 @@ MaxTxRetryAttempts = 8
 	assert.Equal(t, uint64(20), cfg.TransactionManager.TxExpirationSecs)
 	assert.Equal(t, uint64(8), cfg.TransactionManager.MaxTxRetryAttempts)
 }
+
+func TestWorkflowFromAddress_Required(t *testing.T) {
+	t.Parallel()
+
+	baseTOML := `
+ChainID = "2"
+[[Nodes]]
+Name = "node-1"
+URL = "http://node-1"
+`
+
+	t.Run("Workflow without FromAddress fails validation", func(t *testing.T) {
+		t.Parallel()
+
+		raw := baseTOML + `
+[Workflow]
+ForwarderAddress = "0x1234"
+`
+		_, err := NewDecodedTOMLConfig(raw)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Workflow.FromAddress")
+	})
+
+	t.Run("Workflow with FromAddress passes validation", func(t *testing.T) {
+		t.Parallel()
+
+		raw := baseTOML + `
+[Workflow]
+ForwarderAddress = "0x1234"
+FromAddress = "0xabc123"
+`
+		cfg, err := NewDecodedTOMLConfig(raw)
+		require.NoError(t, err)
+		assert.Equal(t, "0xabc123", cfg.Workflow.FromAddress)
+		assert.Equal(t, "0x1234", cfg.Workflow.ForwarderAddress)
+	})
+
+	t.Run("No Workflow section passes validation", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewDecodedTOMLConfig(baseTOML)
+		require.NoError(t, err)
+	})
+}

--- a/relayer/txm/txm.go
+++ b/relayer/txm/txm.go
@@ -120,8 +120,9 @@ func (a *AptosTxm) Enqueue(transactionID string, txMetadata *commontypes.TxMeta,
 	}
 
 	if fromAddress == "" {
-		// If the address is not specified, we assume the public key is for its corresponding address
-		// and not for an address with a rotated authentication key.
+		ctxLogger := GetContexedTxLogger(a.baseLogger, transactionID, txMetadata)
+		ctxLogger.Debugw("FromAddress not specified, deriving from public key",
+			"publicKey", publicKey)
 		acc := utils.Ed25519PublicKeyToAddress(ed25519PublicKey)
 		fromAddress = acc.String()
 	}

--- a/relayer/write_target/aptos/write_target.go
+++ b/relayer/write_target/aptos/write_target.go
@@ -16,7 +16,6 @@ import (
 	aptosconfig "github.com/smartcontractkit/chainlink-aptos/relayer/config"
 	"github.com/smartcontractkit/chainlink-aptos/relayer/txm"
 	"github.com/smartcontractkit/chainlink-aptos/relayer/types"
-	"github.com/smartcontractkit/chainlink-aptos/relayer/utils"
 	"github.com/smartcontractkit/chainlink-aptos/relayer/write_target"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -128,7 +127,8 @@ func NewAptosWriteTarget(ctx context.Context, chain chain.Chain, lggr logger.Log
 			"forwarder": {
 				Functions: map[string]*chainwriter.ChainWriterFunction{
 					"report": {
-						PublicKey: config.Workflow.PublicKey,
+						PublicKey:   config.Workflow.PublicKey,
+						FromAddress: config.Workflow.FromAddress,
 						Params: []crconfig.AptosFunctionParam{
 							{
 								Name:     "Receiver",
@@ -202,7 +202,6 @@ func NewAptosWriteTarget(ctx context.Context, chain chain.Chain, lggr logger.Log
 
 // getTransmitter sources the transmitter address from the CW config
 func getTransmitter(cwConfig chainwriter.ChainWriterConfig) (string, error) {
-	// Try to source the transmitter (e.g., c.cw.config.Functions["forwarder"].FromAddress)
 	moduleConfig, ok := cwConfig.Modules[write_target.ContractName]
 	if !ok {
 		return "", fmt.Errorf("no such contract: %s", write_target.ContractName)
@@ -213,17 +212,9 @@ func getTransmitter(cwConfig chainwriter.ChainWriterConfig) (string, error) {
 		return "", fmt.Errorf("no such method: %s", write_target.ContractMethodName_report)
 	}
 
-	// Notice: reusing logic from the TXM which sources the transmitter this way
-	transmitter := functionConfig.FromAddress
-	if transmitter == "" {
-		// If the address is not specified, we assume the public key is for its corresponding address
-		// and not for an address with a rotated authentication key.
-		ed25519PublicKey, err := utils.HexPublicKeyToEd25519PublicKey(functionConfig.PublicKey)
-		if err != nil {
-			return "", fmt.Errorf("failed to convert public key: %+w", err)
-		}
-		acc := utils.Ed25519PublicKeyToAddress(ed25519PublicKey)
-		transmitter = acc.String()
+	if functionConfig.FromAddress == "" {
+		return "", fmt.Errorf("FromAddress is not configured for %s.%s",
+			write_target.ContractName, write_target.ContractMethodName_report)
 	}
-	return transmitter, nil
+	return functionConfig.FromAddress, nil
 }


### PR DESCRIPTION
## Summary

- **Make `FromAddress` required** in TOML config when `[Workflow]` is set, so operators explicitly provide their on-chain account address instead of relying on implicit derivation from public key
- **Remove derivation fallback** in `getTransmitter()` (write_target) — `FromAddress` is guaranteed by config validation
- **Keep TXM derivation fallback** for CCIP compatibility (callers via `NewContractWriter` JSON path may not provide `FromAddress`)
- **Downgrade TXM derivation log** from warn-level comment to `Debugw` — it's normal behavior for CCIP callers

## Motivation

Aptos has native account abstraction: account addresses are permanent (`SHA3-256(original_pubkey || 0x00)`), but signing keys can be rotated. The codebase was implicitly deriving addresses from public keys, which:
- Fails for accounts with rotated authentication keys
- Caused a balance monitor bug
- Scattered address derivation across multiple layers

## Changes

| File | Change |
|------|--------|
| `relayer/config/config.go` | Uncomment `FromAddress` field, add validation requiring it when `[Workflow]` is set |
| `relayer/config/config_test.go` | Add tests: missing `FromAddress` fails, present passes, no `[Workflow]` passes |
| `relayer/write_target/aptos/write_target.go` | Wire `FromAddress` into chainwriter config, simplify `getTransmitter()`, remove unused `utils` import |
| `relayer/txm/txm.go` | Add `Debugw` log to derivation fallback (kept for CCIP compat) |

## What's NOT changed (and why)

- **`ChainWriterFunction.FromAddress`** — must stay optional for CCIP JSON deserialization compat (`relay.go`)
- **TXM `Enqueue()` fallback** — CCIP callers may not provide `fromAddress`
- **Balance monitor** — `KeyToAccountMapper` works correctly, monitors all keystore accounts
- **No startup sanity check** — warning on rotated keys every startup is noise

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./relayer/config/...` — validation tests pass (including new FromAddress tests)
- [x] `go test ./relayer/write_target/...` — write target tests pass
- [x] `go test ./relayer/txm/...` — TXM tests pass
- [x] `go test ./relayer/chainwriter/...` — chainwriter tests pass
- [x] TOML without `FromAddress` under `[Workflow]` fails validation with clear error
- [x] TOML without `[Workflow]` section still works


🤖 Generated with [Claude Code](https://claude.com/claude-code)