### PR TITLE
[audit-rebase] #443 — Add ExecutedSuccessfully vm status on success tx

### DIFF
--- a/relayer/aptos_service.go
+++ b/relayer/aptos_service.go
@@ -260,7 +260,7 @@ func (s *aptosService) SubmitTransaction(ctx context.Context, req commonaptos.Su
 				return commonaptos.TxFatal, resultErr
 			}
 			s.logger.Infow("SubmitTransaction: finalized result", "txID", txID, "vmStatus", txResult.VmStatus, "txHash", txResult.TxHash)
-			if txResult.VmStatus != "" {
+			if txResult.VmStatus != "" && txResult.VmStatus != "Executed successfully" {
 				s.logger.Warnw("SubmitTransaction: finalized but VM reverted", "txID", txID, "vmStatus", txResult.VmStatus)
 				return commonaptos.TxReverted, nil
 			}


### PR DESCRIPTION
Mirrors #443 (relayer success tx classification fix). Origin: `f932111` (rebased SHA: `527ee9d`). Base: `bugfix/audit_db`.