### PR TITLE
Chore: bump chainlink-common for Aptos helper follow-up

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/shopspring/decimal v1.4.0
 	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
-	github.com/smartcontractkit/chainlink-common v0.11.1-0.20260324124718-1e12ff95068b
+	github.com/smartcontractkit/chainlink-common v0.11.1-0.20260324153442-f5d1fe0c1cad
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260320153346-314ec8dbe5a4
 	github.com/stretchr/testify v1.11.1
 	github.com/valyala/fastjson v1.6.10

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,8 @@ github.com/smartcontractkit/chain-selectors v1.0.89 h1:L9oWZGqQXWyTPnC6ODXgu3b0D
 github.com/smartcontractkit/chain-selectors v1.0.89/go.mod h1:qy7whtgG5g+7z0jt0nRyii9bLND9m15NZTzuQPkMZ5w=
 github.com/smartcontractkit/chainlink-common v0.11.1-0.20260324124718-1e12ff95068b h1:81nacxJivGFaS22Hp2M1nT1bfy4/u/MEZd3eqDQIyfc=
 github.com/smartcontractkit/chainlink-common v0.11.1-0.20260324124718-1e12ff95068b/go.mod h1:9W8E7tfchAsrSNHdMM1mzLmle+bL1P8Ou0I4LG1qNxw=
+github.com/smartcontractkit/chainlink-common v0.11.1-0.20260324153442-f5d1fe0c1cad h1:kMqAFNOyI+dzqpwrjhVSPTGmY/u33gIhZ2vFg/+KEYg=
+github.com/smartcontractkit/chainlink-common v0.11.1-0.20260324153442-f5d1fe0c1cad/go.mod h1:9W8E7tfchAsrSNHdMM1mzLmle+bL1P8Ou0I4LG1qNxw=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260320153346-314ec8dbe5a4 h1:fkS5FJpSozwxL2FA6OJDi7az2DrtMNiK1X5DWuHDyfA=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/smartcontractkit/chain-selectors v1.0.97
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20260318173523-755cafb24200
-	github.com/smartcontractkit/chainlink-common v0.11.1-0.20260324124718-1e12ff95068b
+	github.com/smartcontractkit/chainlink-common v0.11.1-0.20260324153442-f5d1fe0c1cad
 	github.com/smartcontractkit/chainlink-deployments-framework v0.86.3
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.5
 	github.com/smartcontractkit/chainlink/core/scripts v0.0.0-20260217182614-af80ea0f7d31

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1404,6 +1404,8 @@ github.com/smartcontractkit/chainlink-ccv v0.0.0-20260324000441-d4cfddc9f7d2 h1:
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260324000441-d4cfddc9f7d2/go.mod h1:wDHq2E0KwUWG0lQ9f5frW1a7CKVW17MJLPuvKmtSRDg=
 github.com/smartcontractkit/chainlink-common v0.11.1-0.20260324124718-1e12ff95068b h1:81nacxJivGFaS22Hp2M1nT1bfy4/u/MEZd3eqDQIyfc=
 github.com/smartcontractkit/chainlink-common v0.11.1-0.20260324124718-1e12ff95068b/go.mod h1:9W8E7tfchAsrSNHdMM1mzLmle+bL1P8Ou0I4LG1qNxw=
+github.com/smartcontractkit/chainlink-common v0.11.1-0.20260324153442-f5d1fe0c1cad h1:kMqAFNOyI+dzqpwrjhVSPTGmY/u33gIhZ2vFg/+KEYg=
+github.com/smartcontractkit/chainlink-common v0.11.1-0.20260324153442-f5d1fe0c1cad/go.mod h1:9W8E7tfchAsrSNHdMM1mzLmle+bL1P8Ou0I4LG1qNxw=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2 h1:AWisx4JT3QV8tcgh6J5NCrex+wAgTYpWyHsyNPSXzsQ=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2/go.mod h1:rSkIHdomyak3YnUtXLenl6poIq8q0V3UZPiiyYqPdGA=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4 h1:NOUsjsMzNecbjiPWUQGlRSRAutEvCFrqqyETDJeh5q4=


### PR DESCRIPTION
## Summary
- bump `chainlink-common` to the helper follow-up branch SHA in both modules

## Why
- keeps the Aptos stack aligned while the shared conversion helper PR is under review
- this is a small dependency-only follow-up for the capabilities cleanup

## Note
- this draft is expected to depend on the matching `chainlink-common` helper PR