### PR TITLE
Fix Aptos account transaction limit windows

### DIFF
--- a/relayer/aptos_service.go
+++ b/relayer/aptos_service.go
@@ -149,7 +149,7 @@ func (s *aptosService) AccountTransactions(ctx context.Context, req commonaptos.
 		return nil, err
 	}
 	if limit != nil && *limit == 0 {
-		s.logger.Infow("AccountTransactions: returning empty result", "address", sdkAddr.String())
+		s.logger.Debugw("AccountTransactions: returning empty result", "address", sdkAddr.String())
 		return &commonaptos.AccountTransactionsReply{}, nil
 	}
 

--- a/relayer/aptos_service.go
+++ b/relayer/aptos_service.go
@@ -193,6 +193,10 @@ func (s *aptosService) accountTransactionsWindow(
 		return start, limit, nil
 	}
 
+	// Fetch the sequence number to compute a safe window. A small TOCTOU race
+	// exists: new txns committed between Account() and AccountTransactions() may
+	// not appear in the result. That is acceptable — the caller can re-query.
+	// The goal is to prevent underflow, not to guarantee atomicity.
 	accountInfo, err := client.Account(address)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get account info: %w", err)
@@ -201,6 +205,8 @@ func (s *aptosService) accountTransactionsWindow(
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse account sequence number: %w", err)
 	}
+	// Return (0, 0) as a sentinel signalling "nothing to fetch": the caller
+	// short-circuits to an empty reply without issuing an AccountTransactions RPC.
 	if sequenceNumber == 0 || *limit == 0 {
 		zero := uint64(0)
 		return &zero, &zero, nil

--- a/relayer/aptos_service.go
+++ b/relayer/aptos_service.go
@@ -143,7 +143,17 @@ func (s *aptosService) AccountTransactions(ctx context.Context, req commonaptos.
 	}
 
 	sdkAddr := aptos_sdk.AccountAddress(req.Address[:])
-	txns, err := client.AccountTransactions(sdkAddr, req.Start, req.Limit)
+	start, limit, err := s.accountTransactionsWindow(client, sdkAddr, req.Start, req.Limit)
+	if err != nil {
+		s.logger.Errorw("AccountTransactions: failed to resolve transaction window", "address", sdkAddr.String(), "error", err)
+		return nil, err
+	}
+	if limit != nil && *limit == 0 {
+		s.logger.Infow("AccountTransactions: returning empty result", "address", sdkAddr.String())
+		return &commonaptos.AccountTransactionsReply{}, nil
+	}
+
+	txns, err := client.AccountTransactions(sdkAddr, start, limit)
 	if err != nil {
 		s.logger.Errorw("AccountTransactions: failed to get transactions", "address", sdkAddr.String(), "error", err)
 		return nil, fmt.Errorf("failed to get account transactions: %w", err)
@@ -171,6 +181,41 @@ func (s *aptosService) AccountTransactions(ctx context.Context, req commonaptos.
 
 	s.logger.Infow("AccountTransactions: returning", "address", sdkAddr.String(), "txCount", len(result))
 	return &commonaptos.AccountTransactionsReply{Transactions: result}, nil
+}
+
+func (s *aptosService) accountTransactionsWindow(
+	client aptos_sdk.AptosRpcClient,
+	address aptos_sdk.AccountAddress,
+	start *uint64,
+	limit *uint64,
+) (*uint64, *uint64, error) {
+	if start != nil || limit == nil {
+		return start, limit, nil
+	}
+
+	accountInfo, err := client.Account(address)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get account info: %w", err)
+	}
+	sequenceNumber, err := accountInfo.SequenceNumber()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse account sequence number: %w", err)
+	}
+	if sequenceNumber == 0 || *limit == 0 {
+		zero := uint64(0)
+		return &zero, &zero, nil
+	}
+
+	boundedLimit := min(*limit, sequenceNumber)
+	boundedStart := sequenceNumber - boundedLimit
+	s.logger.Debugw("AccountTransactions: resolved latest transaction window",
+		"address", address.String(),
+		"sequenceNumber", sequenceNumber,
+		"requestedLimit", *limit,
+		"start", boundedStart,
+		"limit", boundedLimit,
+	)
+	return &boundedStart, &boundedLimit, nil
 }
 
 func (s *aptosService) SubmitTransaction(ctx context.Context, req commonaptos.SubmitTransactionRequest) (*commonaptos.SubmitTransactionReply, error) {

--- a/relayer/aptos_service_test.go
+++ b/relayer/aptos_service_test.go
@@ -100,7 +100,7 @@ func ptrUint64(v uint64) *uint64 {
 	return &v
 }
 
-func TestAptosServiceAccountTransactionsBoundsLimitOnlyQuery(t *testing.T) {
+func TestAptosServiceAccountTransactionsYoungAccount(t *testing.T) {
 	t.Parallel()
 
 	var addr aptos.AccountAddress
@@ -200,9 +200,10 @@ func TestAptosServiceAccountTransactionsPreservesExplicitStart(t *testing.T) {
 	limit := uint64(10)
 
 	client := clientmocks.NewAptosRpcClient(t)
-	client.EXPECT().AccountTransactions(sdkAddr, &start, &limit).
-		Return([]*api.CommittedTransaction{}, nil).
-		Once()
+	client.EXPECT().AccountTransactions(sdkAddr,
+		mock.MatchedBy(func(s *uint64) bool { return s != nil && *s == start }),
+		mock.MatchedBy(func(l *uint64) bool { return l != nil && *l == limit }),
+	).Return([]*api.CommittedTransaction{}, nil).Once()
 
 	svc := aptosService{
 		chain:  &testChain{client: client},

--- a/relayer/aptos_service_test.go
+++ b/relayer/aptos_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	aptos_sdk "github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/api"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -97,6 +98,124 @@ func TestAptosServiceViewUsesRequestedLedgerVersion(t *testing.T) {
 
 func ptrUint64(v uint64) *uint64 {
 	return &v
+}
+
+func TestAptosServiceAccountTransactionsBoundsLimitOnlyQuery(t *testing.T) {
+	t.Parallel()
+
+	var addr aptos.AccountAddress
+	addr[31] = 0xEE
+	sdkAddr := aptos_sdk.AccountAddress(addr[:])
+	requestedLimit := uint64(10)
+
+	client := clientmocks.NewAptosRpcClient(t)
+	client.EXPECT().Account(sdkAddr).Return(aptos_sdk.AccountInfo{SequenceNumberStr: "4"}, nil).Once()
+	client.EXPECT().AccountTransactions(sdkAddr, mock.Anything, mock.Anything).
+		Run(func(_ aptos_sdk.AccountAddress, start *uint64, limit *uint64) {
+			require.NotNil(t, start)
+			require.NotNil(t, limit)
+			require.Equal(t, uint64(0), *start)
+			require.Equal(t, uint64(4), *limit)
+		}).
+		Return([]*api.CommittedTransaction{}, nil).
+		Once()
+
+	svc := aptosService{
+		chain:  &testChain{client: client},
+		logger: logger.Test(t),
+	}
+
+	reply, err := svc.AccountTransactions(context.Background(), aptos.AccountTransactionsRequest{
+		Address: addr,
+		Limit:   &requestedLimit,
+	})
+	require.NoError(t, err)
+	require.Empty(t, reply.Transactions)
+}
+
+func TestAptosServiceAccountTransactionsUsesLatestWindowForLimitOnlyQuery(t *testing.T) {
+	t.Parallel()
+
+	var addr aptos.AccountAddress
+	addr[31] = 0xEE
+	sdkAddr := aptos_sdk.AccountAddress(addr[:])
+	requestedLimit := uint64(10)
+
+	client := clientmocks.NewAptosRpcClient(t)
+	client.EXPECT().Account(sdkAddr).Return(aptos_sdk.AccountInfo{SequenceNumberStr: "25"}, nil).Once()
+	client.EXPECT().AccountTransactions(sdkAddr, mock.Anything, mock.Anything).
+		Run(func(_ aptos_sdk.AccountAddress, start *uint64, limit *uint64) {
+			require.NotNil(t, start)
+			require.NotNil(t, limit)
+			require.Equal(t, uint64(15), *start)
+			require.Equal(t, uint64(10), *limit)
+		}).
+		Return([]*api.CommittedTransaction{}, nil).
+		Once()
+
+	svc := aptosService{
+		chain:  &testChain{client: client},
+		logger: logger.Test(t),
+	}
+
+	reply, err := svc.AccountTransactions(context.Background(), aptos.AccountTransactionsRequest{
+		Address: addr,
+		Limit:   &requestedLimit,
+	})
+	require.NoError(t, err)
+	require.Empty(t, reply.Transactions)
+}
+
+func TestAptosServiceAccountTransactionsReturnsEmptyForZeroSequenceNumber(t *testing.T) {
+	t.Parallel()
+
+	var addr aptos.AccountAddress
+	addr[31] = 0xEE
+	sdkAddr := aptos_sdk.AccountAddress(addr[:])
+	requestedLimit := uint64(10)
+
+	client := clientmocks.NewAptosRpcClient(t)
+	client.EXPECT().Account(sdkAddr).Return(aptos_sdk.AccountInfo{SequenceNumberStr: "0"}, nil).Once()
+
+	svc := aptosService{
+		chain:  &testChain{client: client},
+		logger: logger.Test(t),
+	}
+
+	reply, err := svc.AccountTransactions(context.Background(), aptos.AccountTransactionsRequest{
+		Address: addr,
+		Limit:   &requestedLimit,
+	})
+	require.NoError(t, err)
+	require.Empty(t, reply.Transactions)
+}
+
+func TestAptosServiceAccountTransactionsPreservesExplicitStart(t *testing.T) {
+	t.Parallel()
+
+	var addr aptos.AccountAddress
+	addr[31] = 0xEE
+	sdkAddr := aptos_sdk.AccountAddress(addr[:])
+	start := uint64(3)
+	limit := uint64(10)
+
+	client := clientmocks.NewAptosRpcClient(t)
+	client.EXPECT().AccountTransactions(sdkAddr, &start, &limit).
+		Return([]*api.CommittedTransaction{}, nil).
+		Once()
+
+	svc := aptosService{
+		chain:  &testChain{client: client},
+		logger: logger.Test(t),
+	}
+
+	reply, err := svc.AccountTransactions(context.Background(), aptos.AccountTransactionsRequest{
+		Address: addr,
+		Start:   &start,
+		Limit:   &limit,
+	})
+	require.NoError(t, err)
+	require.Empty(t, reply.Transactions)
 }
 
 // getAccountWithHighestBalance must query each keystore public key at its


### PR DESCRIPTION
## Summary
- resolve `AccountTransactions(start=nil, limit=N)` into an explicit bounded window before calling the Aptos SDK
- return an empty result for zero-sequence accounts instead of issuing an invalid SDK request
- keep explicit-start account transaction requests unchanged
- lower expected empty-account transaction logs to debug for new/young transmitter accounts
- add relayer unit tests for young accounts, normal windows, zero sequence number, and explicit-start passthrough

## Root Cause
The Chainlink merge queue Aptos CRE test started requesting recent transmitter account transactions with `start=nil, limit=10`. That call shape was introduced by smartcontractkit/capabilities#574, specifically https://github.com/smartcontractkit/capabilities/commit/133e87d6fa49e380db7a4648587ef4dbd314e6b7, when the Aptos tx-search phase-1 probe changed from `start=nil, limit=nil` to a bounded latest-page request.

For limit-only account transaction requests, the Aptos SDK queries the latest transactions and then computes a previous-page cursor from the first returned transaction sequence number. For new accounts with fewer transactions than the requested limit, the earliest returned sequence can be `0`, so the SDK computes `0 - 1` and issues a REST request with `start=18446744073709551615`. The observed CI failure was the Aptos REST API rejecting that invalid cursor.

## Fix
This PR handles the limit-only request shape in the relayer by resolving it into a safe explicit latest transaction window before calling the Aptos SDK. For accounts with sequence number `0`, the relayer returns an empty transaction list directly. Requests that already provide an explicit `start` are still passed through unchanged.

## Testing
- `go test ./relayer -count=1`

Failing runs / consumers:
- https://github.com/smartcontractkit/chainlink/actions/runs/25151620823/job/73724531635
- https://chainlink-core.slack.com/archives/C043E82DUM8/p1777533874251039
- Chainlink consumer PR: https://github.com/smartcontractkit/chainlink/pull/22264

Aptos SDK issue filed:
https://github.com/aptos-labs/aptos-go-sdk/issues/213
