### PR TITLE
set NewNodeClientWithHttpClient params with cache

### DIFF
--- a/relayer/chain/chain.go
+++ b/relayer/chain/chain.go
@@ -2,10 +2,13 @@ package chain
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"math/big"
 	"math/rand"
+	"net/http"
+	"net/http/cookiejar"
 	"strconv"
 	"sync"
 	"time"
@@ -86,6 +89,11 @@ type chain struct {
 	// every GetClient() call, which leads to port exhaustion under load.
 	clientCacheMu sync.RWMutex
 	clientCache   map[string]aptos.AptosRpcClient
+
+	// sharedTransport is used by all NodeClients so connections are pooled (one Transport
+	// per chain). TLS 1.2 and MaxIdleConnsPerHost avoid port exhaustion with SDK v1.12+.
+	sharedTransport     *http.Transport
+	sharedTransportOnce sync.Once
 
 	// Sub-services
 	txm            *txm.AptosTxm
@@ -184,6 +192,38 @@ func (c *chain) KeyStore() loop.Keystore {
 	return c.keyStore
 }
 
+// sharedHTTPTransport returns a Transport with TLS 1.2 and connection pool settings
+// so that all NodeClients for this chain share the same connection pool (avoids
+// port exhaustion with aptos-go-sdk v1.12+).
+func (c *chain) sharedHTTPTransport() *http.Transport {
+	c.sharedTransportOnce.Do(func() {
+		c.sharedTransport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			},
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: 10,
+			IdleConnTimeout:     90 * time.Second,
+		}
+	})
+	return c.sharedTransport
+}
+
+// newHTTPClientForNode returns an http.Client suitable for use with
+// aptos.NewNodeClientWithHttpClient. Uses the chain's shared Transport and a
+// per-node cookie jar (for stickiness). Caller does not need to close the client.
+func (c *chain) newHTTPClientForNode() (*http.Client, error) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Client{
+		Transport: c.sharedHTTPTransport(),
+		Jar:       jar,
+		Timeout:   60 * time.Second,
+	}, nil
+}
+
 // GetClient returns a client, randomly selecting one from available and valid nodes.
 // Clients are cached per node URL to avoid creating a new NodeClient (and http.Transport)
 // on every call, which with aptos-go-sdk v1.12+ causes port exhaustion under load.
@@ -221,14 +261,20 @@ func (c *chain) GetClient() (aptos.AptosRpcClient, error) {
 		}
 	}
 
-	// No valid cached client; create and cache one
+	// No valid cached client; create and cache one using our own http.Client
+	// (shared Transport + TLS 1.2 + connection pool) to avoid port exhaustion.
 	var node *config.Node
 	var client *aptos.NodeClient
 	var err error
 	for _, i := range index {
 		node = nodes[i]
 		urlStr := node.URL.String()
-		client, err = aptos.NewNodeClient(urlStr, 0)
+		httpClient, httpErr := c.newHTTPClientForNode()
+		if httpErr != nil {
+			c.lggr.Warnw("failed to create http client for node", "name", node.Name, "err", httpErr)
+			continue
+		}
+		client, err = aptos.NewNodeClientWithHttpClient(urlStr, 0, httpClient)
 		if err != nil {
 			c.lggr.Warnw("failed to create node", "name", node.Name, "aptos-url", node.URL, "err", err)
 			continue
@@ -277,6 +323,10 @@ func (c *chain) Close() error {
 		c.lggr.Debug("Stopping logPoller")
 		c.lggr.Debug("Stopping balance monitor")
 
+		c.sharedTransportOnce.Do(func() {}) // ensure transport was created if we're about to close it
+		if c.sharedTransport != nil {
+			c.sharedTransport.CloseIdleConnections()
+		}
 		return services.CloseAll(c.txm, c.logPoller, c.balanceMonitor)
 	})
 }

--- a/relayer/chain/chain.go
+++ b/relayer/chain/chain.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"math/rand"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/aptos-labs/aptos-go-sdk"
@@ -80,6 +81,12 @@ type chain struct {
 	ds       sqlutil.DataSource
 	keyStore loop.Keystore
 
+	// clientCache caches a rate-limited Aptos client per node URL to avoid creating
+	// a new NodeClient (and thus a new http.Transport with aptos-go-sdk v1.12+) on
+	// every GetClient() call, which leads to port exhaustion under load.
+	clientCacheMu sync.RWMutex
+	clientCache   map[string]aptos.AptosRpcClient
+
 	// Sub-services
 	txm            *txm.AptosTxm
 	logPoller      *logpoller.AptosLogPoller
@@ -115,11 +122,12 @@ func newChain(cfg *config.TOMLConfig, loopKs loop.Keystore, lggr logger.Logger, 
 	}
 
 	ch := &chain{
-		id:       cfg.ChainID,
-		cfg:      cfg,
-		lggr:     logger.Named(lggr, "Chain"),
-		ds:       ds,
-		keyStore: loopKs,
+		id:         cfg.ChainID,
+		cfg:        cfg,
+		lggr:       logger.Named(lggr, "Chain"),
+		ds:         ds,
+		keyStore:   loopKs,
+		clientCache: make(map[string]aptos.AptosRpcClient),
 	}
 
 	ch.txm, err = txm.New(lggr, loopKs, *cfg.TransactionManager, ch.GetClient, cfg.ChainID)
@@ -176,57 +184,78 @@ func (c *chain) KeyStore() loop.Keystore {
 	return c.keyStore
 }
 
-// GetClient returns a client, randomly selecting one from available and valid nodes
+// GetClient returns a client, randomly selecting one from available and valid nodes.
+// Clients are cached per node URL to avoid creating a new NodeClient (and http.Transport)
+// on every call, which with aptos-go-sdk v1.12+ causes port exhaustion under load.
 func (c *chain) GetClient() (aptos.AptosRpcClient, error) {
-	var node *config.Node
-	var err error
-	var client *aptos.NodeClient
 	nodes := c.cfg.Nodes
 	if len(nodes) == 0 {
 		return nil, errors.New("no nodes available")
 	}
+
+	// Try cached client first (random order)
 	// #nosec
-	index := rand.Perm(len(nodes)) // list of node indexes to try
+	index := rand.Perm(len(nodes))
+	for _, i := range index {
+		node := nodes[i]
+		urlStr := node.URL.String()
+		c.clientCacheMu.RLock()
+		cached := c.clientCache[urlStr]
+		c.clientCacheMu.RUnlock()
+		if cached != nil {
+			// Verify chain ID still matches (node could have been reconfigured)
+			chainId, err := cached.GetChainId()
+			if err != nil {
+				c.clientCacheMu.Lock()
+				delete(c.clientCache, urlStr)
+				c.clientCacheMu.Unlock()
+				continue
+			}
+			chainInfo := c.chainInfo()
+			if strconv.FormatUint(uint64(chainId), 10) == chainInfo.ChainID {
+				return cached, nil
+			}
+			c.clientCacheMu.Lock()
+			delete(c.clientCache, urlStr)
+			c.clientCacheMu.Unlock()
+		}
+	}
+
+	// No valid cached client; create and cache one
+	var node *config.Node
+	var client *aptos.NodeClient
+	var err error
 	for _, i := range index {
 		node = nodes[i]
-		// create client and check. provide a chainId of 0 so that it's fetched when
-		// GetChainId is invoked.
-		client, err = aptos.NewNodeClient(node.URL.String(), 0)
-		// if error, try another node
+		urlStr := node.URL.String()
+		client, err = aptos.NewNodeClient(urlStr, 0)
 		if err != nil {
 			c.lggr.Warnw("failed to create node", "name", node.Name, "aptos-url", node.URL, "err", err)
 			continue
 		}
-
 		chainId, err := client.GetChainId()
 		if err != nil {
 			c.lggr.Errorw("failed to fetch chain id", "name", node.Name, "err", err)
 			continue
 		}
-
 		chainInfo := c.chainInfo()
 		if strconv.FormatUint(uint64(chainId), 10) != chainInfo.ChainID {
 			c.lggr.Errorw("unexpected chain id", "name", node.Name, "localChainId", chainInfo.ChainID, "remoteChainId", chainId)
 			continue
 		}
-		// if all checks passed, mark found and break loop
-		break
+		rateLimitedClient := ratelimit.NewRateLimitedClient(client,
+			chainInfo,
+			urlStr,
+			500,            // max requests in-flight
+			30*time.Second, // timeout
+		)
+		c.clientCacheMu.Lock()
+		c.clientCache[urlStr] = rateLimitedClient
+		c.clientCacheMu.Unlock()
+		c.lggr.Debugw("Created and cached client", "name", node.Name, "url", node.URL)
+		return rateLimitedClient, nil
 	}
-	// if no valid node found, exit with error
-	if client == nil {
-		return nil, errors.New("no node valid nodes available")
-	}
-
-	c.lggr.Debugw("Created client", "name", node.Name, "url", node.URL)
-
-	rateLimitedClient := ratelimit.NewRateLimitedClient(client,
-		c.chainInfo(),
-		node.URL.String(),
-		500,            // max requests in-flight
-		30*time.Second, // timeout
-	)
-
-	return rateLimitedClient, nil
+	return nil, errors.New("no valid nodes available")
 }
 
 func (c *chain) Start(ctx context.Context) error {

--- a/relayer/chain/chain.go
+++ b/relayer/chain/chain.go
@@ -2,13 +2,11 @@ package chain
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"math/big"
 	"math/rand"
 	"net/http"
-	"net/http/cookiejar"
 	"strconv"
 	"sync"
 	"time"
@@ -85,15 +83,10 @@ type chain struct {
 	keyStore loop.Keystore
 
 	// clientCache caches a rate-limited Aptos client per node URL to avoid creating
-	// a new NodeClient (and thus a new http.Transport with aptos-go-sdk v1.12+) on
-	// every GetClient() call, which leads to port exhaustion under load.
+	// a new NodeClient on every GetClient() call (port exhaustion with aptos-go-sdk v1.12+).
+	// The write lock is held throughout creation so a burst of requests doesn't race to create.
 	clientCacheMu sync.RWMutex
 	clientCache   map[string]aptos.AptosRpcClient
-
-	// sharedTransport is used by all NodeClients so connections are pooled (one Transport
-	// per chain). TLS 1.2 and MaxIdleConnsPerHost avoid port exhaustion with SDK v1.12+.
-	sharedTransport     *http.Transport
-	sharedTransportOnce sync.Once
 
 	// Sub-services
 	txm            *txm.AptosTxm
@@ -192,50 +185,21 @@ func (c *chain) KeyStore() loop.Keystore {
 	return c.keyStore
 }
 
-// sharedHTTPTransport returns a Transport with TLS 1.2 and connection pool settings
-// so that all NodeClients for this chain share the same connection pool (avoids
-// port exhaustion with aptos-go-sdk v1.12+).
-func (c *chain) sharedHTTPTransport() *http.Transport {
-	c.sharedTransportOnce.Do(func() {
-		c.sharedTransport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				MinVersion: tls.VersionTLS12,
-			},
-			MaxIdleConns:        100,
-			MaxIdleConnsPerHost: 10,
-			IdleConnTimeout:     90 * time.Second,
-		}
-	})
-	return c.sharedTransport
-}
-
-// newHTTPClientForNode returns an http.Client suitable for use with
-// aptos.NewNodeClientWithHttpClient. Uses the chain's shared Transport and a
-// per-node cookie jar (for stickiness). Caller does not need to close the client.
-func (c *chain) newHTTPClientForNode() (*http.Client, error) {
-	jar, err := cookiejar.New(nil)
-	if err != nil {
-		return nil, err
-	}
-	return &http.Client{
-		Transport: c.sharedHTTPTransport(),
-		Jar:       jar,
-		Timeout:   60 * time.Second,
-	}, nil
-}
-
 // GetClient returns a client, randomly selecting one from available and valid nodes.
-// Clients are cached per node URL to avoid creating a new NodeClient (and http.Transport)
-// on every call, which with aptos-go-sdk v1.12+ causes port exhaustion under load.
+// Clients are cached per node URL. Uses http.DefaultClient so all NodeClients share
+// the process-wide default transport (avoids port exhaustion with aptos-go-sdk v1.12+).
+// The write lock is held throughout creation so a burst of requests cannot race to
+// create multiple clients for the same URL (last writer wins / leaked clients).
 func (c *chain) GetClient() (aptos.AptosRpcClient, error) {
 	nodes := c.cfg.Nodes
 	if len(nodes) == 0 {
 		return nil, errors.New("no nodes available")
 	}
 
-	// Try cached client first (random order)
 	// #nosec
 	index := rand.Perm(len(nodes))
+
+	// Fast path: try cached client (read lock only).
 	for _, i := range index {
 		node := nodes[i]
 		urlStr := node.URL.String()
@@ -243,7 +207,6 @@ func (c *chain) GetClient() (aptos.AptosRpcClient, error) {
 		cached := c.clientCache[urlStr]
 		c.clientCacheMu.RUnlock()
 		if cached != nil {
-			// Verify chain ID still matches (node could have been reconfigured)
 			chainId, err := cached.GetChainId()
 			if err != nil {
 				c.clientCacheMu.Lock()
@@ -261,20 +224,17 @@ func (c *chain) GetClient() (aptos.AptosRpcClient, error) {
 		}
 	}
 
-	// No valid cached client; create and cache one using our own http.Client
-	// (shared Transport + TLS 1.2 + connection pool) to avoid port exhaustion.
-	var node *config.Node
-	var client *aptos.NodeClient
-	var err error
+	// Slow path: create and cache. Hold lock for entire creation so only one goroutine
+	// creates per URL (avoids race where burst of requests all create, last writer wins).
+	c.clientCacheMu.Lock()
+	defer c.clientCacheMu.Unlock()
 	for _, i := range index {
-		node = nodes[i]
+		node := nodes[i]
 		urlStr := node.URL.String()
-		httpClient, httpErr := c.newHTTPClientForNode()
-		if httpErr != nil {
-			c.lggr.Warnw("failed to create http client for node", "name", node.Name, "err", httpErr)
-			continue
+		if c.clientCache[urlStr] != nil {
+			return c.clientCache[urlStr], nil
 		}
-		client, err = aptos.NewNodeClientWithHttpClient(urlStr, 0, httpClient)
+		client, err := aptos.NewNodeClientWithHttpClient(urlStr, 0, http.DefaultClient)
 		if err != nil {
 			c.lggr.Warnw("failed to create node", "name", node.Name, "aptos-url", node.URL, "err", err)
 			continue
@@ -295,9 +255,7 @@ func (c *chain) GetClient() (aptos.AptosRpcClient, error) {
 			500,            // max requests in-flight
 			30*time.Second, // timeout
 		)
-		c.clientCacheMu.Lock()
 		c.clientCache[urlStr] = rateLimitedClient
-		c.clientCacheMu.Unlock()
 		c.lggr.Debugw("Created and cached client", "name", node.Name, "url", node.URL)
 		return rateLimitedClient, nil
 	}
@@ -323,10 +281,6 @@ func (c *chain) Close() error {
 		c.lggr.Debug("Stopping logPoller")
 		c.lggr.Debug("Stopping balance monitor")
 
-		c.sharedTransportOnce.Do(func() {}) // ensure transport was created if we're about to close it
-		if c.sharedTransport != nil {
-			c.sharedTransport.CloseIdleConnections()
-		}
 		return services.CloseAll(c.txm, c.logPoller, c.balanceMonitor)
 	})
 }


### PR DESCRIPTION
Per AI:

Cause in chainlink-aptos (live)
In relayer/chain/chain.go, GetClient() creates a new aptos.NodeClient on every call and does not cache it:

Line 194: client, err = aptos.NewNodeClient(node.URL.String(), 0) is run each time.
Lines 222–226: A new rate-limited wrapper is created and returned; nothing is stored on the chain.
So every caller does this:

aptos_service.go – each View, AccountAPTBalance, TransactionByHash, AccountTransactions, etc. calls s.chain.GetClient().
txm – broadcast/confirm loops call getClient() when they need to talk to the chain.
logpoller – uses getClient() for polling.
balance monitor – uses NewClient: ch.GetClient.
relay.go – calls r.chain.GetClient().
write_target – calls chain.GetClient().
LatestHead – calls c.GetClient().
With aptos-go-sdk v1.12, each NewNodeClient gets its own http.Transport. So in production, every RPC path that calls GetClient() was creating a new client and a new transport. Under load that meant a new connection pool (and new connections) per call → port exhaustion.

So the problem is in chainlink-aptos’ usage: no client reuse, combined with v1.12’s per-client transport.

Change made in chainlink-aptos
File: relayer/chain/chain.go

Client cache

Added a cache keyed by node URL: clientCache map[string]aptos.AptosRpcClient with clientCacheMu sync.RWMutex.
GetClient() behavior

Try nodes in random order (unchanged).
Cache read: For each node URL, check the cache; if a client exists, call GetChainId() to validate it’s still good, then return that cached client.
Cache miss: Create aptos.NewNodeClient(...), validate chain ID, wrap in ratelimit.NewRateLimitedClient, store in the cache, and return it.
So in live environments you now have at most one client (and one Transport) per node URL per chain, reused by aptos_service, txm, logpoller, balance monitor, relay, write_target, and LatestHead. That removes the “new client every call” behavior that was driving port exhaustion with v1.12.

Summary
Layer	Role
aptos-go-sdk v1.12	Each NewNodeClient() uses its own http.Transport (TLS 1.2 change) → many transports if many clients are created.
chainlink-aptos (live)	Before: Every GetClient() created a new Node