### PR TITLE
[audit-rebase] #437 — transmitter address override for key rotation

### DIFF
--- a/relayer/aptos_service.go
+++ b/relayer/aptos_service.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/smartcontractkit/chainlink-aptos/relayer/chain"
-	"github.com/smartcontractkit/chainlink-aptos/relayer/utils"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	commonaptos "github.com/smartcontractkit/chainlink-common/pkg/types/chains/aptos"
@@ -203,20 +202,20 @@ func (s *aptosService) SubmitTransaction(ctx context.Context, req commonaptos.Su
 	if req.GasConfig != nil {
 		gasLimit = big.NewInt(int64(req.GasConfig.MaxGasAmount))
 	}
-	accounts, err := s.chain.KeyStore().Accounts(ctx)
+	publicKeys, err := s.chain.KeyStore().Accounts(ctx)
 	if err != nil {
-		s.logger.Errorw("SubmitTransaction: failed to get accounts", "error", err)
-		return nil, fmt.Errorf("failed to get accounts: %w", err)
+		s.logger.Errorw("SubmitTransaction: failed to get public keys", "error", err)
+		return nil, fmt.Errorf("failed to get public keys: %w", err)
 	}
-	s.logger.Infow("SubmitTransaction: accounts retrieved", "numAccounts", len(accounts))
+	s.logger.Infow("SubmitTransaction: public keys retrieved", "numPublicKeys", len(publicKeys))
 
 	// Find account with highest balance
-	publicKey, err := s.getAccountWithHighestBalance(ctx, accounts)
+	publicKey, fromAddress, err := s.getAccountWithHighestBalance(ctx, publicKeys)
 	if err != nil {
 		s.logger.Errorw("SubmitTransaction: failed to get account with highest balance", "error", err)
 		return nil, fmt.Errorf("failed to determine account for SubmitTransaction: %w", err)
 	}
-	s.logger.Infow("SubmitTransaction: selected account", "publicKey", publicKey)
+	s.logger.Infow("SubmitTransaction: selected account", "publicKey", publicKey, "fromAddress", fromAddress.String())
 
 	txID := uuid.New().String()
 	s.logger.Infow("SubmitTransaction: enqueueing to TxManager", "txID", txID)
@@ -226,6 +225,7 @@ func (s *aptosService) SubmitTransaction(ctx context.Context, req commonaptos.Su
 			GasLimit: gasLimit,
 		},
 		publicKey,
+		fromAddress,
 		entryFn,
 		*s.chain.Config().AptosService.SimulateTx,
 		// TODO: add expected simulation failures to save gas on reported transmissions
@@ -304,56 +304,67 @@ func (s *aptosService) SubmitTransaction(ctx context.Context, req commonaptos.Su
 	}, nil
 }
 
-// getAccountWithHighestBalance returns the public key of the account with the highest APT balance.
-func (s *aptosService) getAccountWithHighestBalance(ctx context.Context, accounts []string) (string, error) {
-	if len(accounts) == 0 {
-		return "", errors.New("no accounts provided")
+// getAccountWithHighestBalance returns the public key and resolved on-chain
+// address of the account with the highest APT balance.
+func (s *aptosService) getAccountWithHighestBalance(ctx context.Context, publicKeys []string) (string, aptos_sdk.AccountAddress, error) {
+	if len(publicKeys) == 0 {
+		return "", aptos_sdk.AccountAddress{}, errors.New("no accounts provided")
 	}
-	if len(accounts) == 1 {
-		s.logger.Debugw("getAccountWithHighestBalance: only one enabled account for chain", "account", accounts[0])
-		return accounts[0], nil
+	if len(publicKeys) == 1 {
+		s.logger.Debugw("getAccountWithHighestBalance: only one enabled account for chain", "publicKey", publicKeys[0])
+		accountAddress, err := s.chain.Config().Transmitter.ResolveAddress(publicKeys[0])
+		if err != nil {
+			return "", aptos_sdk.AccountAddress{}, fmt.Errorf("failed to resolve transmitter address: %w", err)
+		}
+		return publicKeys[0], accountAddress, nil
 	}
 
 	client, err := s.chain.GetClient()
 	if err != nil {
-		return "", fmt.Errorf("failed to get client: %w", err)
+		return "", aptos_sdk.AccountAddress{}, fmt.Errorf("failed to get client: %w", err)
 	}
 
 	var highestBalance uint64
-	var selectedAccount string
+	var selectedPublicKey string
+	var selectedAddress aptos_sdk.AccountAddress
 	var foundAny bool
 
-	for _, account := range accounts {
-		addr, err := utils.HexPublicKeyToAddress(account)
+	for _, publicKey := range publicKeys {
+		accountAddress, err := s.chain.Config().Transmitter.ResolveAddress(publicKey)
 		if err != nil {
-			s.logger.Warnw("getAccountWithHighestBalance: failed to convert public key to address, skipping", "account", account, "error", err)
+			s.logger.Warnw("getAccountWithHighestBalance: failed to resolve transmitter address, skipping", "publicKey", publicKey, "error", err)
 			continue
 		}
 
-		balance, err := client.AccountAPTBalance(addr)
+		balance, err := client.AccountAPTBalance(accountAddress)
 		if err != nil {
-			s.logger.Warnw("getAccountWithHighestBalance: failed to get balance for account, skipping", "account", account, "error", err)
+			s.logger.Warnw("getAccountWithHighestBalance: failed to get balance for account, skipping", "publicKey", publicKey, "error", err)
 			continue
 		}
 
 		if !foundAny || balance > highestBalance {
 			highestBalance = balance
-			selectedAccount = account
+			selectedPublicKey = publicKey
+			selectedAddress = accountAddress
 			foundAny = true
 		}
 	}
 
 	if !foundAny {
 		// Fallback to first account if all balance queries failed
-		return accounts[0], nil
+		fallbackAddress, err := s.chain.Config().Transmitter.ResolveAddress(publicKeys[0])
+		if err != nil {
+			return "", aptos_sdk.AccountAddress{}, fmt.Errorf("failed to resolve fallback transmitter address: %w", err)
+		}
+		return publicKeys[0], fallbackAddress, nil
 	}
 
 	s.logger.Debugw("getAccountWithHighestBalance: selected account",
-		"account", selectedAccount,
+		"publicKey", selectedPublicKey,
 		"balance", highestBalance,
-		"totalAccounts", len(accounts))
+		"totalAccounts", len(publicKeys))
 
-	return selectedAccount, nil
+	return selectedPublicKey, selectedAddress, nil
 }
 
 // convertTypeTagsToSDK converts common TypeTags to SDK TypeTags.

--- a/relayer/aptos_service_test.go
+++ b/relayer/aptos_service_test.go
@@ -17,7 +17,9 @@ import (
 	chainconfig "github.com/smartcontractkit/chainlink-aptos/relayer/config"
 	"github.com/smartcontractkit/chainlink-aptos/relayer/logpoller"
 	clientmocks "github.com/smartcontractkit/chainlink-aptos/relayer/monitor/mocks"
+	"github.com/smartcontractkit/chainlink-aptos/relayer/transmitter"
 	"github.com/smartcontractkit/chainlink-aptos/relayer/txm"
+	aptosutils "github.com/smartcontractkit/chainlink-aptos/relayer/utils"
 )
 
 func TestAptosServiceLedgerVersion(t *testing.T) {
@@ -97,9 +99,49 @@ func ptrUint64(v uint64) *uint64 {
 	return &v
 }
 
+// getAccountWithHighestBalance must query each keystore public key at its
+// configured transmitter address. Strict mock expectations encode the
+// contract: derivedA for pubKeyA, overrideB for pubKeyB. If the resolver
+// returned pubKeyB's derived address, the mock would fail on the unexpected
+// call.
+func TestAptosService_GetAccountWithHighestBalance_HonorsTransmitterOverride(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pubKeyA          = "abababababababababababababababababababababababababababababababab"
+		pubKeyB          = "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
+		overrideAcctAddr = "0x2222222222222222222222222222222222222222222222222222222222222222"
+	)
+
+	var overrideB aptos_sdk.AccountAddress
+	require.NoError(t, overrideB.ParseStringRelaxed(overrideAcctAddr))
+	derivedA, err := aptosutils.HexPublicKeyToAddress(pubKeyA)
+	require.NoError(t, err)
+
+	client := clientmocks.NewAptosRpcClient(t)
+	client.EXPECT().AccountAPTBalance(derivedA).Return(uint64(10), nil).Once()
+	client.EXPECT().AccountAPTBalance(overrideB).Return(uint64(100), nil).Once()
+
+	cfg := &chainconfig.TOMLConfig{
+		Chain: chainconfig.Chain{
+			Transmitter: &transmitter.Config{Overrides: map[string]string{pubKeyB: overrideAcctAddr}},
+		},
+	}
+	svc := aptosService{
+		chain:  &testChain{client: client, config: cfg},
+		logger: logger.Test(t),
+	}
+
+	selected, selectedAddress, err := svc.getAccountWithHighestBalance(context.Background(), []string{pubKeyA, pubKeyB})
+	require.NoError(t, err)
+	require.Equal(t, pubKeyB, selected, "picker must select the key whose resolved address holds the higher balance")
+	require.Equal(t, overrideB, selectedAddress, "picker must return the override address for the selected key")
+}
+
 type testChain struct {
 	commontypes.UnimplementedChainService
 	client aptos_sdk.AptosRpcClient
+	config *chainconfig.TOMLConfig
 }
 
 func (t testChain) Start(context.Context) error {
@@ -127,6 +169,9 @@ func (t testChain) ID() string {
 }
 
 func (t testChain) Config() *chainconfig.TOMLConfig {
+	if t.config != nil {
+		return t.config
+	}
 	return &chainconfig.TOMLConfig{}
 }
 

--- a/relayer/chain/chain.go
+++ b/relayer/chain/chain.go
@@ -144,10 +144,11 @@ func newChain(cfg *config.TOMLConfig, loopKs loop.Keystore, lggr logger.Logger, 
 	ch.balanceMonitor, err = monitor.NewBalanceMonitor(monitor.BalanceMonitorOpts{
 		ChainInfo: ch.chainInfo(),
 
-		Config:    *cfg.BalanceMonitor,
-		Logger:    lggr,
-		Keystore:  loopKs,
-		NewClient: ch.GetClient,
+		Config:      *cfg.BalanceMonitor,
+		Logger:      lggr,
+		Keystore:    loopKs,
+		Transmitter: cfg.Transmitter,
+		NewClient:   ch.GetClient,
 	})
 	if err != nil {
 		return nil, err

--- a/relayer/config/config.go
+++ b/relayer/config/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-aptos/relayer/aptosservice"
 	"github.com/smartcontractkit/chainlink-aptos/relayer/logpoller"
 	"github.com/smartcontractkit/chainlink-aptos/relayer/monitor"
+	"github.com/smartcontractkit/chainlink-aptos/relayer/transmitter"
 	"github.com/smartcontractkit/chainlink-aptos/relayer/txm"
 	"github.com/smartcontractkit/chainlink-aptos/relayer/write_target"
 )
@@ -33,6 +34,7 @@ type Chain struct {
 	WriteTargetCap     *write_target.Config          `toml:"WriteTargetCap"`
 	Workflow           *WorkflowConfig               `toml:"Workflow"`
 	AptosService       *aptosservice.Config          `toml:"AptosService"`
+	Transmitter        *transmitter.Config           `toml:"Transmitter"`
 }
 
 func ptr[T any](v T) *T { return &v }
@@ -117,6 +119,10 @@ func (cfg *TOMLConfig) applyDefaults() {
 	}
 	cfg.AptosService.Resolve()
 
+	if cfg.Transmitter == nil {
+		cfg.Transmitter = &transmitter.Config{}
+	}
+
 	for _, node := range cfg.Nodes {
 		node.Resolve()
 	}
@@ -184,6 +190,8 @@ func (c *TOMLConfig) ValidateConfig() (err error) {
 			err = errors.Join(err, node.ValidateConfig())
 		}
 	}
+
+	err = errors.Join(err, c.Transmitter.ValidateConfig())
 
 	return
 }

--- a/relayer/config/config_test.go
+++ b/relayer/config/config_test.go
@@ -224,3 +224,61 @@ SubmitPollTimeout = "30s"
 	assert.Equal(t, originalNode, DefaultNodeConfig, "Node defaults must not be mutated")
 }
 
+// TestTOMLConfig_Transmitter verifies the [Aptos.Transmitter.Overrides] section
+// decodes, validates, and resolves against a known keystore public key.
+func TestTOMLConfig_Transmitter(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pubKey   = "abababababababababababababababababababababababababababababababab"
+		override = "0x1111111111111111111111111111111111111111111111111111111111111111"
+	)
+
+	t.Run("override resolves to configured address", func(t *testing.T) {
+		t.Parallel()
+		raw := baseTOML + `
+[Transmitter.Overrides]
+"` + pubKey + `" = "` + override + `"
+`
+		cfg, err := NewDecodedTOMLConfig(raw)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Transmitter)
+
+		got, err := cfg.Transmitter.ResolveAddress(pubKey)
+		require.NoError(t, err)
+		assert.Equal(t, "0x1111111111111111111111111111111111111111111111111111111111111111", got.StringLong())
+	})
+
+	t.Run("unlisted pubkey falls back to derivation", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewDecodedTOMLConfig(baseTOML)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Transmitter)
+
+		got, err := cfg.Transmitter.ResolveAddress(pubKey)
+		require.NoError(t, err)
+		// Standard Aptos derivation: SHA3-256(pubkey || 0x00).
+		assert.NotEqual(t, override, got.StringLong())
+	})
+
+	t.Run("malformed address rejected at validation", func(t *testing.T) {
+		t.Parallel()
+		raw := baseTOML + `
+[Transmitter.Overrides]
+"` + pubKey + `" = "not-an-address"
+`
+		_, err := NewDecodedTOMLConfig(raw)
+		require.ErrorContains(t, err, "Transmitter.Overrides")
+	})
+
+	t.Run("malformed public key rejected at validation", func(t *testing.T) {
+		t.Parallel()
+		raw := baseTOML + `
+[Transmitter.Overrides]
+"zz" = "` + override + `"
+`
+		_, err := NewDecodedTOMLConfig(raw)
+		require.ErrorContains(t, err, "Transmitter.Overrides")
+	})
+}
+

--- a/relayer/monitor/balance.go
+++ b/relayer/monitor/balance.go
@@ -10,18 +10,19 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 
+	"github.com/smartcontractkit/chainlink-aptos/relayer/transmitter"
 	"github.com/smartcontractkit/chainlink-aptos/relayer/types"
-	"github.com/smartcontractkit/chainlink-aptos/relayer/utils"
 )
 
 // BalanceMonitorOpts contains the options for creating a new Aptos account balance monitor.
 type BalanceMonitorOpts struct {
 	ChainInfo types.ChainInfo
 
-	Config    GenericBalanceConfig
-	Logger    logger.Logger
-	Keystore  core.Keystore
-	NewClient func() (aptos.AptosRpcClient, error)
+	Config      GenericBalanceConfig
+	Logger      logger.Logger
+	Keystore    core.Keystore
+	Transmitter *transmitter.Config
+	NewClient   func() (aptos.AptosRpcClient, error)
 }
 
 // NewBalanceMonitor returns a balance monitoring services.Service which reports balance of all Keystore accounts.
@@ -41,8 +42,11 @@ func NewBalanceMonitor(opts BalanceMonitorOpts) (services.Service, error) {
 			return balanceClient{client}, nil
 		},
 		KeyToAccountMapper: func(ctx context.Context, pk string) (string, error) {
-			// We need to convert the Aptos public key to an account address
-			return utils.HexPublicKeyToAddressString(pk)
+			addr, err := opts.Transmitter.ResolveAddress(pk)
+			if err != nil {
+				return "", err
+			}
+			return addr.String(), nil
 		},
 	})
 }

--- a/relayer/transmitter/config.go
+++ b/relayer/transmitter/config.go
@@ -1,0 +1,81 @@
+package transmitter
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+
+	"github.com/smartcontractkit/chainlink-aptos/relayer/utils"
+)
+
+// Config is the [Aptos.Transmitter] TOML section.
+type Config struct {
+	// Overrides maps a hex-encoded ed25519 public key (as reported by
+	// `chainlink keys aptos list`) to the on-chain account address to
+	// use as the transaction sender. Unlisted keys fall back to the
+	// standard Aptos derivation.
+	Overrides map[string]string `toml:"Overrides"`
+}
+
+// ValidateConfig rejects malformed entries and semantic duplicates
+// (distinct TOML keys that resolve to the same lookup key).
+func (c *Config) ValidateConfig() error {
+	if c == nil {
+		return nil
+	}
+	seen := make(map[string]string, len(c.Overrides))
+	for pk, addr := range c.Overrides {
+		norm, err := normalizePublicKey(pk)
+		if err != nil {
+			return fmt.Errorf("Transmitter.Overrides key %q: %w", pk, err)
+		}
+		if prev, dup := seen[norm]; dup {
+			return fmt.Errorf("Transmitter.Overrides: keys %q and %q normalize to the same public key", prev, pk)
+		}
+		seen[norm] = pk
+
+		var a aptos.AccountAddress
+		if err := a.ParseStringRelaxed(addr); err != nil {
+			return fmt.Errorf("Transmitter.Overrides[%q] = %q: %w", pk, addr, err)
+		}
+	}
+	return nil
+}
+
+// ResolveAddress returns the override address registered for publicKey
+// if one exists, else derives the address from the public key.
+func (c *Config) ResolveAddress(publicKey string) (aptos.AccountAddress, error) {
+	if c != nil && len(c.Overrides) > 0 {
+		want, err := normalizePublicKey(publicKey)
+		if err != nil {
+			return aptos.AccountAddress{}, fmt.Errorf("invalid public key %q: %w", publicKey, err)
+		}
+		for k, v := range c.Overrides {
+			got, err := normalizePublicKey(k)
+			if err != nil {
+				continue // already rejected by ValidateConfig
+			}
+			if got == want {
+				var addr aptos.AccountAddress
+				if err := addr.ParseStringRelaxed(v); err != nil {
+					return aptos.AccountAddress{}, fmt.Errorf("invalid Transmitter.Overrides[%q] address %q: %w", k, v, err)
+				}
+				return addr, nil
+			}
+		}
+	}
+	return utils.HexPublicKeyToAddress(publicKey)
+}
+
+func normalizePublicKey(pk string) (string, error) {
+	pk = strings.ToLower(strings.TrimPrefix(strings.TrimSpace(pk), "0x"))
+	if _, err := hex.DecodeString(pk); err != nil {
+		return "", fmt.Errorf("not valid hex: %w", err)
+	}
+	if _, err := utils.HexPublicKeyToEd25519PublicKey(pk); err != nil {
+		return "", err
+	}
+	return pk, nil
+}

--- a/relayer/transmitter/config_test.go
+++ b/relayer/transmitter/config_test.go
@@ -1,0 +1,147 @@
+package transmitter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-aptos/relayer/utils"
+)
+
+const (
+	// Two real ed25519 public keys (32 bytes each) for use in tests.
+	pubKeyA = "abababababababababababababababababababababababababababababababab"
+	pubKeyB = "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
+
+	rotatedAddrA = "0x1111111111111111111111111111111111111111111111111111111111111111"
+	rotatedAddrB = "0x2222222222222222222222222222222222222222222222222222222222222222"
+)
+
+func TestConfig_ValidateConfig(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var c *Config
+		require.NoError(t, c.ValidateConfig())
+	})
+
+	t.Run("empty overrides", func(t *testing.T) {
+		c := &Config{}
+		require.NoError(t, c.ValidateConfig())
+	})
+
+	t.Run("valid entries", func(t *testing.T) {
+		c := &Config{Overrides: map[string]string{
+			pubKeyA:        rotatedAddrA,
+			"0x" + pubKeyB: rotatedAddrB,
+		}}
+		require.NoError(t, c.ValidateConfig())
+	})
+
+	t.Run("public key not hex", func(t *testing.T) {
+		c := &Config{Overrides: map[string]string{"zz": rotatedAddrA}}
+		err := c.ValidateConfig()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Transmitter.Overrides key")
+	})
+
+	t.Run("public key wrong length", func(t *testing.T) {
+		c := &Config{Overrides: map[string]string{"abcd": rotatedAddrA}}
+		err := c.ValidateConfig()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Transmitter.Overrides key")
+	})
+
+	t.Run("semantic duplicate keys rejected", func(t *testing.T) {
+		c := &Config{Overrides: map[string]string{
+			pubKeyA:        rotatedAddrA,
+			"0x" + pubKeyA: rotatedAddrB,
+		}}
+		err := c.ValidateConfig()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "normalize to the same public key")
+	})
+
+	t.Run("address invalid", func(t *testing.T) {
+		c := &Config{Overrides: map[string]string{pubKeyA: "not-an-address"}}
+		err := c.ValidateConfig()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Transmitter.Overrides")
+	})
+}
+
+func TestConfig_ResolveAddress(t *testing.T) {
+	derivedA, err := utils.HexPublicKeyToAddress(pubKeyA)
+	require.NoError(t, err)
+
+	t.Run("nil receiver derives", func(t *testing.T) {
+		var c *Config
+		got, err := c.ResolveAddress(pubKeyA)
+		require.NoError(t, err)
+		assert.Equal(t, derivedA.String(), got.String())
+	})
+
+	t.Run("no overrides derives", func(t *testing.T) {
+		c := &Config{}
+		got, err := c.ResolveAddress(pubKeyA)
+		require.NoError(t, err)
+		assert.Equal(t, derivedA.String(), got.String())
+	})
+
+	t.Run("matching override returns override", func(t *testing.T) {
+		c := &Config{Overrides: map[string]string{pubKeyA: rotatedAddrA}}
+		got, err := c.ResolveAddress(pubKeyA)
+		require.NoError(t, err)
+		assert.Equal(t, strings.ToLower(rotatedAddrA), strings.ToLower(got.String()))
+	})
+
+	t.Run("non-matching pubkey derives", func(t *testing.T) {
+		c := &Config{Overrides: map[string]string{pubKeyA: rotatedAddrA}}
+		derivedB, err := utils.HexPublicKeyToAddress(pubKeyB)
+		require.NoError(t, err)
+		got, err := c.ResolveAddress(pubKeyB)
+		require.NoError(t, err)
+		assert.Equal(t, derivedB.String(), got.String())
+	})
+
+	t.Run("normalization: 0x prefix on either side", func(t *testing.T) {
+		c := &Config{Overrides: map[string]string{"0x" + pubKeyA: rotatedAddrA}}
+		got, err := c.ResolveAddress(pubKeyA) // no prefix on lookup
+		require.NoError(t, err)
+		assert.Equal(t, strings.ToLower(rotatedAddrA), strings.ToLower(got.String()))
+	})
+
+	t.Run("normalization: trims surrounding whitespace", func(t *testing.T) {
+		c := &Config{Overrides: map[string]string{"  " + pubKeyA + "\t": rotatedAddrA}}
+		got, err := c.ResolveAddress("\t" + pubKeyA + " ")
+		require.NoError(t, err)
+		assert.Equal(t, strings.ToLower(rotatedAddrA), strings.ToLower(got.String()))
+	})
+
+	t.Run("normalization: case-insensitive", func(t *testing.T) {
+		c := &Config{Overrides: map[string]string{strings.ToUpper(pubKeyA): rotatedAddrA}}
+		got, err := c.ResolveAddress(pubKeyA)
+		require.NoError(t, err)
+		assert.Equal(t, strings.ToLower(rotatedAddrA), strings.ToLower(got.String()))
+	})
+
+	t.Run("multiple overrides resolve independently", func(t *testing.T) {
+		c := &Config{Overrides: map[string]string{
+			pubKeyA: rotatedAddrA,
+			pubKeyB: rotatedAddrB,
+		}}
+		gotA, err := c.ResolveAddress(pubKeyA)
+		require.NoError(t, err)
+		gotB, err := c.ResolveAddress(pubKeyB)
+		require.NoError(t, err)
+		assert.NotEqual(t, gotA.String(), gotB.String())
+		assert.Equal(t, strings.ToLower(rotatedAddrA), strings.ToLower(gotA.String()))
+		assert.Equal(t, strings.ToLower(rotatedAddrB), strings.ToLower(gotB.String()))
+	})
+
+	t.Run("invalid lookup pubkey errors", func(t *testing.T) {
+		c := &Config{Overrides: map[string]string{pubKeyA: rotatedAddrA}}
+		_, err := c.ResolveAddress("not-hex")
+		require.Error(t, err)
+	})
+}

--- a/relayer/txm/enqueue_entry_function_test.go
+++ b/relayer/txm/enqueue_entry_function_test.go
@@ -1,0 +1,86 @@
+package txm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
+
+	"github.com/smartcontractkit/chainlink-aptos/relayer/utils"
+)
+
+// 32-byte ed25519 public key hex (all 0xab).
+const testPubKeyHex = "abababababababababababababababababababababababababababababababab"
+
+func newTestTxm(t *testing.T) *AptosTxm {
+	t.Helper()
+	cfg := DefaultConfigSet
+	cfg.Resolve()
+	return &AptosTxm{
+		baseLogger:    logger.Test(t),
+		config:        cfg,
+		transactions:  make(map[string]*AptosTx),
+		broadcastChan: make(chan string, 1),
+	}
+}
+
+func mustAddress(t *testing.T, hex string) aptos.AccountAddress {
+	t.Helper()
+	var a aptos.AccountAddress
+	require.NoError(t, a.ParseStringRelaxed(hex))
+	return a
+}
+
+func sampleEntryFunction(t *testing.T) *aptos.EntryFunction {
+	t.Helper()
+	return &aptos.EntryFunction{
+		Module: aptos.ModuleId{
+			Address: mustAddress(t, "0x1"),
+			Name:    "counter",
+		},
+		Function: "increment",
+		ArgTypes: []aptos.TypeTag{},
+		Args:     [][]byte{},
+	}
+}
+
+// EnqueueWithEntryFunction must honor a non-zero fromAddress override, even when
+// that address does not match the one the public key would derive to.
+func TestEnqueueWithEntryFunction_OverrideFromAddress(t *testing.T) {
+	txm := newTestTxm(t)
+
+	override := mustAddress(t, "0x1111111111111111111111111111111111111111111111111111111111111111")
+	derived, err := utils.HexPublicKeyToAddress(testPubKeyHex)
+	require.NoError(t, err)
+	require.NotEqual(t, derived.String(), override.String(), "test fixture must use an override different from the derived address")
+
+	id, err := txm.EnqueueWithEntryFunction("tx-override", &commontypes.TxMeta{}, testPubKeyHex, override, sampleEntryFunction(t), false)
+	require.NoError(t, err)
+
+	tx, ok := txm.transactions[id]
+	require.True(t, ok, "tx should be stored")
+	assert.Equal(t, strings.ToLower(override.String()), strings.ToLower(tx.FromAddress.String()), "FromAddress must equal the override, not the derived address")
+	assert.NotEqual(t, derived.String(), tx.FromAddress.String())
+}
+
+// EnqueueWithEntryFunction with zero fromAddress falls back to deriving from the
+// public key (preserves original behavior for non-rotated accounts).
+func TestEnqueueWithEntryFunction_ZeroFromAddressDerives(t *testing.T) {
+	txm := newTestTxm(t)
+
+	derived, err := utils.HexPublicKeyToAddress(testPubKeyHex)
+	require.NoError(t, err)
+
+	id, err := txm.EnqueueWithEntryFunction("tx-derive", &commontypes.TxMeta{}, testPubKeyHex, aptos.AccountAddress{}, sampleEntryFunction(t), false)
+	require.NoError(t, err)
+
+	tx, ok := txm.transactions[id]
+	require.True(t, ok)
+	assert.Equal(t, derived.String(), tx.FromAddress.String(), "zero fromAddress must derive from pubkey")
+}
+

--- a/relayer/txm/txm.go
+++ b/relayer/txm/txm.go
@@ -201,7 +201,8 @@ func (a *AptosTxm) Enqueue(transactionID string, txMetadata *commontypes.TxMeta,
 // skipping the string-based function parsing and BCS serialisation of parameters.
 // The EntryFunction already contains the module, function name, type tags, and
 // pre-encoded BCS args.
-func (a *AptosTxm) EnqueueWithEntryFunction(transactionID string, txMetadata *commontypes.TxMeta, publicKey string, entryFunction *aptos.EntryFunction, simulateTx bool) (string, error) {
+// Pass the zero AccountAddress for fromAddress to derive it from publicKey.
+func (a *AptosTxm) EnqueueWithEntryFunction(transactionID string, txMetadata *commontypes.TxMeta, publicKey string, fromAddress aptos.AccountAddress, entryFunction *aptos.EntryFunction, simulateTx bool) (string, error) {
 	if entryFunction == nil {
 		return "", errors.New("entry function is required")
 	}
@@ -222,14 +223,15 @@ func (a *AptosTxm) EnqueueWithEntryFunction(transactionID string, txMetadata *co
 		return "", fmt.Errorf("failed to convert public key: %+w", err)
 	}
 
-	acc := utils.Ed25519PublicKeyToAddress(ed25519PublicKey)
-	fromAccountAddress := aptos.AccountAddress(acc)
+	if (fromAddress == aptos.AccountAddress{}) {
+		fromAddress = utils.Ed25519PublicKeyToAddress(ed25519PublicKey)
+	}
 
 	tx := &AptosTx{
 		ID:              transactionID,
 		Metadata:        txMetadata,
 		Timestamp:       getTimestampSecs(),
-		FromAddress:     fromAccountAddress,
+		FromAddress:     fromAddress,
 		PublicKey:       ed25519PublicKey,
 		ContractAddress: entryFunction.Module.Address,
 		ModuleName:      entryFunction.Module.Name,

--- a/relayer/txm/txm_local_test.go
+++ b/relayer/txm/txm_local_test.go
@@ -172,6 +172,7 @@ func runTxmTest(t *testing.T, logger logger.Logger, config Config, rpcURL string
 			incrementId,
 			getSampleTxMetadata(),
 			publicKeyHex,
+			accountAddress, // exercise non-zero FromAddress override path
 			&aptos.EntryFunction{
 				Module: aptos.ModuleId{
 					Address: accountAddress,
@@ -194,6 +195,7 @@ func runTxmTest(t *testing.T, logger logger.Logger, config Config, rpcURL string
 			incrementMultId,
 			getSampleTxMetadata(),
 			publicKeyHex,
+			accountAddress, // exercise non-zero FromAddress override path
 			&aptos.EntryFunction{
 				Module: aptos.ModuleId{
 					Address: accountAddress,


### PR DESCRIPTION
Mirrors #437 (transmitter override for aptos key rotation, PLEX-2632) onto `bugfix/audit_db`. Origin: `866ccd8`.