### PR TITLE
chore(integration-tests): bump CTF to fix Aptos cwd tar race

### DIFF
--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20260324144720-484863604698
 	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260406055916-9aa6b6c0ae81
 	github.com/smartcontractkit/chainlink-deployments-framework v0.94.0
-	github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.13
+	github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.16
 	github.com/smartcontractkit/chainlink/core/scripts v0.0.0-20260407130455-5258160d170f
 	github.com/smartcontractkit/mcms v0.39.0
 	github.com/spf13/cobra v1.10.2

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1464,8 +1464,8 @@ github.com/smartcontractkit/chainlink-sui v0.0.0-20260403160819-db38ee3fbcde h1:
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260403160819-db38ee3fbcde/go.mod h1:U3XStbEnbx/+L22n1/8aOIdgcGVxtsZB7p59xJGngAs=
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260304150206-c64e48eb0cb0 h1:5NdsaclAfx+p8lZUZ3WIqMW3M9Cze1ZVPENOQhha1pk=
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260304150206-c64e48eb0cb0/go.mod h1:IfeW6t5Yc5293H5ixuooAft+wYBMSFQWKjbBTwYiKr4=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.13 h1:quHuZ/2I7XZ8pdRw5UAwKW/idsPchHN7KnQ69YWzxS4=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.13/go.mod h1:BALK9cj8sk12e15UF6uDhifHgIApa+6N11TcQfInEro=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.16 h1:pzrAgF6QFMQLS/kukXenLN87PCa48SEMlE7QvJxTOHs=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.16/go.mod h1:BALK9cj8sk12e15UF6uDhifHgIApa+6N11TcQfInEro=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5 h1:jARz/SWbmWoGJJGVcAnWwGMb8JuHRTQQsM3m6ZwrAGk=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5/go.mod h1:dgwtcefGr+0i+C2S6V/Xgntzm7E5CPxXMyi2OnQvnHI=
 github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 h1:cWUHB6QETyKbmh0B988f5AKIKb3aBDWugfrZ04jAUUY=


### PR DESCRIPTION
## Summary

Bumps `github.com/smartcontractkit/chainlink-testing-framework/framework` in `integration-tests/go.mod` to `v0.15.16` to pull in the upstream fix for an `archive/tar: write too long` flake in the Aptos CTF container-start path.

Upstream PR: smartcontractkit/chainlink-testing-framework#2519 (merged as `v0.15.16`).

## Root Cause

`chainlink-deployments-framework/chain/aptos/provider/ctf_provider.go:160` builds a `blockchain.Input{Type: TypeAptos, ...}` with no `ContractsDir`. CTF's `newAptos` unconditionally called `filepath.Abs(in.ContractsDir)` — Go stdlib resolves `filepath.Abs("")` to the process cwd. That path was attached as a `testcontainers.ContainerFile`, tarring the host test working directory. Files in that dir being written concurrently (logs, db dumps) trip `archive/tar.ErrWriteTooLong` between `os.Stat` (header size) and `io.Copy` (body).

Same bug shape as the Sui flake; fix is symmetric.

## Fix

Module bump only — no source changes. Pins framework to `v0.15.16` (stable tag), which gates the `Files:` entry on `in.ContractsDir != ""` in both `sui.go` and `aptos.go`.

## Safety

- Callers passing a non-empty `ContractsDir`: identical behaviour.
- Callers passing empty (including this repo's `integration-tests/ccip/ccip_deployment_test.go`): `req.Files` now nil. testcontainers-go's copy-to-container hook iterates `range files` — zero iterations on nil, no-op.

## Test plan

- [x] `go get` + `go mod tidy` clean
- [x] CI green — 19 checks pass, 1 skipped, 0 failing
