### PR TITLE
Fix stale Aptos relayer cleanup on refresh

### DIFF
--- a/cmd/chainlink-aptos/main.go
+++ b/cmd/chainlink-aptos/main.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"sync"
 
 	"github.com/hashicorp/go-plugin"
 
@@ -51,6 +54,28 @@ func main() {
 type pluginRelayer struct {
 	loop.Plugin
 	ds sqlutil.DataSource
+
+	mu      sync.Mutex
+	current *activeRelayer
+}
+
+type activeRelayer struct {
+	relay   io.Closer
+	emitter io.Closer
+}
+
+func (a *activeRelayer) Close() error {
+	if a == nil {
+		return nil
+	}
+	var err error
+	if a.relay != nil {
+		err = errors.Join(err, a.relay.Close())
+	}
+	if a.emitter != nil {
+		err = errors.Join(err, a.emitter.Close())
+	}
+	return err
 }
 
 // NewRelayer implements the Loopp factory method used by the Loopp server to instantiate an aptos relayer.
@@ -59,6 +84,12 @@ type pluginRelayer struct {
 // [github.com/smartcontractkit/chainlink-aptos/relayer/txm.NewKeystoreAdapter]
 func (p *pluginRelayer) NewRelayer(ctx context.Context, rawConfig string, loopKs core.Keystore, csaKs core.Keystore, capRegistry core.CapabilitiesRegistry) (loop.Relayer, error) {
 	_ = csaKs
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if err := p.closeCurrent(); err != nil {
+		return nil, fmt.Errorf("failed to close previous relayer: %w", err)
+	}
 
 	// Initialize the chain service
 	cfg, err := config.NewDecodedTOMLConfig(rawConfig)
@@ -82,23 +113,35 @@ func (p *pluginRelayer) NewRelayer(ctx context.Context, rawConfig string, loopKs
 	if err := emitter.Start(ctx); err != nil {
 		return nil, fmt.Errorf("failed to start plugin relayer config emitter: %w", err)
 	}
-	p.SubService(emitter)
 	opts := chain.ChainOpts{
 		Logger:   p.Logger,
 		KeyStore: loopKs,
 		DS:       p.ds,
 	}
-	chain, err := chain.NewChain(cfg, opts)
+	ch, err := chain.NewChain(cfg, opts)
 	if err != nil {
+		err = errors.Join(err, emitter.Close())
 		return nil, fmt.Errorf("failed to create chain: %w", err)
 	}
 
 	// Initialize the relayer service
-	relay, err := relayer.NewRelayer(p.Logger, chain, capRegistry)
+	relay, err := relayer.NewRelayer(p.Logger, ch, capRegistry)
 	if err != nil {
+		err = errors.Join(err, ch.Close(), emitter.Close())
 		return nil, fmt.Errorf("failed to create relay: %w", err)
 	}
+	p.SubService(emitter)
 	p.SubService(relay)
+	p.current = &activeRelayer{relay: relay, emitter: emitter}
 
 	return relay, nil
+}
+
+func (p *pluginRelayer) closeCurrent() error {
+	if p.current == nil {
+		return nil
+	}
+	current := p.current
+	p.current = nil
+	return current.Close()
 }

--- a/cmd/chainlink-aptos/main_test.go
+++ b/cmd/chainlink-aptos/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginRelayerCloseCurrent(t *testing.T) {
+	relay := &testCloser{}
+	emitter := &testCloser{}
+	p := &pluginRelayer{
+		current: &activeRelayer{
+			relay:   relay,
+			emitter: emitter,
+		},
+	}
+
+	require.NoError(t, p.closeCurrent())
+	require.Nil(t, p.current)
+	require.Equal(t, 1, relay.closed)
+	require.Equal(t, 1, emitter.closed)
+}
+
+func TestPluginRelayerCloseCurrentClearsCurrentOnError(t *testing.T) {
+	expectedErr := errors.New("close failed")
+	relay := &testCloser{err: expectedErr}
+	emitter := &testCloser{}
+	p := &pluginRelayer{
+		current: &activeRelayer{
+			relay:   relay,
+			emitter: emitter,
+		},
+	}
+
+	err := p.closeCurrent()
+	require.ErrorIs(t, err, expectedErr)
+	require.Nil(t, p.current)
+	require.Equal(t, 1, relay.closed)
+	require.Equal(t, 1, emitter.closed)
+}
+
+type testCloser struct {
+	closed int
+	err    error
+}
+
+func (t *testCloser) Close() error {
+	t.closed++
+	return t.err
+}


### PR DESCRIPTION
## Summary

Fixes the Aptos BalanceMonitor stale socket leak described in PLEX-2873.

When the LOOP host refreshes the relayer client connection, it can invoke NewRelayer again in the still-running Aptos plugin process. The Aptos plugin was constructing a fresh chain, relayer, and config emitter each time without closing the previous instance, leaving the old BalanceMonitor polling a keystore connection backed by a deleted /tmp/plugin* socket.

This PR makes the Aptos plugin relayer:

- serialize NewRelayer calls
- close the previous active relayer and config emitter before replacing them
- clean up the config emitter/chain on partial construction failures
- cover the active relayer cleanup helper with unit tests

## Validation

GOMODCACHE=/private/tmp/gomodcache GOCACHE=/private/tmp/gocache GOPATH=/private/tmp/gopath go test ./cmd/chainlink-aptos -count=1

## Notes

This is the plugin-side fix. A companion chainlink-common draft PR documents/enforces the LOOP server-side replacement contract for served relayer resources.