### PR TITLE
[audit-rebase] #449 — Fix Aptos account transaction limit windows

### DIFF
--- a/relayer/aptos_service.go
+++ b/relayer/aptos_service.go
@@ -144,7 +144,17 @@ func (s *aptosService) AccountTransactions(ctx context.Context, req commonaptos.
 	}
 
 	sdkAddr := aptos_sdk.AccountAddress(req.Address[:])
-	txns, err := client.AccountTransactions(sdkAddr, req.Start, req.Limit)
+	start, limit, err := s.accountTransactionsWindow(client, sdkAddr, req.Start, req.Limit)
+	if err != nil {
+		s.logger.Errorw("AccountTransactions: failed to resolve transaction window", "address", sdkAddr.String(), "error", err)
+		return nil, err
+	}
+	if limit != nil && *limit == 0 {
+		s.logger.Debugw("AccountTransactions: returning empty result", "address", sdkAddr.String())
+		return &commonaptos.AccountTransactionsReply{}, nil
+	}
+
+	txns, err := client.AccountTransactions(sdkAddr, start, limit)
 	if err != nil {
 		s.logger.Errorw("AccountTransactions: failed to get transactions", "address", sdkAddr.String(), "error", err)
 		return nil, fmt.Errorf("failed to get account transactions: %w", err)
@@ -172,6 +182,47 @@ func (s *aptosService) AccountTransactions(ctx context.Context, req commonaptos.
 
 	s.logger.Infow("AccountTransactions: returning", "address", sdkAddr.String(), "txCount", len(result))
 	return &commonaptos.AccountTransactionsReply{Transactions: result}, nil
+}
+
+func (s *aptosService) accountTransactionsWindow(
+	client aptos_sdk.AptosRpcClient,
+	address aptos_sdk.AccountAddress,
+	start *uint64,
+	limit *uint64,
+) (*uint64, *uint64, error) {
+	if start != nil || limit == nil {
+		return start, limit, nil
+	}
+
+	// Fetch the sequence number to compute a safe window. A small TOCTOU race
+	// exists: new txns committed between Account() and AccountTransactions() may
+	// not appear in the result. That is acceptable — the caller can re-query.
+	// The goal is to prevent underflow, not to guarantee atomicity.
+	accountInfo, err := client.Account(address)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get account info: %w", err)
+	}
+	sequenceNumber, err := accountInfo.SequenceNumber()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse account sequence number: %w", err)
+	}
+	// Return (0, 0) as a sentinel signalling "nothing to fetch": the caller
+	// short-circuits to an empty reply without issuing an AccountTransactions RPC.
+	if sequenceNumber == 0 || *limit == 0 {
+		zero := uint64(0)
+		return &zero, &zero, nil
+	}
+
+	boundedLimit := min(*limit, sequenceNumber)
+	boundedStart := sequenceNumber - boundedLimit
+	s.logger.Debugw("AccountTransactions: resolved latest transaction window",
+		"address", address.String(),
+		"sequenceNumber", sequenceNumber,
+		"requestedLimit", *limit,
+		"start", boundedStart,
+		"limit", boundedLimit,
+	)
+	return &boundedStart, &boundedLimit, nil
 }
 
 func (s *aptosService) SubmitTransaction(ctx context.Context, req commonaptos.SubmitTransactionRequest) (*commonaptos.SubmitTransactionReply, error) {

--- a/relayer/aptos_service_test.go
+++ b/relayer/aptos_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	aptos_sdk "github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/api"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -95,6 +96,125 @@ func TestAptosServiceViewUsesRequestedLedgerVersion(t *testing.T) {
 
 func ptrUint64(v uint64) *uint64 {
 	return &v
+}
+
+func TestAptosServiceAccountTransactionsYoungAccount(t *testing.T) {
+	t.Parallel()
+
+	var addr aptos.AccountAddress
+	addr[31] = 0xEE
+	sdkAddr := aptos_sdk.AccountAddress(addr[:])
+	requestedLimit := uint64(10)
+
+	client := clientmocks.NewAptosRpcClient(t)
+	client.EXPECT().Account(sdkAddr).Return(aptos_sdk.AccountInfo{SequenceNumberStr: "4"}, nil).Once()
+	client.EXPECT().AccountTransactions(sdkAddr, mock.Anything, mock.Anything).
+		Run(func(_ aptos_sdk.AccountAddress, start *uint64, limit *uint64) {
+			require.NotNil(t, start)
+			require.NotNil(t, limit)
+			require.Equal(t, uint64(0), *start)
+			require.Equal(t, uint64(4), *limit)
+		}).
+		Return([]*api.CommittedTransaction{}, nil).
+		Once()
+
+	svc := aptosService{
+		chain:  &testChain{client: client},
+		logger: logger.Test(t),
+	}
+
+	reply, err := svc.AccountTransactions(context.Background(), aptos.AccountTransactionsRequest{
+		Address: addr,
+		Limit:   &requestedLimit,
+	})
+	require.NoError(t, err)
+	require.Empty(t, reply.Transactions)
+}
+
+func TestAptosServiceAccountTransactionsUsesLatestWindowForLimitOnlyQuery(t *testing.T) {
+	t.Parallel()
+
+	var addr aptos.AccountAddress
+	addr[31] = 0xEE
+	sdkAddr := aptos_sdk.AccountAddress(addr[:])
+	requestedLimit := uint64(10)
+
+	client := clientmocks.NewAptosRpcClient(t)
+	client.EXPECT().Account(sdkAddr).Return(aptos_sdk.AccountInfo{SequenceNumberStr: "25"}, nil).Once()
+	client.EXPECT().AccountTransactions(sdkAddr, mock.Anything, mock.Anything).
+		Run(func(_ aptos_sdk.AccountAddress, start *uint64, limit *uint64) {
+			require.NotNil(t, start)
+			require.NotNil(t, limit)
+			require.Equal(t, uint64(15), *start)
+			require.Equal(t, uint64(10), *limit)
+		}).
+		Return([]*api.CommittedTransaction{}, nil).
+		Once()
+
+	svc := aptosService{
+		chain:  &testChain{client: client},
+		logger: logger.Test(t),
+	}
+
+	reply, err := svc.AccountTransactions(context.Background(), aptos.AccountTransactionsRequest{
+		Address: addr,
+		Limit:   &requestedLimit,
+	})
+	require.NoError(t, err)
+	require.Empty(t, reply.Transactions)
+}
+
+func TestAptosServiceAccountTransactionsReturnsEmptyForZeroSequenceNumber(t *testing.T) {
+	t.Parallel()
+
+	var addr aptos.AccountAddress
+	addr[31] = 0xEE
+	sdkAddr := aptos_sdk.AccountAddress(addr[:])
+	requestedLimit := uint64(10)
+
+	client := clientmocks.NewAptosRpcClient(t)
+	client.EXPECT().Account(sdkAddr).Return(aptos_sdk.AccountInfo{SequenceNumberStr: "0"}, nil).Once()
+
+	svc := aptosService{
+		chain:  &testChain{client: client},
+		logger: logger.Test(t),
+	}
+
+	reply, err := svc.AccountTransactions(context.Background(), aptos.AccountTransactionsRequest{
+		Address: addr,
+		Limit:   &requestedLimit,
+	})
+	require.NoError(t, err)
+	require.Empty(t, reply.Transactions)
+}
+
+func TestAptosServiceAccountTransactionsPreservesExplicitStart(t *testing.T) {
+	t.Parallel()
+
+	var addr aptos.AccountAddress
+	addr[31] = 0xEE
+	sdkAddr := aptos_sdk.AccountAddress(addr[:])
+	start := uint64(3)
+	limit := uint64(10)
+
+	client := clientmocks.NewAptosRpcClient(t)
+	client.EXPECT().AccountTransactions(sdkAddr,
+		mock.MatchedBy(func(s *uint64) bool { return s != nil && *s == start }),
+		mock.MatchedBy(func(l *uint64) bool { return l != nil && *l == limit }),
+	).Return([]*api.CommittedTransaction{}, nil).Once()
+
+	svc := aptosService{
+		chain:  &testChain{client: client},
+		logger: logger.Test(t),
+	}
+
+	reply, err := svc.AccountTransactions(context.Background(), aptos.AccountTransactionsRequest{
+		Address: addr,
+		Start:   &start,
+		Limit:   &limit,
+	})
+	require.NoError(t, err)
+	require.Empty(t, reply.Transactions)
 }
 
 type testChain struct {


### PR DESCRIPTION
Audit-rebase mirror of [#449](https://github.com/smartcontractkit/chainlink-aptos/pull/449) (merged to `develop` as `295a7f9a`).

Stacked on top of [`audit/rebase/pr-443`](https://github.com/smartcontractkit/chainlink-aptos/pull/451) so the Dedaub auditors see the change against the audit baseline (`bugfix/audit_db`).

## Why this is in scope

PR #449 was merged to `develop` after the audit baseline. Triggered by the new `AccountTransactions(start=nil, limit=N)` request shape introduced by capabilities [#574](https://github.com/smartcontractkit/capabilities/pull/574) (audit fix for the L4 page-size telemetry prerequisite).

## What it does

Relayer-side fix for `AccountTransactions(start=nil, limit=N)` on young / zero-sequence accounts. The Aptos SDK underflowed the previous-page cursor (`0 − 1` → `2^64−1`), causing the REST API to reject the request.

- Resolves limit-only request shapes into an explicit bounded latest-page window before calling the SDK.
- Returns an empty result for zero-sequence accounts directly.
- Passes explicit-start requests through unchanged.
- Lowers the empty-account log to `debug` for new transmitter accounts.

## Conflict resolution

The cherry-pick produced one conflict in `relayer/aptos_service_test.go` because `develop` carried the `TestAptosService_GetAccountWithHighestBalance_HonorsTransmitterOverride` test from [#437](https://github.com/smartcontractkit/chainlink-aptos/pull/437), which is **not** present on the audit branch (functionality reverted, see [#452](https://github.com/smartcontractkit/chainlink-aptos/pull/452)). Resolution: kept the four new `#449` tests, dropped the override test.

## Verification

```
go test ./relayer -run TestAptosServiceAccountTransactions -count=1
```

All four new tests pass:
- `TestAptosServiceAccountTransactionsYoungAccount`
- `TestAptosServiceAccountTransactionsUsesLatestWindowForLimitOnlyQuery`
- `TestAptosServiceAccountTransactionsReturnsEmptyForZeroSequenceNumber`
- `TestAptosServiceAccountTransactionsPreservesExplicitStart`