### PR TITLE
feat(txm): consolidate metrics and add reason tags

### DIFF
--- a/relayer/txm/metrics.go
+++ b/relayer/txm/metrics.go
@@ -13,50 +13,53 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/metrics"
 )
 
+// Error reason constants for the aptos_txm_tx_error metric.
+const (
+	ErrorReasonSequenceNumber = "sequence_number"
+	ErrorReasonStoreCreate    = "store_create"
+	ErrorReasonSimulation     = "simulation"
+	ErrorReasonSigning        = "signing"
+	ErrorReasonNoHash         = "no_hash"
+	ErrorReasonStoreAdd       = "store_add"
+	ErrorReasonUnknownSubmit  = "unknown_submit"
+	ErrorReasonMaxRetries     = "max_retries"
+	ErrorReasonRevert         = "revert"
+	ErrorReasonTypeAssertion  = "type_assertion"
+	ErrorReasonUnexpectedType = "unexpected_type"
+	ErrorReasonExpiredConfirm = "expired_confirm"
+	ErrorReasonDrop           = "drop"
+)
+
 var (
-	// broadcasted transactions
 	promAptosTxmBroadcastedTxs = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "aptos_txm_tx_broadcasted",
 		Help: "Number of transactions successfully submitted to the mempool",
 	}, []string{"chainID"})
 
-	// successful transactions
 	promAptosTxmSuccessTxs = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "aptos_txm_tx_success",
 		Help: "Number of transactions confirmed successfully on-chain",
 	}, []string{"chainID"})
+
 	promAptosTxmFinalizedTxs = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "aptos_txm_tx_finalized",
 		Help: "Number of transactions that reached finalized status",
 	}, []string{"chainID"})
 
-	// inflight transactions
 	promAptosTxmPendingTxs = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "aptos_txm_tx_pending",
 		Help: "Number of unconfirmed transactions currently in-flight",
 	}, []string{"chainID"})
 
-	// error cases
 	promAptosTxmErrorTxs = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "aptos_txm_tx_error",
-		Help: "Total number of transaction errors across all failure modes",
-	}, []string{"chainID"})
-	promAptosTxmRevertTxs = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "aptos_txm_tx_error_revert",
-		Help: "Number of transactions confirmed but unsuccessful on-chain (e.g. out of gas)",
-	}, []string{"chainID"})
-	promAptosTxmRejectTxs = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "aptos_txm_tx_error_reject",
-		Help: "Number of transactions rejected by the RPC after exhausting submit retries",
-	}, []string{"chainID"})
-	promAptosTxmDropTxs = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "aptos_txm_tx_error_drop",
-		Help: "Number of transactions that expired without being committed on-chain",
-	}, []string{"chainID"})
+		Help: "Transaction errors by reason",
+	}, []string{"chainID", "reason"})
+
 	promAptosTxmRetryTxs = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "aptos_txm_tx_retry",
-		Help: "Number of transaction retries triggered (out-of-gas or expired)",
-	}, []string{"chainID"})
+		Help: "Transaction retries by reason",
+	}, []string{"chainID", "reason"})
 )
 
 type aptosTxmMetrics struct {
@@ -68,9 +71,6 @@ type aptosTxmMetrics struct {
 	finalizedTxs   metric.Int64Counter
 	pendingTxs     metric.Int64Gauge
 	errorTxs       metric.Int64Counter
-	revertTxs      metric.Int64Counter
-	rejectTxs      metric.Int64Counter
-	dropTxs        metric.Int64Counter
 	retryTxs       metric.Int64Counter
 }
 
@@ -102,21 +102,6 @@ func newAptosTxmMetrics(chainID string) (*aptosTxmMetrics, error) {
 		return nil, fmt.Errorf("failed to register error txs counter: %w", err)
 	}
 
-	revertTxs, err := m.Int64Counter("aptos_txm_tx_error_revert")
-	if err != nil {
-		return nil, fmt.Errorf("failed to register revert txs counter: %w", err)
-	}
-
-	rejectTxs, err := m.Int64Counter("aptos_txm_tx_error_reject")
-	if err != nil {
-		return nil, fmt.Errorf("failed to register reject txs counter: %w", err)
-	}
-
-	dropTxs, err := m.Int64Counter("aptos_txm_tx_error_drop")
-	if err != nil {
-		return nil, fmt.Errorf("failed to register drop txs counter: %w", err)
-	}
-
 	retryTxs, err := m.Int64Counter("aptos_txm_tx_retry")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register retry txs counter: %w", err)
@@ -131,9 +116,6 @@ func newAptosTxmMetrics(chainID string) (*aptosTxmMetrics, error) {
 		finalizedTxs:   finalizedTxs,
 		pendingTxs:     pendingTxs,
 		errorTxs:       errorTxs,
-		revertTxs:      revertTxs,
-		rejectTxs:      rejectTxs,
-		dropTxs:        dropTxs,
 		retryTxs:       retryTxs,
 	}, nil
 }
@@ -162,27 +144,14 @@ func (m *aptosTxmMetrics) SetPendingTxs(ctx context.Context, count int) {
 	m.pendingTxs.Record(ctx, int64(count), metric.WithAttributes(m.getOtelAttributes()...))
 }
 
-func (m *aptosTxmMetrics) IncrementErrorTxs(ctx context.Context) {
-	promAptosTxmErrorTxs.WithLabelValues(m.chainID).Add(1)
-	m.errorTxs.Add(ctx, 1, metric.WithAttributes(m.getOtelAttributes()...))
+func (m *aptosTxmMetrics) IncrementErrorTxs(ctx context.Context, reason string) {
+	promAptosTxmErrorTxs.WithLabelValues(m.chainID, reason).Add(1)
+	otelAttrs := append(m.getOtelAttributes(), attribute.String("reason", reason))
+	m.errorTxs.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
 }
 
-func (m *aptosTxmMetrics) IncrementRevertTxs(ctx context.Context) {
-	promAptosTxmRevertTxs.WithLabelValues(m.chainID).Add(1)
-	m.revertTxs.Add(ctx, 1, metric.WithAttributes(m.getOtelAttributes()...))
-}
-
-func (m *aptosTxmMetrics) IncrementRejectTxs(ctx context.Context) {
-	promAptosTxmRejectTxs.WithLabelValues(m.chainID).Add(1)
-	m.rejectTxs.Add(ctx, 1, metric.WithAttributes(m.getOtelAttributes()...))
-}
-
-func (m *aptosTxmMetrics) IncrementDropTxs(ctx context.Context) {
-	promAptosTxmDropTxs.WithLabelValues(m.chainID).Add(1)
-	m.dropTxs.Add(ctx, 1, metric.WithAttributes(m.getOtelAttributes()...))
-}
-
-func (m *aptosTxmMetrics) IncrementRetryTxs(ctx context.Context) {
-	promAptosTxmRetryTxs.WithLabelValues(m.chainID).Add(1)
-	m.retryTxs.Add(ctx, 1, metric.WithAttributes(m.getOtelAttributes()...))
+func (m *aptosTxmMetrics) IncrementRetryTxs(ctx context.Context, reason string) {
+	promAptosTxmRetryTxs.WithLabelValues(m.chainID, reason).Add(1)
+	otelAttrs := append(m.getOtelAttributes(), attribute.String("reason", reason))
+	m.retryTxs.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
 }

--- a/relayer/txm/txm.go
+++ b/relayer/txm/txm.go
@@ -587,14 +587,14 @@ func (a *AptosTxm) signAndBroadcast(ctx context.Context, tx *AptosTx) {
 		if err != nil {
 			ctxLogger.Errorw("failed to get sequence number", "fromAddress", tx.FromAddress.String(), "error", err)
 			a.updateTransactionStatus(tx, commontypes.Failed)
-			a.metrics.IncrementErrorTxs(ctx)
+			a.metrics.IncrementErrorTxs(ctx, ErrorReasonSequenceNumber)
 			return
 		}
 		newTxStore, err := a.accountStore.CreateTxStore(tx.FromAddress.String(), sequenceNumber)
 		if err != nil {
 			ctxLogger.Errorw("failed to create tx store", "fromAddress", tx.FromAddress.String(), "error", err)
 			a.updateTransactionStatus(tx, commontypes.Failed)
-			a.metrics.IncrementErrorTxs(ctx)
+			a.metrics.IncrementErrorTxs(ctx, ErrorReasonStoreCreate)
 			return
 		}
 		txStore = newTxStore
@@ -617,7 +617,7 @@ func (a *AptosTxm) signAndBroadcast(ctx context.Context, tx *AptosTx) {
 			a.updateTransactionStatus(tx, commontypes.Failed)
 			if !errors.As(err, new(*expectedSimulationFailureError)) {
 				ctxLogger.Errorw("failed to create raw tx", "error", err)
-				a.metrics.IncrementErrorTxs(ctx)
+				a.metrics.IncrementErrorTxs(ctx, ErrorReasonSimulation)
 			}
 			return
 		}
@@ -626,7 +626,7 @@ func (a *AptosTxm) signAndBroadcast(ctx context.Context, tx *AptosTx) {
 		if err != nil {
 			ctxLogger.Errorw("failed to create signed tx", "error", err)
 			a.updateTransactionStatus(tx, commontypes.Failed)
-			a.metrics.IncrementErrorTxs(ctx)
+			a.metrics.IncrementErrorTxs(ctx, ErrorReasonSigning)
 			return
 		}
 
@@ -635,7 +635,7 @@ func (a *AptosTxm) signAndBroadcast(ctx context.Context, tx *AptosTx) {
 			if submitResponse == nil || submitResponse.Hash == "" {
 				ctxLogger.Errorw("did not receive hash after successful tx submission")
 				a.updateTransactionStatus(tx, commontypes.Failed)
-				a.metrics.IncrementErrorTxs(ctx)
+				a.metrics.IncrementErrorTxs(ctx, ErrorReasonNoHash)
 				return
 			}
 
@@ -650,7 +650,7 @@ func (a *AptosTxm) signAndBroadcast(ctx context.Context, tx *AptosTx) {
 				// TODO: figure out what to do here, this should never occur.
 				ctxLogger.Errorw("failed to add unconfirmed tx", "txHash", submitResponse.Hash, "error", err)
 				a.updateTransactionStatus(tx, commontypes.Failed)
-				a.metrics.IncrementErrorTxs(ctx)
+				a.metrics.IncrementErrorTxs(ctx, ErrorReasonStoreAdd)
 				return
 			}
 
@@ -666,7 +666,7 @@ func (a *AptosTxm) signAndBroadcast(ctx context.Context, tx *AptosTx) {
 				// Do not retry on unknown errors
 				ctxLogger.Errorw("failed to submit signed tx, discarding..", "error", err)
 				a.updateTransactionStatus(tx, commontypes.Failed)
-				a.metrics.IncrementErrorTxs(ctx)
+				a.metrics.IncrementErrorTxs(ctx, ErrorReasonUnknownSubmit)
 				return
 			}
 
@@ -683,8 +683,7 @@ func (a *AptosTxm) signAndBroadcast(ctx context.Context, tx *AptosTx) {
 
 	ctxLogger.Errorw("reached max retries for submitting the tx")
 	a.updateTransactionStatus(tx, commontypes.Failed)
-	a.metrics.IncrementRejectTxs(ctx)
-	a.metrics.IncrementErrorTxs(ctx)
+	a.metrics.IncrementErrorTxs(ctx, ErrorReasonMaxRetries)
 }
 
 func matchExpectedSimulationFailure(err error, expectedSimulationFailures []ExpectedSimulationFailureRule) bool {
@@ -784,8 +783,7 @@ func (a *AptosTxm) checkUnconfirmed(ctx context.Context) {
 							}
 						} else {
 							ctxLogger.Infow("confirmed tx: unsuccessful", "hash", hash, "chainTx", chainTx, "chainTx.Type", chainTx.Type)
-							a.metrics.IncrementRevertTxs(ctx)
-							a.metrics.IncrementErrorTxs(ctx)
+							a.metrics.IncrementErrorTxs(ctx, ErrorReasonRevert)
 							if userTx.VmStatus == "Out of gas" {
 								// https://github.com/aptos-labs/aptos-core/blob/77ff4bf413f54c41206bd5573e1891fa3a0dccf6/api/types/src/convert.rs#L1062
 								// Example transaction: https://api.testnet.aptoslabs.com/v1/transactions/by_hash/0x7a106db811c8d5dfd71ac98f374ca36e4f630ce5412b99c8f0e871e7feda37ea
@@ -800,13 +798,13 @@ func (a *AptosTxm) checkUnconfirmed(ctx context.Context) {
 						// NOTE: Type assertion failed on UserTransaction.
 						ctxLogger.Errorw("failed to read confirmed user tx", "hash", hash, "chainTxInner", chainTx.Inner)
 						// Incrementing error as we dont know if it was a success.
-						a.metrics.IncrementErrorTxs(ctx)
+						a.metrics.IncrementErrorTxs(ctx, ErrorReasonTypeAssertion)
 					}
 				} else {
 					// NOTE: Committed tx is not TransactionVariantUser (e.g. some future variant).
 					ctxLogger.Errorw("unexpected confirmed tx type", "hash", hash, "chainTx", chainTx, "chainTx.Type", chainTx.Type)
 					// Incrementing error as we dont know if it was a success.
-					a.metrics.IncrementErrorTxs(ctx)
+					a.metrics.IncrementErrorTxs(ctx, ErrorReasonUnexpectedType)
 				}
 
 				a.updateTransactionStatus(unconfirmedTx.Tx, commontypes.Finalized)
@@ -832,12 +830,11 @@ func (a *AptosTxm) checkUnconfirmed(ctx context.Context) {
 				if err != nil {
 					ctxLogger.Errorw("couldn't confirm expired tx", "error", err)
 					a.updateTransactionStatus(unconfirmedTx.Tx, commontypes.Failed)
-					a.metrics.IncrementErrorTxs(ctx)
+					a.metrics.IncrementErrorTxs(ctx, ErrorReasonExpiredConfirm)
 					continue
 				}
 
-				a.metrics.IncrementDropTxs(ctx)
-				a.metrics.IncrementErrorTxs(ctx)
+				a.metrics.IncrementErrorTxs(ctx, ErrorReasonDrop)
 				a.incrementTransactionAttempt(unconfirmedTx.Tx)
 				if !a.maybeRetry(ctx, unconfirmedTx, RetryReasonExpired) {
 					a.updateTransactionStatus(unconfirmedTx.Tx, commontypes.Failed)
@@ -877,7 +874,7 @@ func (a *AptosTxm) maybeRetry(ctx context.Context, unconfirmedTx *UnconfirmedTx,
 	select {
 	case a.broadcastChan <- unconfirmedTx.Tx.ID:
 		ctxLogger.Debugw("retrying tx", "attempt", currentAttempt, "hash", unconfirmedTx.Hash, "retryReason", retryReason)
-		a.metrics.IncrementRetryTxs(ctx)
+		a.metrics.IncrementRetryTxs(ctx, retryReason.String())
 		return true
 	default:
 		ctxLogger.Errorw("failed to enqueue tx for rebroadcast", "attempt", currentAttempt, "hash", unconfirmedTx.Hash, "retryReason", retryReason)


### PR DESCRIPTION
## Summary

- Collapse 4 separate error counters (`error`, `revert`, `reject`, `drop`) into a single `aptos_txm_tx_error` counter with a `reason` label
- Add `reason` label to `aptos_txm_tx_retry` counter
- Define 13 error reason constants and update all call sites in `txm.go`
- Net result: 9 metrics → 6 metrics, 46 insertions / 80 deletions

**Ticket:** [PLEX-2600](https://smartcontract-it.atlassian.net/browse/PLEX-2600)

## Test plan

- [x] `go build ./relayer/txm/...` passes
- [x] `go test ./relayer/txm/... -short` — all 4 existing unit tests pass
- [x] Verified no remaining references to removed methods (`IncrementRevertTxs`, `IncrementRejectTxs`, `IncrementDropTxs`)
- [x] Verified no untagged `IncrementErrorTxs(ctx)` calls remain
- [x] Verified no old Prometheus vars remain

[PLEX-2600]: https://smartcontract-it.atlassian.net/browse/PLEX-2600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ