### PR TITLE
[audit-rebase] mirrored — all post-baseline changes (rollup)

### DIFF
--- a/relayer/aptos_service.go
+++ b/relayer/aptos_service.go
@@ -260,7 +260,7 @@ func (s *aptosService) SubmitTransaction(ctx context.Context, req commonaptos.Su
 				return commonaptos.TxFatal, resultErr
 			}
 			s.logger.Infow("SubmitTransaction: finalized result", "txID", txID, "vmStatus", txResult.VmStatus, "txHash", txResult.TxHash)
-			if txResult.VmStatus != "" {
+			if txResult.VmStatus != "" && txResult.VmStatus != "Executed successfully" {
 				s.logger.Warnw("SubmitTransaction: finalized but VM reverted", "txID", txID, "vmStatus", txResult.VmStatus)
 				return commonaptos.TxReverted, nil
 			}

--- a/relayer/aptos_service.go
+++ b/relayer/aptos_service.go
@@ -144,7 +144,17 @@ func (s *aptosService) AccountTransactions(ctx context.Context, req commonaptos.
 	}
 
 	sdkAddr := aptos_sdk.AccountAddress(req.Address[:])
-	txns, err := client.AccountTransactions(sdkAddr, req.Start, req.Limit)
+	start, limit, err := s.accountTransactionsWindow(client, sdkAddr, req.Start, req.Limit)
+	if err != nil {
+		s.logger.Errorw("AccountTransactions: failed to resolve transaction window", "address", sdkAddr.String(), "error", err)
+		return nil, err
+	}
+	if limit != nil && *limit == 0 {
+		s.logger.Debugw("AccountTransactions: returning empty result", "address", sdkAddr.String())
+		return &commonaptos.AccountTransactionsReply{}, nil
+	}
+
+	txns, err := client.AccountTransactions(sdkAddr, start, limit)
 	if err != nil {
 		s.logger.Errorw("AccountTransactions: failed to get transactions", "address", sdkAddr.String(), "error", err)
 		return nil, fmt.Errorf("failed to get account transactions: %w", err)
@@ -172,6 +182,47 @@ func (s *aptosService) AccountTransactions(ctx context.Context, req commonaptos.
 
 	s.logger.Infow("AccountTransactions: returning", "address", sdkAddr.String(), "txCount", len(result))
 	return &commonaptos.AccountTransactionsReply{Transactions: result}, nil
+}
+
+func (s *aptosService) accountTransactionsWindow(
+	client aptos_sdk.AptosRpcClient,
+	address aptos_sdk.AccountAddress,
+	start *uint64,
+	limit *uint64,
+) (*uint64, *uint64, error) {
+	if start != nil || limit == nil {
+		return start, limit, nil
+	}
+
+	// Fetch the sequence number to compute a safe window. A small TOCTOU race
+	// exists: new txns committed between Account() and AccountTransactions() may
+	// not appear in the result. That is acceptable — the caller can re-query.
+	// The goal is to prevent underflow, not to guarantee atomicity.
+	accountInfo, err := client.Account(address)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get account info: %w", err)
+	}
+	sequenceNumber, err := accountInfo.SequenceNumber()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse account sequence number: %w", err)
+	}
+	// Return (0, 0) as a sentinel signalling "nothing to fetch": the caller
+	// short-circuits to an empty reply without issuing an AccountTransactions RPC.
+	if sequenceNumber == 0 || *limit == 0 {
+		zero := uint64(0)
+		return &zero, &zero, nil
+	}
+
+	boundedLimit := min(*limit, sequenceNumber)
+	boundedStart := sequenceNumber - boundedLimit
+	s.logger.Debugw("AccountTransactions: resolved latest transaction window",
+		"address", address.String(),
+		"sequenceNumber", sequenceNumber,
+		"requestedLimit", *limit,
+		"start", boundedStart,
+		"limit", boundedLimit,
+	)
+	return &boundedStart, &boundedLimit, nil
 }
 
 func (s *aptosService) SubmitTransaction(ctx context.Context, req commonaptos.SubmitTransactionRequest) (*commonaptos.SubmitTransactionReply, error) {

--- a/relayer/aptos_service_test.go
+++ b/relayer/aptos_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	aptos_sdk "github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/api"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -95,6 +96,125 @@ func TestAptosServiceViewUsesRequestedLedgerVersion(t *testing.T) {
 
 func ptrUint64(v uint64) *uint64 {
 	return &v
+}
+
+func TestAptosServiceAccountTransactionsYoungAccount(t *testing.T) {
+	t.Parallel()
+
+	var addr aptos.AccountAddress
+	addr[31] = 0xEE
+	sdkAddr := aptos_sdk.AccountAddress(addr[:])
+	requestedLimit := uint64(10)
+
+	client := clientmocks.NewAptosRpcClient(t)
+	client.EXPECT().Account(sdkAddr).Return(aptos_sdk.AccountInfo{SequenceNumberStr: "4"}, nil).Once()
+	client.EXPECT().AccountTransactions(sdkAddr, mock.Anything, mock.Anything).
+		Run(func(_ aptos_sdk.AccountAddress, start *uint64, limit *uint64) {
+			require.NotNil(t, start)
+			require.NotNil(t, limit)
+			require.Equal(t, uint64(0), *start)
+			require.Equal(t, uint64(4), *limit)
+		}).
+		Return([]*api.CommittedTransaction{}, nil).
+		Once()
+
+	svc := aptosService{
+		chain:  &testChain{client: client},
+		logger: logger.Test(t),
+	}
+
+	reply, err := svc.AccountTransactions(context.Background(), aptos.AccountTransactionsRequest{
+		Address: addr,
+		Limit:   &requestedLimit,
+	})
+	require.NoError(t, err)
+	require.Empty(t, reply.Transactions)
+}
+
+func TestAptosServiceAccountTransactionsUsesLatestWindowForLimitOnlyQuery(t *testing.T) {
+	t.Parallel()
+
+	var addr aptos.AccountAddress
+	addr[31] = 0xEE
+	sdkAddr := aptos_sdk.AccountAddress(addr[:])
+	requestedLimit := uint64(10)
+
+	client := clientmocks.NewAptosRpcClient(t)
+	client.EXPECT().Account(sdkAddr).Return(aptos_sdk.AccountInfo{SequenceNumberStr: "25"}, nil).Once()
+	client.EXPECT().AccountTransactions(sdkAddr, mock.Anything, mock.Anything).
+		Run(func(_ aptos_sdk.AccountAddress, start *uint64, limit *uint64) {
+			require.NotNil(t, start)
+			require.NotNil(t, limit)
+			require.Equal(t, uint64(15), *start)
+			require.Equal(t, uint64(10), *limit)
+		}).
+		Return([]*api.CommittedTransaction{}, nil).
+		Once()
+
+	svc := aptosService{
+		chain:  &testChain{client: client},
+		logger: logger.Test(t),
+	}
+
+	reply, err := svc.AccountTransactions(context.Background(), aptos.AccountTransactionsRequest{
+		Address: addr,
+		Limit:   &requestedLimit,
+	})
+	require.NoError(t, err)
+	require.Empty(t, reply.Transactions)
+}
+
+func TestAptosServiceAccountTransactionsReturnsEmptyForZeroSequenceNumber(t *testing.T) {
+	t.Parallel()
+
+	var addr aptos.AccountAddress
+	addr[31] = 0xEE
+	sdkAddr := aptos_sdk.AccountAddress(addr[:])
+	requestedLimit := uint64(10)
+
+	client := clientmocks.NewAptosRpcClient(t)
+	client.EXPECT().Account(sdkAddr).Return(aptos_sdk.AccountInfo{SequenceNumberStr: "0"}, nil).Once()
+
+	svc := aptosService{
+		chain:  &testChain{client: client},
+		logger: logger.Test(t),
+	}
+
+	reply, err := svc.AccountTransactions(context.Background(), aptos.AccountTransactionsRequest{
+		Address: addr,
+		Limit:   &requestedLimit,
+	})
+	require.NoError(t, err)
+	require.Empty(t, reply.Transactions)
+}
+
+func TestAptosServiceAccountTransactionsPreservesExplicitStart(t *testing.T) {
+	t.Parallel()
+
+	var addr aptos.AccountAddress
+	addr[31] = 0xEE
+	sdkAddr := aptos_sdk.AccountAddress(addr[:])
+	start := uint64(3)
+	limit := uint64(10)
+
+	client := clientmocks.NewAptosRpcClient(t)
+	client.EXPECT().AccountTransactions(sdkAddr,
+		mock.MatchedBy(func(s *uint64) bool { return s != nil && *s == start }),
+		mock.MatchedBy(func(l *uint64) bool { return l != nil && *l == limit }),
+	).Return([]*api.CommittedTransaction{}, nil).Once()
+
+	svc := aptosService{
+		chain:  &testChain{client: client},
+		logger: logger.Test(t),
+	}
+
+	reply, err := svc.AccountTransactions(context.Background(), aptos.AccountTransactionsRequest{
+		Address: addr,
+		Start:   &start,
+		Limit:   &limit,
+	})
+	require.NoError(t, err)
+	require.Empty(t, reply.Transactions)
 }
 
 type testChain struct {


### PR DESCRIPTION
Single rollup of every post-baseline change from `develop`/`main` since the audit baseline (`bugfix/audit_db` @ `209ab06d`).

Use this PR for the **one-shot diff** of everything that landed on the trunk during the audit window. Per-PR granular review is on the stacked draft PRs below.

## Contents (in stack order)

| Original PR | Rebase PR | Status |
|---|---|---|
| [#443](https://github.com/smartcontractkit/chainlink-aptos/pull/443) — Add ExecutedSuccessfully vm_status | [#451](https://github.com/smartcontractkit/chainlink-aptos/pull/451) | Audit fix (preliminary L6, superseded by #447) |
| [#449](https://github.com/smartcontractkit/chainlink-aptos/pull/449) — Fix Aptos account transaction limit windows | [#453](https://github.com/smartcontractkit/chainlink-aptos/pull/453) | Additional scope |

## Note

Does **not** carry the per-finding L6 fix [#447](https://github.com/smartcontractkit/chainlink-aptos/pull/447) — that remains on its own branch against `bugfix/audit_db`.