### PR TITLE
NONEVM-926: Make FromAddress explicit in WorkflowConfig

### DIFF
--- a/relayer/chain/chain.go
+++ b/relayer/chain/chain.go
@@ -112,6 +112,13 @@ func newChain(cfg *config.TOMLConfig, loopKs loop.Keystore, lggr logger.Logger, 
 
 	if cfg.Chain.Workflow != nil {
 		cfg.Chain.Workflow.PublicKey = accounts[0]
+		if cfg.Chain.Workflow.FromAddress == "" {
+			addr, err := utils.HexPublicKeyToAddressString(accounts[0])
+			if err != nil {
+				return nil, fmt.Errorf("failed to derive account address from public key: %w", err)
+			}
+			cfg.Chain.Workflow.FromAddress = addr
+		}
 	}
 
 	ch := &chain{

--- a/relayer/config/config.go
+++ b/relayer/config/config.go
@@ -38,8 +38,8 @@ type ConfigSet struct { //nolint:revive
 
 type WorkflowConfig struct {
 	ForwarderAddress string
-	// FromAddress      string
-	PublicKey string
+	FromAddress      string // explicit account address (optional, derived from PublicKey if empty)
+	PublicKey        string
 }
 
 type Chain struct {

--- a/relayer/write_target/aptos/write_target.go
+++ b/relayer/write_target/aptos/write_target.go
@@ -128,7 +128,8 @@ func NewAptosWriteTarget(ctx context.Context, chain chain.Chain, lggr logger.Log
 			"forwarder": {
 				Functions: map[string]*chainwriter.ChainWriterFunction{
 					"report": {
-						PublicKey: config.Workflow.PublicKey,
+						PublicKey:   config.Workflow.PublicKey,
+						FromAddress: config.Workflow.FromAddress,
 						Params: []crconfig.AptosFunctionParam{
 							{
 								Name:     "Receiver",


### PR DESCRIPTION
## Summary

- Uncomment `FromAddress` in `WorkflowConfig` and populate it at chain initialization, so the account address flows through existing plumbing (`chain.go` → `write_target` → `chainwriter` → TXM) instead of being independently re-derived from the public key at each layer
- Consolidates address derivation to one place at startup, preparing for key rotation support where the account address differs from the signing key
- Adds a warning log in TXM when `FromAddress` is not provided, making implicit derivation visible for debugging

## Changes

| File | Change |
|------|--------|
| `relayer/config/config.go` | Uncomment `FromAddress` field in `WorkflowConfig` |
| `relayer/chain/chain.go` | Derive and set `FromAddress` at startup if not explicitly configured |
| `relayer/write_target/aptos/write_target.go` | Pass `FromAddress` through to ChainWriter config |
| `relayer/txm/txm.go` | Add warning log when TXM falls back to deriving address from public key |

## Backward Compatibility

Fully backward compatible — TOML configs without `FromAddress` will have an empty string, which triggers automatic derivation from `PublicKey` in `chain.go`.

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./relayer/config/... ./relayer/chain/... ./relayer/write_target/... ./relayer/txm/...` all pass
- [ ] Verify `FromAddress` propagates end-to-end in a deployed environment
- [ ] Verify existing TOML configs without `FromAddress` still work (empty string triggers derivation)

> Continuation of #387 (could not reopen after force-push)